### PR TITLE
fixes slowness with searching.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,11 +29,14 @@ see CHANGELOG.md for a more formal list of changes by release
         - no, apparently. I got one of these:
             - java.lang.ClassNotFoundException: java.awt.event.FocusEvent$Cause
         - it could be a lone error or the first of dozens, not going to spend much time on it until gui2
+* search is painfully slow because I made no effort porting it
+    - have made the input vs output asynchronous
+        - this means the typing happens normally and results appear as they become available
+    - it could still be improved, definitely
+    - done
 
 ## todo
 
-* search is painfully slow because I made no effort porting it
-    - fix
 * update ticket template
     - with command to run that uses the debug flag
         - do I even have a --debug flag?

--- a/project.clj
+++ b/project.clj
@@ -40,12 +40,14 @@
   :main strongbox.main
 
   :plugins [[lein-cljfmt "0.6.4"]
-            [jonase/eastwood "0.3.10"]
+            [jonase/eastwood "0.3.11"]
             [lein-cloverage "1.1.1"]]
   :eastwood {:exclude-linters [:constant-test]
+             ;; linters that are otherwise disabled
              :add-linters [:unused-namespaces
-                           ;;:unused-locals :unused-fn-args ;; too many false positives to always be enabled
-                           ;; :non-clojure-file  ;; just noise
-                           ;; :keyword-typos ;; bugged with spec?
+                           :unused-private-vars
+                           ;;:unused-locals ;; prefer to keep for readability
+                           ;;:unused-fn-args ;; prefer to keep for readability
+                           ;;:keyword-typos ;; bugged with spec?
                            ]}
   )

--- a/src/strongbox/db.clj
+++ b/src/strongbox/db.clj
@@ -97,8 +97,8 @@
 (defn-spec -search :addon/summary-list
   "returns a list of addon summaries whose label or description matches the given user input `uin`.
   matches are case insensitive.
-  label matching matches from the beginning of the label.
-  description matching matches any substring within description"
+  label-matching matches from the beginning of the label.
+  description-matching matches any substring within description"
   [db :addon/summary-list, uin (s/nilable string?), cap int?]
   (if (nil? uin)
     (take cap (random-sample 0.005 db))

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -169,7 +169,7 @@
             obj (some-> uin utils/unmangle-https-url java.net.URL.)
             path (when-not (empty? (.getPath obj)) (.getPath obj))
 
-            ;; values here are tentative because user URL may resolve to a different URL
+            ;; values here are tentative because given URL may resolve to a different URL
             [-owner -repo] (-> path (subs 1) (split #"/") (pad 2))
             -source-id (when (and -owner -repo)
                          (format "%s/%s" -owner -repo))

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -634,11 +634,10 @@
         date-renderer #(when % (-> % clojure.instant/read-instant-date (utils/fmt-date "yyyy-MM-dd")))
 
         update-rows-fn (fn [state]
-                         (let [uinput (-> state :search-field-input (or "") trim)
-                               search-results (if (empty? uinput)
-                                                (core/db-search)
-                                                (core/db-search uinput))]
-                           (insert-all grid search-results)))]
+                         (future
+                           (let [uinput (some-> state :search-field-input trim)
+                                 search-results (core/db-search uinput)]
+                             (insert-all grid search-results))))]
 
     ;; I'm rather pleased these just work as-is :)
     ;; todo: rename these to something a bit more general

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -5,7 +5,7 @@
    [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [envvar.core :refer [with-env]]
    [me.raynes.fs :as fs]
-   ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
+   [taoensso.timbre :as log :refer [debug info warn error spy]]
    [strongbox
     [db :as db]
     [logging :as logging]
@@ -772,7 +772,7 @@
         (core/refresh)
 
         ;; this is the guard to the `db-load-catalogue` fn
-        ;; catalogue fixture in test-helper is an empty map, this should always return false
+        ;; catalogue fixture in `test-helper.clj` is an empty map so this should always return false
         (is (not (core/db-catalogue-loaded?)))
 
         ;; empty the file. quickest way to bad json
@@ -780,7 +780,10 @@
 
         ;; the catalogue will be re-requested, this time we've swapped out the fixture with one with a single entry
         (with-fake-routes-in-isolation fake-routes
-          (core/db-load-catalogue))
+          ;; this will print a warning with a stacktrace.
+          ;; it's being hidden so actual stacktraces don't get overlooked
+          (log/with-level :error
+            (core/db-load-catalogue)))
 
         (is (core/db-catalogue-loaded?))))))
 
@@ -801,7 +804,10 @@
 
         ;; the catalogue will be re-requested, this time the remote file is also corrupt
         (with-fake-routes-in-isolation fake-routes
-          (core/db-load-catalogue))
+          ;; this will print a warning with a stacktrace.
+          ;; it's being hidden so actual stacktraces don't get overlooked
+          (log/with-level :error
+            (core/db-load-catalogue)))
 
         (is (not (core/db-catalogue-loaded?)))))))
 


### PR DESCRIPTION
* not *all* slowness, it's still fundamentally a naive linear search using regexes over structs in memory, but the appearance of results is no longer tied to typing speed (results are updated asynchronously).

* hides some stacktraces that were appearing while testing - these were deliberate but potentially masking actual stacktraces happening in threads that aren't causing tests to fail

* bumps `eastwood`

* found a bug caught by an eastwood linter that was disabled. it wasn't a big deal, didn't affect anything, but was definitely incorrect