### PR TITLE
elvui fix 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,27 +36,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - done
 * fixed a bug where using 'Quit' from the gui would leave app running
 * fixed useragent, it was still stuck on 'wowman'
-
-## todo
-
-* update ticket template
-    - with command to run that uses the debug flag
-        - do I even have a --debug flag?
-            - I do now
-        - does the arch script allow further commands?
-            - yup
-    - which files to upload
-        - ...
-* wowman-comrades, shift asterisk description out of strongbox README
-* game track list in catalogue
-    - can game-track-list be included from all other hosts?
-        - not just wowi?
-            - even wowi is broken though
-            - I've seen a reference to a v4 of their 'api' that should be investigated
-                - naming changes mostly so far
-            - I've also noticed switches in game tracks for some of their addons this week (2020-03)
-        - tukui might benefit from this
-            - it might even be a fix for this bug: https://github.com/ogri-la/strongbox/issues/143
 * tukui and elvui can't be switched to classic
     - on classic track they show updates
         - elvui 1.82 => 1.211
@@ -72,8 +51,48 @@ see CHANGELOG.md for a more formal list of changes by release
         - ids are 1 and 2
         - I thought these were negative? or I made them negative?
         - anyway
+* game track list in catalogue
+    - can game-track-list be included from all other hosts?
+        - not just wowi?
+            - even wowi is broken though
+            - I've seen a reference to a v4 of their 'api' that should be investigated
+                - naming changes mostly so far
+            - I've also noticed switches in game tracks for some of their addons this week (2020-03)
+        - tukui might benefit from this
+            - it might even be a fix for this bug: https://github.com/ogri-la/strongbox/issues/143
+    - not fixing
+        - game track for tukui would be redundant information as game track is already encoded into the catalogue name
+        - curseforge as of a few days ago has been acquired by Overwolf and catalogue may be disappearing or changing
+* search tweaks
+    - adjust the number of addons displayed in the search results according to number of addons in catalogue
+    - it's clear which tukui addons are classic and which are retail
+    - tukui search results shouldn't both be highlighted if only one is installed
+    - done
+
+
+## todo
+
+* update ticket template
+    - with command to run that uses the debug flag
+        - do I even have a --debug flag?
+            - I do now
+        - does the arch script allow further commands?
+            - yup
+    - which files to upload
+        - ...
+* wowman-comrades, shift asterisk description out of strongbox README
+
 
 ## todo bucket (no particular order)
+
+* change installation from 'overwrite' to 'uninstall+install'
+
+* just encountered a case where the classic version overwrote one of the retail directories but not the other
+    - (tukui classic and retail?)
+    - so there was a broken retail installation but a working classic installation
+        - I was able to 'uninstall' the broken retail installation without a problem
+
+* add ability to explicitly unignore addon from context menu
 
 * test, can gui-diff and main/test be pushed back into the testing namespace and elided from release somehow?
 

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -21,7 +21,7 @@
                       "wowinterface" wowinterface-api/expand-summary
                       "github" github-api/expand-summary
                       "tukui" tukui-api/expand-summary
