### PR TITLE
bug, reinstall is busted

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -49,6 +49,11 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* bug, reinstall is busted
+    - looks like I've been relying on the selected table rows to be returning correct data
+        - it's not. it's been mangled and padded to suit the gui
+        - and now the ignore flag value isn't consistent with the proper data
+
 * remove support for v1 addon imports
 
 * just encountered a case where the classic version overwrote one of the retail directories but not the other

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -368,15 +368,20 @@
 
 ;; selecting addons
 
-(defn-spec select-addons nil?
-  "creates a sub-selection of installed addons for bulk operations like 'update', 'delete', 'ignore', etc"
-  [selected-rows ::sp/list-of-maps]
-  (swap! state assoc :selected-installed selected-rows)
+(defn-spec select-addons* nil?
+  "sets the selected list of addons to the given `selected-rows` for bulk operations like 'update', 'delete', 'ignore', etc"
+  [selected-addons :addon/installed-list]
+  (swap! state assoc :selected-installed selected-addons)
   nil)
 
-(defn-spec select-addons-by nil?
-  [f fn?]
-  (select-addons (filter f (get-state :installed-addon-list))))
+(defn-spec select-addons nil?
+  "creates a sub-selection of installed addons for bulk operations like 'update', 'delete', 'ignore', etc.
+  called with no args, selects *all* installed addons.
+  called with a function, selects just those where `(f addon)` is `true`"
+  ([]
+   (select-addons identity))
+  ([f fn?]
+   (->> (get-state :installed-addon-list) (filter f) (remove nil?) vec select-addons*)))
 
 ;; downloading and installing and updating
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -374,6 +374,10 @@
   (swap! state assoc :selected-installed selected-rows)
   nil)
 
+(defn-spec select-addons-by nil?
+  [f fn?]
+  (select-addons (filter f (get-state :installed-addon-list))))
+
 ;; downloading and installing and updating
 
 (defn-spec downloaded-addon-fname string?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -369,7 +369,7 @@
 ;; selecting addons
 
 (defn-spec select-addons* nil?
-  "sets the selected list of addons to the given `selected-rows` for bulk operations like 'update', 'delete', 'ignore', etc"
+  "sets the selected list of addons to the given `selected-addons` for bulk operations like 'update', 'delete', 'ignore', etc"
   [selected-addons :addon/installed-list]
   (swap! state assoc :selected-installed selected-addons)
   nil)

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -235,11 +235,10 @@
 
 (defn-spec installed-addons-selection-handler nil?
   [_ ::sp/gui-event]
-  (let [selected-rows (tbl-selected-rows :#tbl-installed-addons)]
+  (let [selected-rows (tbl-selected-rows :#tbl-installed-addons)
+        dirname-list (mapv :dirname selected-rows)]
     (debug (count selected-rows) "selected, " (count (filter :update? selected-rows)) "updatable")
-    ;; todo: bug here. this data is suspect, we need to convert these rows to actual installed addons
-    ;;(info "selected rows" (vec selected-rows))
-    (core/select-addons (or selected-rows [])))
+    (core/select-addons-by (fn [addon] (some #{(:dirname addon)} dirname-list))))
   nil)
 
 (defn-spec search-results-selection-handler nil?

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -234,12 +234,14 @@
     (sstbl/value-at tbl (ss/selection tbl {:multi? true}))))
 
 (defn-spec installed-addons-selection-handler nil?
-  "the gui will force every row to have a certain set of keys, even if it's value is `nil`
-  this skewed data can't be allowed 'back in' to the application state
-  instead, we match what was selected against the list of installed addons using the :dirname"
+  "matches the selected addons to the list of installed addons in application state.
+  because the gui forces every row to have a certain set of keys, even if it's value is `nil`,
+  then this skewed data can't be allowed 'back in' to the application state.
+  instead, we match what was selected against the list of installed addons using `:dirname`"
   [_ ::sp/gui-event]
   (let [selected-rows (tbl-selected-rows :#tbl-installed-addons)
         dirname-list (mapv :dirname selected-rows)]
+    (debug (count selected-rows) "selected")
     (core/select-addons (fn [addon] (some #{(:dirname addon)} dirname-list))))
   nil)
 

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -234,11 +234,13 @@
     (sstbl/value-at tbl (ss/selection tbl {:multi? true}))))
 
 (defn-spec installed-addons-selection-handler nil?
+  "the gui will force every row to have a certain set of keys, even if it's value is `nil`
+  this skewed data can't be allowed 'back in' to the application state
+  instead, we match what was selected against the list of installed addons using the :dirname"
   [_ ::sp/gui-event]
   (let [selected-rows (tbl-selected-rows :#tbl-installed-addons)
         dirname-list (mapv :dirname selected-rows)]
-    (debug (count selected-rows) "selected, " (count (filter :update? selected-rows)) "updatable")
-    (core/select-addons-by (fn [addon] (some #{(:dirname addon)} dirname-list))))
+    (core/select-addons (fn [addon] (some #{(:dirname addon)} dirname-list))))
   nil)
 
 (defn-spec search-results-selection-handler nil?

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1056,7 +1056,7 @@
         (core/install-addon addon)
         (is (= ["EveryAddon"] (helper/install-dir-contents)))
         (core/load-installed-addons)
-        (core/select-addons (core/get-state :installed-addon-list))
+        (core/select-addons)
         (core/ignore-selected) ;; calls `core/refresh`
         (is (= expected (first (core/get-state :installed-addon-list))))))))
 
@@ -1083,7 +1083,7 @@
                       :update? false}]
         (core/install-addon addon)
         (core/load-installed-addons)
-        (core/select-addons (core/get-state :installed-addon-list))
+        (core/select-addons)
         (core/ignore-selected) ;; calls `core/refresh`
         (is (:ignore? (first (core/get-state :installed-addon-list))))
 
@@ -1115,6 +1115,6 @@
         (core/load-installed-addons)
         (is (:ignore? (first (core/get-state :installed-addon-list)))) ;; implicitly ignored
 
-        (core/select-addons (core/get-state :installed-addon-list))
+        (core/select-addons)
         (core/clear-ignore-selected)
         (is (= expected (first (core/get-state :installed-addon-list))))))))

--- a/test/strongbox/gui_test.clj
+++ b/test/strongbox/gui_test.clj
@@ -46,11 +46,10 @@
         (is (= expected (gui/as-selector given)))))))
 
 (deftest gui-select-installed-addons
-  (testing "selecting installed addons using the gui selects the corresponding installed addons"
+  (testing "selecting addons using the gui selects the corresponding installed addons in the application state"
     (let [addon {:name "everyaddon" :label "EveryAddon" :version "1.2.3" :url "https://group.id/never/fetched"
                  :source "curseforge" :source-id 1
                  :-testing-zipfile (fixture-path "everyaddon--1-2-3.zip")}
-
           expected [{:description "Does what no other addon does, slightly differently",
                      :dirname "EveryAddon",
                      :group-id "https://group.id/never/fetched",


### PR DESCRIPTION
The `ignore?` value being returned by the selected rows from the gui is mangled and causing a crash when calling re-install.

- [x] fix reinstall bug
- [x] tests
- [x] review