-                      "tukui-classic" tukui-api/expand-summary
+                      "tukui-classic" tukui-api/expand-summary-classic
                       nil (fn [_ _] (error "malformed addon-summary:" (utils/pprint addon-summary)))}
         key (:source addon-summary)]
     (try

--- a/src/strongbox/db.clj
+++ b/src/strongbox/db.clj
@@ -100,16 +100,17 @@
   label-matching matches from the beginning of the label.
   description-matching matches any substring within description"
   [db :addon/summary-list, uin (s/nilable string?), cap int?]
-  (if (nil? uin)
-    (take cap (random-sample 0.005 db))
-    (let [label-regex (re-pattern (str "(?i)^" uin ".*"))
-          desc-regex (re-pattern (str "(?i).*" uin ".*"))
-          ;; a little slow and naive, but ok for now
-          xf (filter (fn [row]
-                       (or
-                        (re-find label-regex (:label row))
-                        (re-find desc-regex (get row :description "")))))]
-      (into [] (comp xf (take cap)) db))))
+  (let [pct (->> db count (max 1) (/ 100) (* 0.6))]
+    (if (nil? uin)
+      (take cap (random-sample pct db))
+      (let [label-regex (re-pattern (str "(?i)^" uin ".*"))
+            desc-regex (re-pattern (str "(?i).*" uin ".*"))
+            ;; a little slow and naive, but ok for now
+            xf (filter (fn [row]
+                         (or
+                          (re-find label-regex (:label row))
+                          (re-find desc-regex (get row :description "")))))]
+        (into [] (comp xf (take cap)) db)))))
 
 ;; not specced because the results and argument lists may vary greatly
 (defn stored-query

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -20,7 +20,7 @@
 (def tukui-proper-url (format proper-url "tukui"))
 (def elvui-proper-url (format proper-url "elvui"))
 
-(defn-spec expand-summary (s/or :ok :addon/source-updates, :error nil?)
+(defn-spec -expand-summary (s/or :ok :addon/source-updates, :error nil?)
   "given a summary, adds the remaining attributes that couldn't be gleaned from the summary page. one additional look-up per ::addon required"
   [addon-summary :addon/summary game-track ::sp/game-track]
   (let [source-id (:source-id addon-summary)
@@ -38,6 +38,18 @@
       {:download-url (:url ti)
        :version (:version ti)
        :interface-version (-> ti :patch utils/game-version-to-interface-version)})))
+
+(defn-spec expand-summary (s/or :ok :addon/source-updates, :error nil?)
+  "given a summary, adds the remaining attributes that couldn't be gleaned from the summary page. one additional look-up per ::addon required"
+  [addon-summary :addon/summary game-track ::sp/game-track]
+  (when (= game-track :retail)
+    (-expand-summary addon-summary game-track)))
+
+(defn-spec expand-summary-classic (s/or :ok :addon/source-updates, :error nil?)
+  "given a summary, adds the remaining attributes that couldn't be gleaned from the summary page. one additional look-up per ::addon required"
+  [addon-summary :addon/summary game-track ::sp/game-track]
+  (when (= game-track :classic)
+    (-expand-summary addon-summary game-track)))
 
 ;;
 

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -488,7 +488,9 @@
                                        "www.curseforge.com" "curseforge"
                                        "www.wowinterface.com" "wowinterface"
                                        "github.com" "github"
-                                       "www.tukui.org" "tukui"
+                                       "www.tukui.org" (if (= (.getPath url) "/classic-addons.php")
+                                                         "tukui-classic"
+                                                         "tukui")
                                        "???")]
                            (format url-template label))))]
 

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -606,8 +606,9 @@
 
 (defn search-results-panel
   []
-  (let [hidden-by-default-cols [:source-id]
+  (let [hidden-by-default-cols [:source-id "-source"]
         tblmdl (sstbl/table-model :columns [{:key :url :text "source"}
+                                            {:key :source :text "-source"}
                                             :source-id
                                             {:key :label :text "name"}
                                             :description
@@ -624,12 +625,17 @@
         label-idx (atom (set []))
         update-label-idx (fn [_]
                            (reset! label-idx
-                                   (->> (get-state :installed-addon-list) (map :label) (remove nil?) set)))
+                                   (->> (get-state :installed-addon-list)
+                                        (map (fn [{:keys [source source-id]}]
+                                               [(name (or source "")) source-id]))
+                                        (remove nil?)
+                                        set)))
         _ (state-bind [:installed-addon-list] update-label-idx)
 
         addon-installed? (fn [adapter]
-                           (let [label-column (find-column-by-label grid "name")
-                                 value (.getValue adapter label-column)]
+                           (let [source (.getValue adapter (find-column-by-label grid "-source"))
+                                 source-id (.getValue adapter (find-column-by-label grid "source-id"))
+                                 value [source source-id]]
                              (contains? @label-idx value)))
 
         date-renderer #(when % (-> % clojure.instant/read-instant-date (utils/fmt-date "yyyy-MM-dd")))


### PR DESCRIPTION
fix for issue #143

- [x] classic elvui can be installed
- [x] classic tukui can be installed
- [x] it's clear which tukui addons are classic and which are retail
- [x] adjust the number of addons displayed in the search results according to number of addons in catalogue.
- [x] tukui search results shouldn't both be highlighted if only one is installed
- [x] review