### PR TITLE
gui2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # strongbox, a World of Warcraft Addon Manager
 
-[![Build Status](https://travis-ci.org/ogri-la/strongbox.svg?branch=master)](https://travis-ci.org/ogri-la/strongbox)
+[![Build Status](https://api.travis-ci.com/ogri-la/strongbox.svg?branch=develop)](https://travis-ci.com/ogri-la/strongbox)
 
 `strongbox` is an **open source**, **advertisement free** and **privacy respecting** addon manager for World of Warcraft. 
 

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,13 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * single distributable binary with no reliance on external jvm
 
+* scrub gui string values of newlines before displaying
+    - see tukui-classic, id 2, it's description is 
+        "A USER INTERFACE DESIGNED AROUND USER-FRIENDLINESS WITH EXTRA FEATURES THAT ARE NOT INCLUDED IN THE STANDARD UI.\r\n"
+    - swing gui ignored these
+    - probably do this in the catalogue
+        - is it possible to enter the system via tocs?
+
 ## todo bucket (no particular order)
 
 * datetime parsing is broken *again* in wowinterface-api

--- a/project.clj
+++ b/project.clj
@@ -39,7 +39,9 @@
   :profiles {:dev {:dependencies [;; fake http responses for testing
                                   [clj-http-fake "1.0.3"]
                                   ]}
-             :uberjar {:aot :all}}
+             :uberjar {:aot :all
+                       ;; https://github.com/cljfx/cljfx/issues/17
+                       :injections [(javafx.application.Platform/exit)]}}
 
   :main strongbox.main
 

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
-                 [cljfx "1.7.4"]
+                 [cljfx "1.7.6"]
 
                  ]
 

--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
 
                  [cljfx "1.7.6"]
                  ;;[org.clojure/core.cache "1.0.207"]
+                 [cljfx/css "1.1.0"]
 
                  ]
 

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,6 @@
                  ;; remember to update pom file (`lein pom`)
 
                  [cljfx "1.7.8"]
-                 ;;[org.clojure/core.cache "1.0.207"]
                  [cljfx/css "1.1.0"]
 
                  ]
@@ -40,7 +39,8 @@
                                   [clj-http-fake "1.0.3"]
                                   ]}
              :uberjar {:aot :all
-                       ;; https://github.com/cljfx/cljfx/issues/17
+                       ;; fixes hanging issue:
+                       ;; - https://github.com/cljfx/cljfx/issues/17
                        :injections [(javafx.application.Platform/exit)]}}
 
   :main strongbox.main

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
-                 [cljfx "1.7.6"]
+                 [cljfx "1.7.8"]
                  ;;[org.clojure/core.cache "1.0.207"]
                  [cljfx/css "1.1.0"]
 

--- a/project.clj
+++ b/project.clj
@@ -28,6 +28,7 @@
                  ;; remember to update pom file (`lein pom`)
 
                  [cljfx "1.7.6"]
+                 ;;[org.clojure/core.cache "1.0.207"]
 
                  ]
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
-# (always ratchet threshold upwards)
+set -e
 
-set -ex
+# always ratchet *upwards*
+fail_threshold=80
 
 # this file can't live in src/strongbox because lein-cloverage can't be found during dev.
 # so we copy it in and destroy it afterwards
 cp cloverage.clj src/strongbox/cloverage.clj
 
-lein cloverage --runner "strongbox" --fail-threshold 80 --html || {
+function finish {
+  rm src/strongbox/cloverage.clj
+}
+trap finish EXIT
+
+lein cloverage --runner "strongbox" --fail-threshold "$fail_threshold" --html || {
     retval="$?"
     # 1 for failed tests
     # 253 for failed coverage
@@ -18,5 +24,3 @@ lein cloverage --runner "strongbox" --fail-threshold 80 --html || {
     fi
     exit "$retval"
 }
-
-rm src/strongbox/cloverage.clj

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # (always ratchet threshold upwards)
 
+set -e
+
 # this file can't live in src/strongbox because lein-cloverage can't be found during dev.
 # so we copy it in and destroy it afterwards
 cp cloverage.clj src/strongbox/cloverage.clj

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -10,6 +10,7 @@ cp cloverage.clj src/strongbox/cloverage.clj
 
 function finish {
   rm src/strongbox/cloverage.clj
+  lein clean
 }
 trap finish EXIT
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 # (always ratchet threshold upwards)
 
-set -e
+set -ex
 
 # this file can't live in src/strongbox because lein-cloverage can't be found during dev.
 # so we copy it in and destroy it afterwards
 cp cloverage.clj src/strongbox/cloverage.clj
 
 lein cloverage --runner "strongbox" --fail-threshold 80 --html || {
+    retval="$?"
     # 1 for failed tests
     # 253 for failed coverage
-    if [ "$?" = "253" ]; then
+    if [ "$retval" = "253" ]; then
         if which otter-browser; then
             otter-browser "file://$(pwd)/target/coverage/index.html" &
         fi
     fi
+    exit "$retval"
 }
 
 rm src/strongbox/cloverage.clj

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -118,7 +118,7 @@
   [catalogue-data :catalogue/catalogue, output-file ::sp/file]
   (if (some->> catalogue-data validate (utils/dump-json-file output-file))
     (do
-      (info "wrote" output-file)
+      (info "wrote:" output-file)
       output-file)
     (error "catalogue data is invalid, refusing to write:" output-file)))
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -149,9 +149,6 @@
    ;; the root swing window
    :gui nil
 
-   ;; jfx gui state 
-   :gui2 nil
-
    ;; set to anything other than `nil` to have `main.clj` restart the gui
    :gui-restart-flag nil
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -40,11 +40,15 @@
 
    ;; jfx
    :base "#ececec"
+   :accent "lightsteelblue"
    :button-text-hovering "black"
    :table-border "#bbb"
    :row "-fx-control-inner-background"
    :row-hover "derive(-fx-control-inner-background,-10%)"
-   :unsteady "lightsteelblue"})
+   :unsteady "lightsteelblue"
+   :row-updateable "lemonchiffon"
+   :row-warning "lemonchiffon"
+   :row-error "tomato"})
 
 ;; inverse colours of -colour-map
 (def -dark-colour-map
@@ -60,11 +64,15 @@
 
    ;; jfx
    :base "#121212"
+   :accent "#443754" ;; dark purple
    :button-text-hovering "white"
    :table-border "#333"
    :row "-fx-control-inner-background"
    :row-hover "derive(-fx-control-inner-background,-10%)"
-   :unsteady "lightsteelblue"})
+   :unsteady "-fx-selection-bar"
+   :row-updateable "#aaa"
+   :row-warning "#ce6028"
+   :row-error "#ce2828"})
 
 (def themes
   {:light -colour-map

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -163,6 +163,8 @@
    :selected-installed []
 
    :search-field-input nil
+   :search-results [] ;; results of searching db for `:search-field-input`
+
    :selected-search []
    ;; number of results to display in search results pane.
    ;; adjust to whatever performs the best

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -365,6 +365,10 @@
   [addon]
   (swap! state update-in [:unsteady-addons] clojure.set/difference #{(:name addon)}))
 
+(defn unsteady?
+  [addon]
+  (utils/in? (:name addon) (get-state :unsteady-addons)))
+
 (defn affects-addon-wrapper
   [wrapped-fn]
   (fn [addon & args]

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -1120,7 +1120,9 @@
 (defn watch-for-addon-dir-change
   "when the current addon directory changes, the list of installed addons should be re-read"
   []
-  (state-bind [:cfg :selected-addon-dir] (fn [_] (refresh))))
+  (state-bind [:cfg :selected-addon-dir] (fn [_]
+                                           ;;(future ;; this seems to prevent it, but it can't stay.
+                                           (refresh))))
 
 (defn watch-for-catalogue-change
   "when the catalogue changes, the db should be rebuilt"
@@ -1153,7 +1155,7 @@
   (init-dirs)
   (prune-http-cache!)
   (load-settings! cli-opts)
-  (watch-for-addon-dir-change)
+  (watch-for-addon-dir-change) ;; this is causing a race condition/double update with gui
   (watch-for-catalogue-change)
 
   state)

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -193,7 +193,7 @@
    :search-field-input nil
 
    ;; results of searching db for `:search-field-input`
-   :search-results [] 
+   :search-results []
 
    :selected-search []
    ;; number of results to display in search results pane.

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -71,7 +71,7 @@
    :row-hover "derive(-fx-control-inner-background,-10%)"
    :unsteady "-fx-selection-bar"
    :row-updateable "#aaa"
-   :row-warning "#ce6028"
+   :row-warning "#aaa"
    :row-error "#ce2828"})
 
 (def themes

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -270,6 +270,7 @@
       (swap! state update-in [:cfg :addon-dir-list] conj stub))
     nil))
 
+;; see strongbox.ui.cli/set-addon-dir! 
 (defn-spec set-addon-dir! nil?
   "adds a new :addon-dir to :addon-dir-list (if it doesn't already exist) and marks it as selected"
   [addon-dir ::sp/addon-dir]
@@ -1179,7 +1180,12 @@
   (init-dirs)
   (prune-http-cache!)
   (load-settings! cli-opts)
-  (watch-for-addon-dir-change) ;; this is causing a race condition/double update with gui
+
+  ;; I'm coming to the opinion that these two are only here because I'm lazy and calling (refresh) is convenient
+  ;; I've also been interested in separating UI concerns from core logic for a while
+  ;; shifting this logic to ui/cli.clj
+
+  ;;(watch-for-addon-dir-change) ;; this is causing a race condition/double update with gui
   (watch-for-catalogue-change)
 
   state)

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -36,7 +36,12 @@
    :installed/needs-updating :lemonchiffon
    :installed/hovering "#e6e6e6" ;; light grey
    :search/already-installed "#99bc6b" ;; greenish
-   :hyperlink :blue})
+   :hyperlink :blue
+
+   :button-text-hovering "black"
+   :table-border-colour "#bbb"
+   :odd-coloured-rows "white"
+   :unsteady "lightsteelblue"})
 
 ;; inverse colours of -colour-map
 (def -dark-colour-map
@@ -48,7 +53,12 @@
    :installed/needs-updating "#000532"
    :installed/hovering "#191919"
    :search/already-installed "#664394"
-   :hyperlink :yellow})
+   :hyperlink :yellow
+
+   :button-text-hovering "white"
+   :table-border-colour "#333"
+   :odd-coloured-rows "black"
+   :unsteady "lightsteelblue"})
 
 (def themes
   {:light -colour-map

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -304,10 +304,10 @@
 
 (defn-spec get-game-track (s/or :ok ::sp/game-track, :missing nil?)
   ([]
-   (when-let [addon-dir (selected-addon-dir)]
-     (get-game-track addon-dir)))
-  ([addon-dir ::sp/addon-dir]
-   (-> addon-dir addon-dir-map :game-track)))
+   (get-game-track (selected-addon-dir)))
+  ([addon-dir (s/nilable ::sp/addon-dir)]
+   (when addon-dir
+     (-> addon-dir addon-dir-map :game-track))))
 
 ;; settings
 
@@ -971,7 +971,7 @@
 ;;
 
 (defn refresh
-  [& _]
+  [& _] ;; todo: remove args with swing gui
   (profile
    {:when (get-state :profile?)}
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -38,9 +38,12 @@
    :search/already-installed "#99bc6b" ;; greenish
    :hyperlink :blue
 
+   ;; jfx
+   :base "#ececec"
    :button-text-hovering "black"
-   :table-border-colour "#bbb"
-   :odd-coloured-rows "white"
+   :table-border "#bbb"
+   :row "-fx-control-inner-background"
+   :row-hover "derive(-fx-control-inner-background,-10%)"
    :unsteady "lightsteelblue"})
 
 ;; inverse colours of -colour-map
@@ -55,9 +58,12 @@
    :search/already-installed "#664394"
    :hyperlink :yellow
 
+   ;; jfx
+   :base "#121212"
    :button-text-hovering "white"
-   :table-border-colour "#333"
-   :odd-coloured-rows "black"
+   :table-border "#333"
+   :row "-fx-control-inner-background"
+   :row-hover "derive(-fx-control-inner-background,-10%)"
    :unsteady "lightsteelblue"})
 
 (def themes

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -72,7 +72,8 @@
    :unsteady "-fx-selection-bar"
    :row-updateable "#aaa"
    :row-warning "#aaa"
-   :row-error "#ce2828"})
+   :row-error "#ce2828"
+   :hyperlink-hover "yellow"})
 
 (def themes
   {:light -colour-map

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -173,6 +173,9 @@
    ;; the root swing window
    :gui nil
 
+   ;; jfx ui showing?
+   :gui-showing? true
+
    ;; set to anything other than `nil` to have `main.clj` restart the gui
    :gui-restart-flag nil
 
@@ -232,6 +235,11 @@
    :get-etag #(get-state :etag-db %) ;; do this instead
    :cache-dir (paths :cache-dir)})
 
+(defn-spec add-cleanup-fn nil?
+  [f fn?]
+  (swap! state update-in [:cleanup] conj f)
+  nil)
+
 (defn-spec state-bind nil?
   "executes given callback function when value at path in state map changes. 
   trigger is discarded if old and new values are identical"
@@ -251,8 +259,7 @@
                      (callback new-state)
                      (catch Exception e
                        (error e "error caught in watch! your callback *must* be catching these or the thread dies silently:" path))))))
-
-    (swap! state update-in [:cleanup] conj rmwatch)
+    (add-cleanup-fn rmwatch)
     nil))
 
 ;; addon dirs

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -374,6 +374,12 @@
 
 ;; selecting addons
 
+(defn-spec select-addons-search* nil?
+  "sets the selected list of addons to the given `selected-addons` for bulk operations like"
+  [selected-addons :addon/summary-list]
+  (swap! state assoc :selected-search selected-addons)
+  nil)
+
 (defn-spec select-addons* nil?
   "sets the selected list of addons to the given `selected-addons` for bulk operations like 'update', 'delete', 'ignore', etc"
   [selected-addons :addon/installed-list]

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -174,7 +174,7 @@
    :gui nil
 
    ;; jfx ui showing?
-   :gui-showing? true
+   :gui-showing? false
 
    ;; set to anything other than `nil` to have `main.clj` restart the gui
    :gui-restart-flag nil
@@ -764,6 +764,7 @@
                :matched :addon/toc+summary+match)]
   (let [expanded-addon (when (:matched? addon)
                          (expand-summary-wrapper addon))
+        _ (debug "done expanding")
         addon (or expanded-addon addon) ;; expanded addon may still be nil
         {:keys [installed-version version]} addon
         update? (boolean

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -1142,18 +1142,6 @@
 
 ;; init
 
-(defn watch-for-addon-dir-change
-  "when the current addon directory changes, the list of installed addons should be re-read"
-  []
-  (state-bind [:cfg :selected-addon-dir] (fn [_]
-                                           ;;(future ;; this seems to prevent it, but it can't stay.
-                                           (refresh))))
-
-(defn watch-for-catalogue-change
-  "when the catalogue changes, the db should be rebuilt"
-  []
-  (state-bind [:cfg :selected-catalogue] (fn [_] (db-reload-catalogue))))
-
 (defn-spec set-paths! nil?
   []
   (swap! state assoc :paths (generate-path-map))
@@ -1180,13 +1168,6 @@
   (init-dirs)
   (prune-http-cache!)
   (load-settings! cli-opts)
-
-  ;; I'm coming to the opinion that these two are only here because I'm lazy and calling (refresh) is convenient
-  ;; I've also been interested in separating UI concerns from core logic for a while
-  ;; shifting this logic to ui/cli.clj
-
-  ;;(watch-for-addon-dir-change) ;; this is causing a race condition/double update with gui
-  (watch-for-catalogue-change)
 
   state)
 

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -98,6 +98,7 @@
     (if (fresh-cache-file-exists? output-file)
       (do
         (debug "cache hit for:" url "(" output-file ")")
+        (Thread/sleep 10)
         output-file)
 
       ;; ... otherwise, we must sing and dance

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -98,7 +98,6 @@
     (if (fresh-cache-file-exists? output-file)
       (do
         (debug "cache hit for:" url "(" output-file ")")
-        (Thread/sleep 10)
         output-file)
 
       ;; ... otherwise, we must sing and dance

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -1,7 +1,7 @@
 (ns strongbox.main
   (:refer-clojure :rename {test clj-test})
   (:require
-   [taoensso.timbre :as timbre :refer [spy info error]]
+   [taoensso.timbre :as timbre :refer [spy info warn error]]
    [clojure.test]
    [clojure.tools.cli]
    [clojure.tools.namespace.repl :as tn :refer [refresh]]
@@ -65,8 +65,9 @@
   (core/start (merge {:profile? profile?, :spec? spec?} cli-opts))
   (case (:ui cli-opts)
     :cli (cli/start cli-opts)
+    :gui (gui/start)
     :gui2 (jfx/start)
-    (gui/start))
+    (jfx/start))
 
   (watch-for-gui-restart)
 
@@ -181,7 +182,7 @@
 
             ;; switch default ui to :cli if --headless given without explicit --ui
             args (if (not (contains? options :ui))
-                   (assoc-in args [:options :ui] (if (:headless? options) :cli :gui))
+                   (assoc-in args [:options :ui] (if (:headless? options) :cli :gui2))
                    args)
 
             ;; force :cli for certain actions

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -182,7 +182,7 @@
 
             ;; switch default ui to :cli if --headless given without explicit --ui
             args (if (not (contains? options :ui))
-                   (assoc-in args [:options :ui] (if (:headless? options) :cli :gui2))
+                   (assoc-in args [:options :ui] (if (:headless? options) :cli :gui))
                    args)
 
             ;; force :cli for certain actions

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -50,6 +50,7 @@
   (let [opts (:cli-opts @core/state)]
     (case (:ui opts)
       :cli (cli/stop)
+      :gui (gui/stop)
       :gui2 (jfx/stop)
       (gui/stop))
     (core/stop core/state)))
@@ -67,7 +68,7 @@
     :cli (cli/start cli-opts)
     :gui (gui/start)
     :gui2 (jfx/start)
-    (jfx/start))
+    (gui/start))
 
   (watch-for-gui-restart)
 

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -94,7 +94,7 @@
     (if ns-kw
       (if (some #{ns-kw} [:main :utils :http :tags
                           :core :toc :nfo :zip :config :catalogue :db :addon
-                          :cli :gui
+                          :cli :gui :jfx
                           :curseforge-api :wowinterface :wowinterface-api :github-api :tukui-api])
         (with-gui-diff
           (if fn-kw

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -277,3 +277,12 @@
 (s/def :db/installed-addon :addon/installed) ;; alias :(
 (s/def :db/addon-catalogue-match (s/or :no-match nil?
                                        :match (s/keys :req-un [:db/idx :db/key :db/installed-addon ::matched? :db/catalogue-match])))
+
+;; javafx, cljfx, gui2
+
+(s/def :javafx/action-event #(instance? javafx.event.ActionEvent %))
+
+(s/def :gui/text string?)
+(s/def :gui/cell-value-factory ifn?)
+(s/def :gui/style-class (s/coll-of string? :kind vector?))
+(s/def :gui/column-data (s/keys :opt-un [:gui/text :gui/cell-value-factory :gui/style-class]))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -36,11 +36,8 @@
 (defn-spec set-catalogue-location! nil?
   [catalogue-name keyword?]
   (core/set-catalogue-location! catalogue-name)
-  (core/download-current-catalogue)
-  (core/db-load-catalogue)
-  (core/match-installed-addons-with-catalogue)
-  (core/check-for-updates)
-  (core/save-settings)
+  ;; a full refresh is necessary for this action
+  (core/db-reload-catalogue)
   nil)
 
 ;;

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -12,37 +12,7 @@
     [wowinterface :as wowinterface]
     [core :as core :refer [get-state paths find-catalogue-local-path]]]))
 
-(comment "the UIs pool their logic here, which calls core.clj")
-
-(comment
-(defn refresh
-  [& _] ;; todo: remove args with swing gui
-  (profile
-   {:when (get-state :profile?)}
-
-   ;; parse toc files in install-dir. do this first so we see *something* while catalogue downloads (next)
-   (load-installed-addons)
-
-   ;; downloads the big long list of addon information stored on github
-   (download-current-catalogue)
-
-   ;; load the contents of the catalogue into the database
-   (p :p2/db (db-load-catalogue))
-
-   ;; match installed addons to those in catalogue
-   (match-installed-addons-with-catalogue)
-
-   ;; for those addons that have matches, download their details
-   (check-for-updates)
-
-   ;; 2019-06-30, travis is failing with 403: Forbidden. Moved to gui init
-   ;;(latest-strongbox-release) ;; check for updates after everything else is done 
-
-   ;; seems like a good place to preserve the etag-db
-   (save-settings)
-
-   nil))
-)
+(comment "the UIs pool their logic here, which calls core.clj.")
 
 (defn-spec set-addon-dir! nil?
   [addon-dir ::sp/addon-dir]
@@ -50,7 +20,8 @@
   (core/load-installed-addons)
   (core/match-installed-addons-with-catalogue)
   (core/check-for-updates)
-  (core/save-settings))
+  (core/save-settings)
+  nil)
 
 (defn-spec remove-addon-dir! nil?
   []
@@ -59,13 +30,8 @@
   (core/load-installed-addons)
   (core/match-installed-addons-with-catalogue)
   (core/check-for-updates)
-  (core/save-settings))
-
-
-  
-
-
-  
+  (core/save-settings)
+  nil)
 
 ;;
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -33,6 +33,16 @@
   (core/save-settings)
   nil)
 
+(defn-spec set-catalogue-location! nil?
+  [catalogue-name keyword?]
+  (core/set-catalogue-location! catalogue-name)
+  (core/download-current-catalogue)
+  (core/db-load-catalogue)
+  (core/match-installed-addons-with-catalogue)
+  (core/check-for-updates)
+  (core/save-settings)
+  nil)
+
 ;;
 
 (defmulti action

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -15,6 +15,7 @@
 (comment "the UIs pool their logic here, which calls core.clj.")
 
 (defn-spec set-addon-dir! nil?
+  "adds/sets an addon-dir marks it as selected, partial refresh of application state"
   [addon-dir ::sp/addon-dir]
   (core/set-addon-dir! addon-dir)
   (core/load-installed-addons)
@@ -24,6 +25,7 @@
   nil)
 
 (defn-spec remove-addon-dir! nil?
+  "deletes an addon-dir, selects first available addon dir, partial refresh of application state"
   []
   (core/remove-addon-dir!)
   ;; the next addon dir is selected, if any
@@ -34,9 +36,10 @@
   nil)
 
 (defn-spec set-catalogue-location! nil?
+  "changes the catalogue and refreshes application state.
+  a complete refresh is necessary for this action as addons accumulate keys like `:matched?` and `:update?`"
   [catalogue-name keyword?]
   (core/set-catalogue-location! catalogue-name)
-  ;; a full refresh is necessary for this action
   (core/db-reload-catalogue)
   nil)
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -1,7 +1,9 @@
 (ns strongbox.ui.cli
   (:require
+   [orchestra.core :refer [defn-spec]]
    [taoensso.timbre :as timbre :refer [spy info warn error debug]]
    [strongbox
+    [specs :as sp]
     [tukui-api :as tukui-api]
     [catalogue :as catalogue]
     [http :as http]
@@ -9,6 +11,63 @@
     [curseforge-api :as curseforge-api]
     [wowinterface :as wowinterface]
     [core :as core :refer [get-state paths find-catalogue-local-path]]]))
+
+(comment "the UIs pool their logic here, which calls core.clj")
+
+(comment
+(defn refresh
+  [& _] ;; todo: remove args with swing gui
+  (profile
+   {:when (get-state :profile?)}
+
+   ;; parse toc files in install-dir. do this first so we see *something* while catalogue downloads (next)
+   (load-installed-addons)
+
+   ;; downloads the big long list of addon information stored on github
+   (download-current-catalogue)
+
+   ;; load the contents of the catalogue into the database
+   (p :p2/db (db-load-catalogue))
+
+   ;; match installed addons to those in catalogue
+   (match-installed-addons-with-catalogue)
+
+   ;; for those addons that have matches, download their details
+   (check-for-updates)
+
+   ;; 2019-06-30, travis is failing with 403: Forbidden. Moved to gui init
+   ;;(latest-strongbox-release) ;; check for updates after everything else is done 
+
+   ;; seems like a good place to preserve the etag-db
+   (save-settings)
+
+   nil))
+)
+
+(defn-spec set-addon-dir! nil?
+  [addon-dir ::sp/addon-dir]
+  (core/set-addon-dir! addon-dir)
+  (core/load-installed-addons)
+  (core/match-installed-addons-with-catalogue)
+  (core/check-for-updates)
+  (core/save-settings))
+
+(defn-spec remove-addon-dir! nil?
+  []
+  (core/remove-addon-dir!)
+  ;; the next addon dir is selected, if any
+  (core/load-installed-addons)
+  (core/match-installed-addons-with-catalogue)
+  (core/check-for-updates)
+  (core/save-settings))
+
+
+  
+
+
+  
+
+;;
 
 (defmulti action
   "handles the following actions:

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -346,8 +346,7 @@
                             ;; positioned here so the dropdown change is shown immediately
                             (ss/invoke-later
                              (ss/selection! wow-game-track (-> new-addon-dir core/addon-dir-map :game-track kw2str))))
-                          (cli/set-addon-dir! new-addon-dir)
-                          ))))
+                          (cli/set-addon-dir! new-addon-dir)))))
 
         ;; called when the selected addon directory changes (like via `cli/set-addon-dir!`)
         _ (state-bind [:cfg :selected-addon-dir]
@@ -876,8 +875,7 @@
      (sb/b-do [val]
               (when val ;; hrm, we're getting two events here, one where the value is nil ...
                 (async (fn []
-                         (core/set-catalogue-location! (-> val ss/user-data :name))
-                         (core/save-settings))))))
+                         (cli/set-catalogue-location! (-> val ss/user-data :name)))))))
 
     ;; application state updates menu selection
     (core/state-bind [:cfg :selected-catalogue]

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -1,6 +1,7 @@
 (ns strongbox.ui.gui
   (:require
    [me.raynes.fs :as fs]
+   [strongbox.ui.cli :as cli]
    [strongbox
     [core :as core :refer [get-state state-bind colours]]
     [logging :as logging]
@@ -316,9 +317,7 @@
                                       :type :open
                                       :selection-mode :dirs-only)]
     (if (fs/directory? dir)
-      (do
-        (core/set-addon-dir! (str dir))
-        (core/save-settings))
+      (cli/set-addon-dir! (str dir))
       (ss/alert (format "Directory doesn't exist: %s" (str dir)))))
   nil)
 
@@ -347,10 +346,10 @@
                             ;; positioned here so the dropdown change is shown immediately
                             (ss/invoke-later
                              (ss/selection! wow-game-track (-> new-addon-dir core/addon-dir-map :game-track kw2str))))
-                          (core/set-addon-dir! new-addon-dir)
-                          (core/save-settings)))))
+                          (cli/set-addon-dir! new-addon-dir)
+                          ))))
 
-        ;; called when the selected addon directory changes (like via `core/set-addon-dir!`)
+        ;; called when the selected addon directory changes (like via `cli/set-addon-dir!`)
         _ (state-bind [:cfg :selected-addon-dir]
                       (fn [state]
                         (let [new-addon-dir (get-in state [:cfg :selected-addon-dir]) ;; use the given `state`

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -46,7 +46,7 @@
                ;;:-fx-font-size ".9em"
                
                }
-      ".table-view" {:-fx-table-cell-border-color "#aaa"
+      ".table-view" {:-fx-table-cell-border-color "#ccc"
                      :-fx-font-size ".9em"
                      :-fx-font-family "\"Bitstream Vera Sans Mono\", Mono"
 
@@ -70,6 +70,10 @@
       {:-fx-max-height 0
        :-fx-pref-height 0 
        :-fx-min-height 0
+       }
+
+      ".table-view#notice-logger #level"
+      {:-fx-alignment "center"
        }
 
       ;;".table-row-cell" {:-fx-background "white"}
@@ -499,7 +503,7 @@
   [{:keys [fx/context]}]
   (let [log-message-list (fx/sub-val context :log-message-list)
         log-message-list (reverse log-message-list) ;; nfi how to programmatically change column sort order
-        column-list [{:text "level" :max-width 100 :cell-value-factory :level}
+        column-list [{:id "level" :text "level" :max-width 100 :cell-value-factory (comp name :level)}
                      {:text "message" :pref-width 500 :cell-value-factory :message}]]
     {:fx/type :table-view
      :id "notice-logger"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -475,12 +475,17 @@
 (defn installed-addons-table
   [{:keys [fx/context]}]
   (let [row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
+
+
+        iface-version (fn [row]
+                        (some-> row :interface-version str utils/interface-version-to-game-version))
+        
         column-list [{:text "source" :min-width 100 :max-width 110 :cell-value-factory source-to-href-fn}
                      {:text "name" :min-width 150 :pref-width 300 :max-width 500 :cell-value-factory :label}
                      {:text "description" :pref-width 700 :cell-value-factory :description}
                      {:text "installed" :max-width 150 :cell-value-factory :installed-version}
                      {:text "available" :max-width 150 :cell-value-factory :version}
-                     {:text "WoW" :max-width 100 :cell-value-factory :interface-version}]]
+                     {:text "WoW" :max-width 100 :cell-value-factory iface-version}]]
     {:fx/type fx.ext.table-view/with-selection-props
      :props {:selection-mode :multiple
              ;; unlike gui.clj, we have access to the original data here

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -542,7 +542,10 @@
                                                   (core/refresh)))
                              :items ["retail" "classic"]}
 
-        ;; todo: add upgrade strongbox button
+        update-app-button {:fx/type :button
+                           :text (str "Update Available: " (core/latest-strongbox-release))
+                           :on-action (handler #(utils/browse-to "https://github.com/ogri-la/strongbox/releases"))
+                           :visible (not (core/latest-strongbox-version?))}
         ]
     {:fx/type :h-box
      :padding 10
@@ -550,7 +553,8 @@
      :children [refresh-button
                 update-all-button
                 wow-dir-dropdown
-                game-track-dropdown]}))
+                game-track-dropdown
+                update-app-button]}))
 
 (defn table-column
   [column-data]
@@ -740,7 +744,6 @@
         all-matching-template "all installed addons found in catalogue."
         catalogue-count-template "%s addons in catalogue."
 
-        ;;ia (:installed-addon-list state)
         ia (fx/sub-val context get-in [:app-state :installed-addon-list])
 
         uia (filter :matched? ia)
@@ -813,18 +816,9 @@
                                             (swap! gui-state fx/swap-context assoc :style style)))
 
         update-gui-state (fn [new-state]
-                           ;;@(fx/on-fx-thread ;; doesn't work
-                           ;;(future ;; also doesn't work (why would it?)
                            (swap! gui-state fx/swap-context assoc :app-state new-state))
 
-
-        ;; when :selected-addon-dir changes the app state is updated then this watcher is triggered, updating the gui state.
-        ;; a watcher in the *app* looking at :selected-addon-dir is also triggered. it causes a refresh.
-        ;; a refresh causes many changes to app state, each change causes a change to the *gui* state.
-
         ;; the installed-addon-list-table fn will update itself from the *gui* state when the installed-addon-list data changes.
-
-
         _ (core/state-bind [] update-gui-state)
 
         ;; async search. should be able to get this effect with idiomatic cljs use

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -24,126 +24,126 @@
 (def style
   (css/register
    ::style
-   (let [text-color "black"
-         table-border-colour "#bbb"]
+   (let [generate-style
+         (fn [theme-kw]
+           (let [colour-map (theme-kw  core/themes)
+                 colour #(name (get colour-map %))]
+             {(format "#%s.root " (name theme-kw))
+              {:-fx-padding 0
+               ;;:-fx-base "#fefefe"
+               ;;:-fx-base "white"
+               ;;:-fx-accent "#0096C9"
 
-     {".root"
-      {:-fx-padding 0
-       ;;:-fx-base "#fefefe"
-       ;;:-fx-base "white"
-       ;;:-fx-accent "#0096C9"
+               ;; backgrounds
+               ;;:-fx-accent "transparent"
+               :-fx-accent "lightsteelblue"
+               ".text" {:-fx-font-smoothing-type "gray"}
 
-       ;; backgrounds
-       ;;:-fx-accent "transparent"
-       :-fx-accent "lightsteelblue"}
+               ".context-menu" {:-fx-effect "None"}
+               ".combo-box-base" {:-fx-padding "1px"
+                                  :-fx-background-radius "0"}
 
-      ".text"
-      {:-fx-font-smoothing-type "gray"}
+               ".button" {:-fx-background-radius "0"
+                          ;;:-fx-text-fill "black"
+                          ;; vector values are space-separated
+                          :-fx-padding ["6px" "17px"]
+                          ":hover" {:-fx-text-fill (colour :button-text-hovering)}}
 
-      ".context-menu" {:-fx-effect "None"}
-      ".combo-box-base" {:-fx-padding "1px"
-                         :-fx-background-radius "0"}
+               ;; tabber
+               ".tab-pane > .tab-header-area > .headers-region > .tab "
+               {:-fx-background-radius "0"
+                ;;:-fx-padding "3px 20px"
+                }
 
-      ".button" {:-fx-background-radius "0"
-                 :-fx-text-fill text-color
-                 ;; vector values are space-separated
-                 :-fx-padding ["6px" "17px"]
-                 ;; nested string key defines new selector: `.button:hover`
-                 ":hover" {:-fx-text-fill :black}}
+               ;; common tables
+               ".table-view"
+               {:-fx-table-cell-border-color (colour :table-border-colour)
+                :-fx-font-size ".9em"}
 
-      ;;".label" {:-fx-text-fill text-color
-      ;;          :-fx-wrap-text true}
+               ".table-view .column-header"
+               {;;:-fx-background-color "#ddd" ;; flat colour
+                :-fx-font-size "1em"
+                :-fx-font-weight "Normal"
+                :-fx-font-family "Sans"}
 
-      ;; tabber
-      ".tab-pane > .tab-header-area > .headers-region > .tab "
-      {:-fx-background-radius "0"
-       ;;:-fx-padding "3px 20px"
-       }
+               ".table-view .table-row-cell"
+               {:-fx-border-insets "-1 -1 0 -1"
+                :-fx-border-color (colour :table-border-colour)
 
-      ;; common tables
-      ".table-view"
-      {:-fx-table-cell-border-color table-border-colour
-       :-fx-font-size ".9em"}
+                ":hover" {:-fx-background-color (colour :installed/hovering)}
+                ":selected" {:-fx-background-color "-fx-selection-bar"}
 
-      ".table-view .column-header"
-      {;;:-fx-background-color "#ddd" ;; flat colour
-       :-fx-font-size "1em"
-       :-fx-font-weight "Normal"
-       :-fx-font-family "Sans"}
+                ":odd" {:-fx-background-color (colour :odd-coloured-rows)}
+                ":odd:hover" {:-fx-background-color (colour :installed/hovering)}
+                ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
+                ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
 
-      ".table-view .table-row-cell"
-      {:-fx-border-insets "-1 -1 0 -1"
-       :-fx-border-color table-border-colour
-
-       ":hover" {:-fx-background-color "#eee"}
-       ":selected" {:-fx-background-color "-fx-selection-bar"}
-
-       ":odd" {:-fx-background-color "white"}
-       ":odd:hover" {:-fx-background-color "#eee"}
-       ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
-       ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
-
-       ".unsteady" {:-fx-background-color "lightsteelblue"}}
+                ".unsteady" {:-fx-background-color (colour :unsteady)}}
 
 
-      ;; installed-addons table
+               ;; installed-addons table
 
 
-      ".table-view#installed-addons"
-      {" .updateable"
-       {:-fx-background-color "lemonchiffon"
-        ;; selected updateable addons are do not look any different
-        ":selected" {:-fx-background-color "-fx-selection-bar"}}
-
-       " .ignored .table-cell"
-       {:-fx-text-fill "#aaa"}
-
-       " .wow-column" {:-fx-alignment "center"}}
-
-
-      ;; notice-logger
-
-
-      ".table-view#notice-logger"
-      {" .warn" {:-fx-background-color "lemonchiffon"
+               ".table-view#installed-addons"
+               {" .updateable"
+                {:-fx-background-color (colour :installed/needs-updating)
+                 ;; selected updateable addons are do not look any different
                  ":selected" {:-fx-background-color "-fx-selection-bar"}}
-       " .error" {:-fx-background-color "tomato"
-                  " .text" {:-fx-text-fill "blue"}
-                  ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
-       " #level" {:-fx-alignment "center"
-                  :-fx-border-width "0"}
+                " .ignored .table-cell"
+                {:-fx-text-fill (colour :installed/ignored-fg)}
 
-       ;; hide column headers
-       " > .column-header-background"
-       {:-fx-max-height 0
-        :-fx-pref-height 0
-        :-fx-min-height 0}
+                " .wow-column" {:-fx-alignment "center"}}
 
-       " .table-row-cell"
-       {:-fx-border-color "white"}
 
-       :-fx-font-family "monospace"}
+               ;; notice-logger
 
-      "#splitter .split-pane-divider"
-      {:-fx-padding "8px"}
 
-      ;; search
-      ".table-view#search-addons"
-      {" .downloads-column" {:-fx-alignment "center-right"}
-       " .installed" {:-fx-background-color "#99bc6b"}}
+               ".table-view#notice-logger"
+               {" .warn" {:-fx-background-color (colour :notice/warning)
+                          ":selected" {:-fx-background-color "-fx-selection-bar"}}
+                " .error" {:-fx-background-color (colour :notice/error)
+                           ;;" .text" {:-fx-text-fill "blue"}
+                           ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
-      "#status-bar"
-      {:-fx-font-size ".9em"
-       :-fx-padding "5px"}
+                " #level" {:-fx-alignment "center"
+                           :-fx-border-width "0"}
 
-      ;; common table fields
-      ".table-view .source-column"
-      {:-fx-alignment "center-left"
-       :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
-       " .hyperlink:visited" {:-fx-underline "false"}
-       " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
-                                        :-fx-text-fill "blue"}}})))
+                ;; hide column headers
+
+
+                " > .column-header-background"
+                {:-fx-max-height 0
+                 :-fx-pref-height 0
+                 :-fx-min-height 0}
+
+                ;;" .table-row-cell" {:-fx-border-color "white"}
+
+                :-fx-font-family "monospace"}
+
+               "#splitter .split-pane-divider"
+               {:-fx-padding "8px"}
+
+               ;; search
+               ".table-view#search-addons"
+               {" .downloads-column" {:-fx-alignment "center-right"}
+                " .installed" {:-fx-background-color "#99bc6b"}}
+
+               "#status-bar"
+               {:-fx-font-size ".9em"
+                :-fx-padding "5px"}
+
+               ;; common table fields
+               ".table-view .source-column"
+               {:-fx-alignment "center-left"
+                :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
+                " .hyperlink:visited" {:-fx-underline "false"}
+                " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
+                                                 :-fx-text-fill (colour :hyperlink)}}}}))]
+
+     (merge
+      (generate-style :light)
+      (generate-style :dark)))))
 
 (defn get-root
   [event]
@@ -250,6 +250,23 @@
                              (core/set-catalogue-location! name)
                              (core/save-settings))})]
       (mapv rb catalogue-addon-list))))
+
+(defn build-theme-menu
+  "returns a menu of radio buttons that can toggle through the available themes defined in `core/themes`"
+  [selected-theme theme-map]
+  (let [rb (fn [theme-key]
+             {:fx/type :radio-menu-item
+              :text (format "%s theme" (-> theme-key name clojure.string/capitalize))
+              :selected (= selected-theme theme-key)
+              :toggle-group {:fx/type fx/ext-get-ref
+                             :ref ::theme-toggle-group}
+              :on-action (fn [_]
+                           (swap! core/state assoc-in [:cfg :gui-theme] theme-key)
+                           (core/save-settings)
+                           ;; trigger-gui-restart ...
+                           )})]
+
+    (mapv rb (keys theme-map))))
 
 (defn menu
   [label items & [opt-map]]
@@ -416,6 +433,7 @@
 
 ;;
 
+
 (def separator {:fx/type fx/ext-instance-factory
                 :create #(javafx.scene.control.SeparatorMenuItem.)})
 
@@ -426,13 +444,15 @@
                    separator
                    (menu-item "E_xit" exit-handler {:key "Ctrl+Q"})]
 
-        view-menu [(menu-item "Refresh" (async-handler core/refresh) {:key "F5"})
-                   separator
-                   (menu-item "_Installed" (switch-tab-handler INSTALLED-TAB) {:key "Ctrl+I"})
-                   (menu-item "Searc_h" (switch-tab-handler SEARCH-TAB) {:key "Ctrl+H"})
-                   ;; separator
-                   ;; todo: build-theme-menu
-                   ]
+        view-menu (into
+                   [(menu-item "Refresh" (async-handler core/refresh) {:key "F5"})
+                    separator
+                    (menu-item "_Installed" (switch-tab-handler INSTALLED-TAB) {:key "Ctrl+I"})
+                    (menu-item "Searc_h" (switch-tab-handler SEARCH-TAB) {:key "Ctrl+H"})
+                    separator]
+                   (build-theme-menu
+                    (fx/sub-val context get-in [:app-state :cfg :gui-theme])
+                    core/themes))
 
         catalogue-menu (into (build-catalogue-menu
                               (fx/sub-val context get-in [:app-state :cfg :selected-catalogue])
@@ -462,7 +482,8 @@
         help-menu [(menu-item "About strongbox" about-strongbox-dialog)]]
 
     {:fx/type fx/ext-let-refs
-     :refs {::catalogue-toggle-group {:fx/type :toggle-group}}
+     :refs {::catalogue-toggle-group {:fx/type :toggle-group}
+            ::theme-toggle-group {:fx/type :toggle-group}}
      :desc {:fx/type :menu-bar
             :id "main-menu"
             :menus [(menu "_File" file-menu)
@@ -722,30 +743,35 @@
 
 (defn root
   [{:keys [fx/context]}]
-  (fx/sub-val context get :style) ;; todo: remove outside of dev?
-  {:fx/type :stage
-   :showing true
-   :on-close-request (fn [ev]
-                       ;; called on ctrl-c
-                       ;;(println "got ev" ev)
-                       ;;(println (bean ev))
-                       (when-not (core/get-state :in-repl?)
-                         (System/exit 0)))
 
-   :title "strongbox"
-   :width 1024
-   :height 768
-   :scene {:fx/type :scene
-           :stylesheets [(::css/url style)]
-           :root {:fx/type :v-box
-                  :children [{:fx/type menu-bar}
-                             {:fx/type :split-pane
-                              :id "splitter"
-                              :orientation :vertical
-                              :divider-positions [0.65]
-                              :items [{:fx/type tabber}
-                                      {:fx/type notice-logger}]}
-                             {:fx/type status-bar}]}}})
+  (let [;; re-render gui whenever style state changes
+        _ (fx/sub-val context get :style) ;; todo: remove outside of dev?
+        theme (fx/sub-val context get-in [:app-state :cfg :gui-theme])]
+
+    {:fx/type :stage
+     :showing true
+     :on-close-request (fn [ev]
+                         ;; called on ctrl-c
+                         ;;(println "got ev" ev)
+                         ;;(println (bean ev))
+                         (when-not (core/get-state :in-repl?)
+                           (System/exit 0)))
+
+     :title "strongbox"
+     :width 1024
+     :height 768
+     :scene {:fx/type :scene
+             :stylesheets [(::css/url style)]
+             :root {:fx/type :v-box
+                    :id (name theme)
+                    :children [{:fx/type menu-bar}
+                               {:fx/type :split-pane
+                                :id "splitter"
+                                :orientation :vertical
+                                :divider-positions [0.65]
+                                :items [{:fx/type tabber}
+                                        {:fx/type notice-logger}]}
+                               {:fx/type status-bar}]}}}))
 
 (defn init-notice-logger!
   [gui-state]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -383,6 +383,9 @@
                                                   :text "strongbox"}
                                                  {:fx/type :text
                                                   :text (format "version %s" (core/strongbox-version))}
+                                                 {:fx/type :text
+                                                  :text (format "version %s is now available to download!" (core/latest-strongbox-release))
+                                                  :visible (not (core/latest-strongbox-version?))}
                                                  {:fx/type :hyperlink
                                                   :text "https://github.com/ogri-la/strongbox"}
                                                  {:fx/type :text
@@ -513,11 +516,7 @@
 
 (defn installed-addons-menu-bar
   [{:keys [fx/context]}]
-  (let [;; temporary
-        refresh-button {:fx/type :button
-                        :text "Refresh"
-                        :on-action (async-handler core/refresh)}
-        update-all-button {:fx/type :button
+  (let [update-all-button {:fx/type :button
                            :text "Update all"
                            :on-action (async-handler core/install-update-all)}
 
@@ -545,13 +544,12 @@
         update-app-button {:fx/type :button
                            :text (str "Update Available: " (core/latest-strongbox-release))
                            :on-action (handler #(utils/browse-to "https://github.com/ogri-la/strongbox/releases"))
-                           :visible (not (core/latest-strongbox-version?))}
-        ]
+                           :visible (not (core/latest-strongbox-version?))}]
+
     {:fx/type :h-box
      :padding 10
      :spacing 10
-     :children [refresh-button
-                update-all-button
+     :children [update-all-button
                 wow-dir-dropdown
                 game-track-dropdown
                 update-app-button]}))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -15,8 +15,7 @@
     [core :as core]])
   (:import
    [javafx.util Callback]
-   [javafx.scene.control TableRow]
-   [javafx.scene.control TextInputDialog Alert Alert$AlertType ButtonType]
+   [javafx.scene.control TableRow TextInputDialog Alert Alert$AlertType ButtonType]
    [javafx.stage FileChooser DirectoryChooser WindowEvent]
    [javafx.application Platform]
    [javafx.event ActionEvent]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -21,7 +21,7 @@
 (def style
   (css/register
    ::style
-   (let [padding 0
+   (let [padding 2
          ;;text-color "#111111"
          text-color "black"
          text-size 12
@@ -37,7 +37,7 @@
       ;; string key ".root" defines `.root` selector with these rules: `-fx-padding: 10;`
 
       ".root" {:-fx-padding padding
-               :-fx-base "#fefefe"
+               ;;:-fx-base "#fefefe"
                ;;:-fx-base "white"
                ;;:-fx-accent: "#0096C9"
                :-fx-accent "#cfcfcf"
@@ -64,6 +64,12 @@
        :-fx-font-weight "Normal"
        :-fx-font-family "Sans"
        :-fx-size "1.9em"
+       }
+
+      ".table-view#notice-logger > .column-header-background"
+      {:-fx-max-height 0
+       :-fx-pref-height 0 
+       :-fx-min-height 0
        }
 
       ;;".table-row-cell" {:-fx-background "white"}
@@ -496,6 +502,7 @@
         column-list [{:text "level" :max-width 100 :cell-value-factory :level}
                      {:text "message" :pref-width 500 :cell-value-factory :message}]]
     {:fx/type :table-view
+     :id "notice-logger"
      :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
      :columns (mapv table-column column-list)
      :items (or log-message-list [])}))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -27,7 +27,7 @@
    (let [generate-style
          (fn [theme-kw]
            (let [colour-map (theme-kw  core/themes)
-                 colour #(name (get colour-map %))]
+                 colour #(name (get colour-map % "green"))]
              {(format "#%s.root " (name theme-kw))
               {:-fx-padding 0
                ;;:-fx-accent "#0096C9"
@@ -35,8 +35,9 @@
 
                ;; backgrounds
                ;;:-fx-accent "transparent"
-               :-fx-accent "lightsteelblue" ;; selection colour of backgrounds
-               ".text" {:-fx-font-smoothing-type "gray"}
+               :-fx-accent (colour :accent) ;; selection colour of backgrounds
+
+               ;;".text" {:-fx-font-smoothing-type "gray"}
 
                ".context-menu" {:-fx-effect "None"}
                ".combo-box-base" {:-fx-padding "1px"
@@ -69,19 +70,22 @@
                {:-fx-border-insets "-1 -1 0 -1"
                 :-fx-border-color (colour :table-border)
 
+                " .table-cell" {;;:-fx-text-fill "derive(-fx-control-inner-background,-90%)"
+                                }
+
                 ;; even
                 :-fx-background-color (colour :row)
                 ":hover" {:-fx-background-color (colour :row-hover)}
-                ":selected" {:-fx-background-color "-fx-selection-bar"}
+                ":selected" {:-fx-background-color "-fx-selection-bar"
+                             " .table-cell" {:-fx-text-fill "-fx-focused-text-base-color"}
+                             :-fx-table-cell-border-color (colour :table-border)}
 
                 ":odd" {:-fx-background-color (colour :row)}
                 ":odd:hover" {:-fx-background-color (colour :row-hover)}
                 ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
                 ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
 
-                ".unsteady" {:-fx-background-color (colour :unsteady)}
-
-                }
+                ".unsteady" {:-fx-background-color (colour :unsteady)}}
 
 
                ;; installed-addons table
@@ -89,7 +93,8 @@
 
                ".table-view#installed-addons"
                {" .updateable"
-                {:-fx-background-color (colour :installed/needs-updating)
+                {:-fx-background-color (colour :row-updateable)
+
                  ;; selected updateable addons are do not look any different
                  ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
@@ -103,10 +108,10 @@
 
 
                ".table-view#notice-logger"
-               {" .warn" {:-fx-background-color (colour :notice/warning)
+               {" .warn" {:-fx-background-color (colour :row-warning)
                           ":selected" {:-fx-background-color "-fx-selection-bar"}}
-                " .error" {:-fx-background-color (colour :notice/error)
-                           ;;" .text" {:-fx-text-fill "blue"}
+
+                " .error" {:-fx-background-color (colour :row-error)
                            ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
                 " #level" {:-fx-alignment "center"
@@ -771,7 +776,7 @@
                                {:fx/type :split-pane
                                 :id "splitter"
                                 :orientation :vertical
-                                :divider-positions [0.65]
+                                :divider-positions [0.7]
                                 :items [{:fx/type tabber}
                                         {:fx/type notice-logger}]}
                                {:fx/type status-bar}]}}}))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -424,6 +424,7 @@
                :visible (not (core/latest-strongbox-version?))}
               {:fx/type :hyperlink
                :text "https://github.com/ogri-la/strongbox"
+               :on-action (handler #(utils/browse-to "https://github.com/ogri-la/strongbox"))
                :id "about-pane-hyperlink"}
               {:fx/type :text
                :text "AGPL v3"}]})

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -30,13 +30,12 @@
                  colour #(name (get colour-map %))]
              {(format "#%s.root " (name theme-kw))
               {:-fx-padding 0
-               ;;:-fx-base "#fefefe"
-               ;;:-fx-base "white"
                ;;:-fx-accent "#0096C9"
+               :-fx-base (colour :base)
 
                ;; backgrounds
                ;;:-fx-accent "transparent"
-               :-fx-accent "lightsteelblue"
+               :-fx-accent "lightsteelblue" ;; selection colour of backgrounds
                ".text" {:-fx-font-smoothing-type "gray"}
 
                ".context-menu" {:-fx-effect "None"}
@@ -57,7 +56,7 @@
 
                ;; common tables
                ".table-view"
-               {:-fx-table-cell-border-color (colour :table-border-colour)
+               {:-fx-table-cell-border-color (colour :table-border)
                 :-fx-font-size ".9em"}
 
                ".table-view .column-header"
@@ -68,17 +67,21 @@
 
                ".table-view .table-row-cell"
                {:-fx-border-insets "-1 -1 0 -1"
-                :-fx-border-color (colour :table-border-colour)
+                :-fx-border-color (colour :table-border)
 
-                ":hover" {:-fx-background-color (colour :installed/hovering)}
+                ;; even
+                :-fx-background-color (colour :row)
+                ":hover" {:-fx-background-color (colour :row-hover)}
                 ":selected" {:-fx-background-color "-fx-selection-bar"}
 
-                ":odd" {:-fx-background-color (colour :odd-coloured-rows)}
-                ":odd:hover" {:-fx-background-color (colour :installed/hovering)}
+                ":odd" {:-fx-background-color (colour :row)}
+                ":odd:hover" {:-fx-background-color (colour :row-hover)}
                 ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
                 ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
 
-                ".unsteady" {:-fx-background-color (colour :unsteady)}}
+                ".unsteady" {:-fx-background-color (colour :unsteady)}
+
+                }
 
 
                ;; installed-addons table

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -86,7 +86,8 @@
                 ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
                 ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
 
-                ".unsteady" {:-fx-background-color (colour :unsteady)}}
+                ".unsteady" {;; '!important' so that it takes precedence over .updateable addons
+                             :-fx-background-color (str (colour :unsteady) " !important")}}
 
 
                ;; installed-addons table
@@ -256,8 +257,7 @@
                 :toggle-group {:fx/type fx/ext-get-ref
                                :ref ::catalogue-toggle-group}
                 :on-action (fn [_]
-                             (core/set-catalogue-location! name)
-                             (core/save-settings))})]
+                             (cli/set-catalogue-location! name))})]
       (mapv rb catalogue-addon-list))))
 
 (defn build-theme-menu
@@ -340,13 +340,12 @@
   [ev]
   (if (core/get-state :in-repl?)
     (when-let [stage (try
-                       (-> ev 
+                       (-> ev
                            .getTarget
                            .getParentPopup
                            .getOwnerWindow
                            .getScene
-                           .getWindow
-                           )
+                           .getWindow)
                        (catch NullPointerException npe
                          (println "cannot use Ctrl-Q in repl :(")))]
       (.fireEvent stage (WindowEvent. stage WindowEvent/WINDOW_CLOSE_REQUEST)))
@@ -600,13 +599,9 @@
 
 (defn installed-addons-table
   [{:keys [fx/context]}]
-  ;;(dosync
-  ;; (fx/sub-val context get-in [:app-state :selected-addon-dir])
-  ;; (fx/sub-val context get-in [:app-state :installed-addon-list]))
-
-  (let [_ (fx/sub-val context get-in [:app-state :unsteady-addons])
-        ;;_ (fx/sub-val context get-in [:app-state :selected-addon-dir])
-        row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
+  ;; re-render table when unsteady addons changes
+  (fx/sub-val context get-in [:app-state :unsteady-addons])
+  (let [row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
 
         iface-version (fn [row]
                         (some-> row :interface-version str utils/interface-version-to-game-version))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -247,36 +247,6 @@
    (when-let [key (:key opt-map)]
      {:accelerator key})))
 
-(defn build-catalogue-menu
-  [selected-catalogue catalogue-addon-list]
-  (when catalogue-addon-list
-    (let [rb (fn [{:keys [label name]}]
-               {:fx/type :radio-menu-item
-                :text label
-                :selected (= selected-catalogue name)
-                :toggle-group {:fx/type fx/ext-get-ref
-                               :ref ::catalogue-toggle-group}
-                :on-action (fn [_]
-                             (cli/set-catalogue-location! name))})]
-      (mapv rb catalogue-addon-list))))
-
-(defn build-theme-menu
-  "returns a menu of radio buttons that can toggle through the available themes defined in `core/themes`"
-  [selected-theme theme-map]
-  (let [rb (fn [theme-key]
-             {:fx/type :radio-menu-item
-              :text (format "%s theme" (-> theme-key name clojure.string/capitalize))
-              :selected (= selected-theme theme-key)
-              :toggle-group {:fx/type fx/ext-get-ref
-                             :ref ::theme-toggle-group}
-              :on-action (fn [_]
-                           (swap! core/state assoc-in [:cfg :gui-theme] theme-key)
-                           (core/save-settings)
-                           ;; trigger-gui-restart ...
-                           )})]
-
-    (mapv rb (keys theme-map))))
-
 (defn menu
   [label items & [opt-map]]
   (merge
@@ -454,6 +424,35 @@
 
 (def separator {:fx/type fx/ext-instance-factory
                 :create #(javafx.scene.control.SeparatorMenuItem.)})
+
+(defn build-catalogue-menu
+  [selected-catalogue catalogue-addon-list]
+  (when catalogue-addon-list
+    (let [rb (fn [{:keys [label name]}]
+               {:fx/type :radio-menu-item
+                :text label
+                :selected (= selected-catalogue name)
+                :toggle-group {:fx/type fx/ext-get-ref
+                               :ref ::catalogue-toggle-group}
+                :on-action (async-handler #(cli/set-catalogue-location! name))})]
+      (mapv rb catalogue-addon-list))))
+
+(defn build-theme-menu
+  "returns a menu of radio buttons that can toggle through the available themes defined in `core/themes`"
+  [selected-theme theme-map]
+  (let [rb (fn [theme-key]
+             {:fx/type :radio-menu-item
+              :text (format "%s theme" (-> theme-key name clojure.string/capitalize))
+              :selected (= selected-theme theme-key)
+              :toggle-group {:fx/type fx/ext-get-ref
+                             :ref ::theme-toggle-group}
+              :on-action (fn [_]
+                           (swap! core/state assoc-in [:cfg :gui-theme] theme-key)
+                           (core/save-settings)
+                           ;; trigger-gui-restart ...
+                           )})]
+
+    (mapv rb (keys theme-map))))
 
 (defn menu-bar
   [{:keys [fx/context]}]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -571,10 +571,13 @@
 
         wow-dir-dropdown {:fx/type :combo-box
                           :value selected-addon-dir
+                          :button-cell (fn [row] {:text (:addon-dir row)})
+                          :cell-factory {:fx/cell-type :list-cell
+                                         :describe (fn [row] {:text (:addon-dir row)})}
                           :on-value-changed (async-event-handler
                                              (fn [new-addon-dir]
-                                               (cli/set-addon-dir! new-addon-dir)))
-                          :items (mapv :addon-dir addon-dir-map-list)}
+                                               (cli/set-addon-dir! (:addon-dir new-addon-dir))))
+                          :items addon-dir-map-list}
 
         game-track-dropdown {:fx/type :combo-box
                              :value (-> selected-game-track (or "") name)
@@ -869,7 +872,6 @@
         ;; don't do this, renderer has to be unmounted and the app closed before further state changes happen during cleanup
         ;;_ (core/add-cleanup-fn #(fx/unmount-renderer gui-state renderer))
         _ (swap! core/state assoc :disable-gui (fn []
-                                                 (println "unmounting renderer")
                                                  (fx/unmount-renderer gui-state renderer)
                                                  ;; the slightest of delays allows any final rendering to happen before the exit-handler is called.
                                                  ;; only affects testing from the repl apparently and not `./run-tests.sh`

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -8,6 +8,7 @@
     [api :as fx]]
    [cljfx.css :as css]
    ;;[clojure.core.cache :as cache]
+   [strongbox.ui.cli :as cli]
    [strongbox
     [logging :as logging]
     [utils :as utils]
@@ -332,8 +333,7 @@
   (when-let [dir (dir-chooser ev)]
     (when (fs/directory? dir)
       ;; doesn't appear possible to select a non-directory with javafx
-      (core/set-addon-dir! dir)
-      (core/save-settings))))
+      (cli/set-addon-dir! dir))))
 
 ;; todo: reconcile this with the on-close-request handler in the stage
 (defn exit-handler
@@ -459,7 +459,7 @@
 (defn menu-bar
   [{:keys [fx/context]}]
   (let [file-menu [(menu-item "_New addon directory" (event-handler wow-dir-picker) {:key "Ctrl+N"})
-                   (menu-item "Remove addon directory" (async-handler core/remove-addon-dir!))
+                   (menu-item "Remove addon directory" (async-handler cli/remove-addon-dir!))
                    separator
                    (menu-item "E_xit" exit-handler {:key "Ctrl+Q"})]
 
@@ -532,7 +532,7 @@
                           :on-value-changed (async-event-handler
                                              (fn [new-addon-dir]
                                                ;; dosync doesn't work here, stop trying it
-                                               (core/set-addon-dir! new-addon-dir)
+                                               (cli/set-addon-dir! new-addon-dir)
                                                (println "done setting addon dir")))
                           :items (mapv :addon-dir addon-dir-map-list)}
 

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -107,13 +107,20 @@
 
 
 (defn installed-addons-menu-bar
-  [{:keys [_]}]
+  [{:keys [state]}]
   (let [update-all-button {:fx/type :button
                            :text "Update all"}
+
+        addon-dir-map-list (-> state :cfg :addon-dir-list (or []))
+        selected-addon-dir (-> state :cfg :selected-addon-dir)
+        selected-game-track (core/get-game-track selected-addon-dir)
+
         wow-dir-dropdown {:fx/type :combo-box
-                          :items ["/home/torkus/path/to/wine/prefix/World of Warcraft/_retail_/Interface/Addons/"]}
+                          :value selected-addon-dir
+                          :items (mapv :addon-dir addon-dir-map-list)}
 
         game-track-dropdown {:fx/type :combo-box
+                             :value selected-game-track
                              :items ["retail" "classic"]}]
     {:fx/type :h-box
      :padding 10
@@ -188,7 +195,7 @@
 (defn installed-addons-pane
   [{:keys [state]}]
   {:fx/type :v-box
-   :children [{:fx/type installed-addons-menu-bar}
+   :children [{:fx/type installed-addons-menu-bar :state state}
               {:fx/type :split-pane
                :orientation :vertical
                :divider-positions [0.7]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -92,9 +92,11 @@
       ".table-view#installed-addons"
       {" .updateable"
        {:-fx-background-color "lemonchiffon"
-
         ;; selected updateable addons are do not look any different
         ":selected" {:-fx-background-color "-fx-selection-bar"}}
+
+       " .ignored .table-cell"
+       {:-fx-text-fill "#aaa"}
 
        " .wow-column" {:-fx-alignment "center"}}
 
@@ -561,6 +563,7 @@
                                        (remove nil?
                                                ["table-row-cell" ;; :style-class actually *replaces* the list of classes
                                                 (when (:update? row) "updateable")
+                                                (when (:ignore? row) "ignored")
                                                 (when (core/unsteady? row) "unsteady")])})}
             :columns (mapv table-column column-list)
             :context-menu {:fx/type :context-menu

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -2,6 +2,7 @@
   (:require
    [me.raynes.fs :as fs]
    [taoensso.timbre :as timbre :refer [debug info warn error spy]]
+   [cljfx.ext.table-view :as fx.ext.table-view]
    [cljfx
     [api :as fx]]
    ;;[clojure.core.cache :as cache]
@@ -159,10 +160,7 @@
 
 ;; todo: reconcile this with the on-close-request handler in the stage
 (defn exit-handler
-  [event]
-  (println "hit exit handler")
-  ;;(javafx.application.Platform/exit) ;; won't open again
-  (-> event .getTarget .getParentPopup .getOwnerWindow .getScene .getWindow .close)
+  [_]
   (when-not (core/get-state :in-repl?)
     (System/exit 0)))
 
@@ -375,12 +373,15 @@
                      {:text "installed" :max-width 150 :cell-value-factory :installed-version}
                      {:text "available" :max-width 150 :cell-value-factory :version}
                      {:text "WoW" :max-width 100 :cell-value-factory :interface-version}]]
-    {:fx/type :table-view
-     :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
-     :selection-mode :multiple
-     :pref-height 999.0
-     :columns (mapv table-column column-list)
-     :items (or row-list [])}))
+    {:fx/type fx.ext.table-view/with-selection-props
+     :props {:selection-mode :multiple
+             ;; unlike gui.clj, we have access to the original data here
+             :on-selected-items-changed core/select-addons*}
+     :desc {:fx/type :table-view
+            :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
+            :pref-height 999.0
+            :columns (mapv table-column column-list)
+            :items (or row-list [])}}))
 
 (defn notice-logger
   [{:keys [fx/context]}]
@@ -408,12 +409,15 @@
                      {:text "tags" :pref-width 380 :min-width 230 :max-width 450 :cell-value-factory (comp str :tag-list)}
                      {:text "updated" :min-width 85 :max-width 120 :pref-width 100 :cell-value-factory (comp #(utils/safe-subs % 10)  :updated-date)}
                      {:text "downloads" :min-width 100 :max-width 120 :cell-value-factory :download-count}]]
-    {:fx/type :table-view
-     :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
-     :selection-mode :multiple
-     :pref-height 999.0
-     :columns (mapv table-column column-list)
-     :items addon-list}))
+    {:fx/type fx.ext.table-view/with-selection-props
+     :props {:selection-mode :multiple
+             ;; unlike gui.clj, we have access to the original data here. and it's an ordered/map ...?
+             :on-selected-items-changed core/select-addons-search*}
+     :desc {:fx/type :table-view
+            :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
+            :pref-height 999.0
+            :columns (mapv table-column column-list)
+            :items addon-list}}))
 
 (defn search-addons-search-field
   [_]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -162,7 +162,6 @@
   (when-not (core/get-state :in-repl?)
     (System/exit 0)))
 
-(def export-user-catalogue-handler donothing)
 (def about-strongbox-dialog donothing)
 
 (defn switch-tab-handler
@@ -212,6 +211,14 @@
     (core/export-installed-addon-list-safely (-> file-obj .getAbsolutePath str))
     nil))
 
+(defn export-user-catalogue-handler
+  "prompts user with a file selection dialogue then writes the user catalogue to selected file"
+  [event]
+  (when-let [;; todo: json filters
+             file-obj (file-chooser event {:type :save})]
+    (core/export-user-catalogue-addon-list-safely (-> file-obj .getAbsolutePath str))
+    nil))
+
 ;;
 
 (def separator {:fx/type fx/ext-instance-factory
@@ -245,7 +252,7 @@
                      separator
                      (menu-item "Import addon list" (async-event-handler import-addon-list-handler))
                      (menu-item "Export addon list" (async-event-handler export-addon-list-handler))
-                     (menu-item "Export Github addon list" (async-handler export-user-catalogue-handler))]
+                     (menu-item "Export Github addon list" (async-event-handler export-user-catalogue-handler))]
 
         cache-menu [(menu-item "Clear http cache" (async-handler core/delete-http-cache!))
                     (menu-item "Clear addon zips" (async-handler core/delete-downloaded-addon-zips!))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -371,22 +371,25 @@
     (core/export-user-catalogue-addon-list-safely (-> file-obj .getAbsolutePath str))
     nil))
 
+(defn -about-strongbox-dialog
+  []
+  {:fx/type :v-box
+   :children [{:fx/type :text
+               :text "strongbox"}
+              {:fx/type :text
+               :text (format "version %s" (core/strongbox-version))}
+              {:fx/type :text
+               :text (format "version %s is now available to download!" (core/latest-strongbox-release))
+               :visible (not (core/latest-strongbox-version?))}
+              {:fx/type :hyperlink
+               :text "https://github.com/ogri-la/strongbox"}
+              {:fx/type :text
+               :text "AGPL v3"}]})
+
 (defn about-strongbox-dialog
   [event]
-  (let [content (fx/create-component {:fx/type :v-box
-                                      :children [{:fx/type :text
-                                                  :text "strongbox"}
-                                                 {:fx/type :text
-                                                  :text (format "version %s" (core/strongbox-version))}
-                                                 {:fx/type :text
-                                                  :text (format "version %s is now available to download!" (core/latest-strongbox-release))
-                                                  :visible (not (core/latest-strongbox-version?))}
-                                                 {:fx/type :hyperlink
-                                                  :text "https://github.com/ogri-la/strongbox"}
-                                                 {:fx/type :text
-                                                  :text "AGPL v3"}]})]
-    (alert event "" {:type :info :content (fx/instance content)})
-    nil))
+  (alert event "" {:type :info :content (fx/instance (fx/create-component (-about-strongbox-dialog)))})
+  nil)
 
 (defn remove-selected-confirmation-handler
   [event]
@@ -715,7 +718,6 @@
 (defn status-bar
   "this is the litle strip of text at the bottom of the application."
   [{:keys [fx/context]}]
-  []
   (let [num-matching-template "%s of %s installed addons found in catalogue."
         all-matching-template "all installed addons found in catalogue."
         catalogue-count-template "%s addons in catalogue."

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -121,11 +121,18 @@
        :-fx-font-family "monospace"}
 
 
+      "#splitter .split-pane-divider"
+       {:-fx-padding "8px"}
+
       ;; search
       ".table-view#search-addons"
       {" .downloads-column" {:-fx-alignment "center-right"}
        " .installed" {:-fx-background-color "#99bc6b"}}
 
+
+      "#status-bar"
+      {:-fx-font-size ".9em"
+       :-fx-padding "5px"}      
 
       ;; common table fields
       ".table-view .source-column"
@@ -662,6 +669,33 @@
            :closable false
            :content {:fx/type search-addons-pane}}]})
 
+(defn status-bar
+  [{:keys [fx/context]}]
+  "this is the litle strip of text at the bottom of the application."
+  []
+  (let [num-matching-template "%s of %s installed addons found in catalogue."
+        all-matching-template "all installed addons found in catalogue."
+        catalogue-count-template "%s addons in catalogue."
+
+        ;;ia (:installed-addon-list state)
+        ia (fx/sub-val context get-in [:app-state :installed-addon-list])
+        
+        uia (filter :matched? ia)
+
+        a-count (count (fx/sub-val context get-in [:app-state :db]))
+        ia-count (count ia)
+        uia-count (count uia)
+
+        strings [(format catalogue-count-template a-count)
+                 (if (= ia-count uia-count)
+                   all-matching-template
+                   (format num-matching-template uia-count ia-count))]]
+    
+    {:fx/type :h-box
+     :id "status-bar"
+     :children [{:fx/type :text
+                 :text (clojure.string/join " " strings)}]}))
+
 ;;
 
 (defn root
@@ -684,10 +718,12 @@
            :root {:fx/type :v-box
                   :children [{:fx/type menu-bar}
                              {:fx/type :split-pane
+                              :id "splitter"
                               :orientation :vertical
                               :divider-positions [0.65]
                               :items [{:fx/type tabber}
-                                      {:fx/type notice-logger}]}]}}})
+                                      {:fx/type notice-logger}]}
+                             {:fx/type status-bar}]}}})
 
 (defn init-notice-logger!
   [gui-state]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -843,6 +843,7 @@
                       (when-not (:search-field-input core/state)
                         (swap! core/state assoc :search-field-input "")))]
 
+    (swap! core/state assoc :gui-showing? true)
     (fx/mount-renderer gui-state renderer)
     (init-notice-logger! gui-state)
 

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -689,6 +689,7 @@
    :padding 10
    :spacing 10
    :children [{:fx/type :text-field
+               :id "search-text-field"
                :prompt-text "search"
                :on-text-changed (fn [v]
                                   (swap! core/state assoc :search-field-input v))}
@@ -718,6 +719,12 @@
           {:fx/type :tab
            :text "search"
            :closable false
+           :on-selection-changed (fn [ev]
+                                   (when (-> ev .getTarget .isSelected)
+                                     (let [text-field (-> ev .getTarget .getTabPane (.lookupAll "#search-text-field") first)]
+                                       (Platform/runLater
+                                        (fn []
+                                          (-> text-field .requestFocus))))))
            :content {:fx/type search-addons-pane}}]})
 
 (defn status-bar

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -38,16 +38,19 @@
                ;;:-fx-font-size ".9em"
                }
 
-      ".table-view" {:-fx-table-cell-border-color table-border-colour
-                     ;;:-fx-font-size "1em"
-                     :-fx-font-size ".9em"
-                     ;;:-fx-font-family "\"Bitstream Vera Sans Mono\", Mono"
-                     }
+      ".table-view"
+      {:-fx-table-cell-border-color table-border-colour
+       ;;:-fx-font-size "1em"
+       :-fx-font-size ".9em"
+       ;;:-fx-font-family "\"Bitstream Vera Sans Mono\", Mono"
+       }
 
       ".table-view .table-column"
       {:-fx-alignment "center-left"
        
        }
+
+      ".unsteady" {:-fx-background-color "lightsteelblue"}
 
       ".table-view .table-row-cell"
       {:-fx-cell-size row-size
@@ -108,7 +111,6 @@
       ".wow"
       {:-fx-alignment "center"
        }
-
 
       })))
 
@@ -495,7 +497,8 @@
 
 (defn installed-addons-table
   [{:keys [fx/context]}]
-  (let [row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
+  (let [_ (fx/sub-val context get-in [:app-state :unsteady-addons])
+        row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
 
         iface-version (fn [row]
                         (some-> row :interface-version str utils/interface-version-to-game-version))
@@ -515,9 +518,12 @@
             :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
             :pref-height 999.0
             :row-factory {:fx/cell-type :table-row
-                          :describe (fn [x]
-                                      (when (:update? x)
-                                        {:style-class ["updateable"]}))}
+                          :describe (fn [row]
+                                      {:style-class
+                                       (remove nil?
+                                               ["table-row-cell" ;; :style-class actually *replaces* the list of classes
+                                                (when (:update? row) "updateable")
+                                                (when (core/unsteady? row) "unsteady")])})}
             :columns (mapv table-column column-list)
             :context-menu {:fx/type :context-menu
                            :items [(menu-item "Update" (async-handler core/install-update-selected))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -5,6 +5,7 @@
    [cljfx.ext.table-view :as fx.ext.table-view]
    [cljfx
     [api :as fx]]
+   [cljfx.css :as css]
    ;;[clojure.core.cache :as cache]
    [strongbox
     [logging :as logging]
@@ -16,6 +17,85 @@
    [javafx.application Platform]
    [javafx.event ActionEvent]
    [javafx.scene Node]))
+
+(def style
+  (css/register
+   ::style
+   (let [padding 0
+         ;;text-color "#111111"
+         text-color "black"
+         text-size 12
+         ]
+
+     ;; you can put style settings that you need to access from code at keyword keys in a
+     ;; style map and access them directly in an app
+
+     {::padding padding
+      ::text-color text-color
+      ::text-size text-size
+
+      ;; string key ".root" defines `.root` selector with these rules: `-fx-padding: 10;`
+
+      ".root" {:-fx-padding padding
+               :-fx-base "#fefefe"
+               ;;:-fx-base "white"
+               ;;:-fx-accent: "#0096C9"
+               :-fx-accent "#cfcfcf"
+               }
+      ".text" {;;:-fx-font-smoothing-type "gray"
+               ;;:-fx-font-size ".9em"
+               
+               }
+      ".table-view" {:-fx-table-cell-border-color "#aaa"
+                     :-fx-font-size ".9em"
+                     :-fx-font-family "\"Bitstream Vera Sans Mono\", Mono"
+
+                     }
+
+      ".tab-pane > .tab-header-area > .headers-region > .tab "
+      {:-fx-background-radius "0"
+       ;;:-fx-padding "3px 20px"
+
+       }
+      
+      ".table-view .column-header"
+      {;;:-fx-background-color "#ddd"
+       :-fx-font-size "1em"
+       :-fx-font-weight "Normal"
+       :-fx-font-family "Sans"
+       :-fx-size "1.9em"
+       }
+
+      ;;".table-row-cell" {:-fx-background "white"}
+      
+      ".table-row-cell:odd" {
+                             :-fx-background "white"
+                             
+                             }
+      
+      ".table-row-cell:hover" {;;:-fx-background "#eee"
+                               
+                               }
+      
+      ".label" {:-fx-text-fill text-color
+                :-fx-wrap-text true
+
+                }
+
+      ".context-menu" {:-fx-effect "None"}
+      ".combo-box-base" {:-fx-padding "1px"
+                         :-fx-background-radius "0"
+
+                         }
+      
+      ".button" {:-fx-background-radius "0"
+                 :-fx-text-fill text-color
+                 ;; vector values are space-separated
+                 :-fx-padding ["6px" "17px"]
+                 ;; nested string key defines new selector: `.button:hover`
+                 ":hover" {:-fx-text-fill :black}}})))
+
+;;
 
 (defn file-chooser
   [^ActionEvent event & [opt-map]]
@@ -492,7 +572,8 @@
 ;;
 
 (defn root
-  [_]
+  [{:keys [fx/context]}]
+  (fx/sub-val context get :style) ;; todo: remove outside of dev?
   {:fx/type :stage
    :showing true
    :on-close-request (fn [ev]
@@ -506,6 +587,7 @@
    :width 1024
    :height 768
    :scene {:fx/type :scene
+           :stylesheets [(::css/url style)]
            :root {:fx/type :v-box
                   :children [{:fx/type menu-bar}
                              {:fx/type :split-pane
@@ -526,8 +608,12 @@
   []
   (info "starting gui")
   (let [state-template {:app-state nil,
-                        :log-message-list []}
+                        :log-message-list []
+                        :style style}
         gui-state (atom (fx/create-context state-template)) ;; cache/lru-cache-factory))
+
+        _ (add-watch #'style :refresh-app (fn [_ _ _ _]
+                                            (swap! gui-state fx/swap-context assoc :style style)))
 
         update-gui-state (fn [new-state]
                            (swap! gui-state fx/swap-context assoc :app-state new-state))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -661,7 +661,7 @@
                                                ["table-row-cell" ;; `:style-class` will actually *replace* the list of classes
                                                 (when (:update? row) "updateable")
                                                 (when (:ignore? row) "ignored")
-                                                (when (core/unsteady? row) "unsteady")])})}
+                                                (when (and row (core/unsteady? (:name row))) "unsteady")])})}
             :columns (mapv table-column column-list)
             :context-menu {:fx/type :context-menu
                            :items [(menu-item "Update" (async-handler core/install-update-selected))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -3,6 +3,7 @@
    [taoensso.timbre :as timbre :refer [debug info warn error spy]]
    [cljfx.api :as fx]
    [strongbox
+    [utils :as utils]
     [core :as core]]))
 
 (def INSTALLED-TAB 0)
@@ -218,11 +219,11 @@
   [{:keys [state]}]
   (let [addon-list (core/db-search (:search-field-input state))
         column-list [{:text "source" :min-width 100 :max-width 110 :cell-value-factory source-to-href-fn}
-                     {:text "name" :min-width 150 :pref-width 300 :max-width 500 :cell-value-factory :label}
+                     {:text "name" :min-width 150 :pref-width 300 :max-width 450 :cell-value-factory :label}
                      {:text "description" :pref-width 700 :cell-value-factory :description}
-                     {:text "tags" :cell-value-factory (comp str :tag-list)}
-                     {:text "updated" :cell-value-factory :updated-date}
-                     {:text "downloads" :cell-value-factory :download-count}]]
+                     {:text "tags" :pref-width 380 :min-width 230 :max-width 450 :cell-value-factory (comp str :tag-list)}
+                     {:text "updated" :min-width 85 :max-width 120 :pref-width 100 :cell-value-factory (comp #(utils/safe-subs % 10)  :updated-date)}
+                     {:text "downloads" :min-width 100 :max-width 120 :cell-value-factory :download-count}]]
     {:fx/type :table-view
      :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
      :selection-mode :multiple

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -54,14 +54,12 @@
       ;;          :-fx-wrap-text true}
 
       ;; tabber
-
       ".tab-pane > .tab-header-area > .headers-region > .tab "
       {:-fx-background-radius "0"
        ;;:-fx-padding "3px 20px"
        }
 
       ;; common tables
-
       ".table-view"
       {:-fx-table-cell-border-color table-border-colour
        :-fx-font-size ".9em"}
@@ -88,7 +86,6 @@
 
 
       ;; installed-addons table
-
       ".table-view#installed-addons"
       {" .updateable"
        {:-fx-background-color "lemonchiffon"
@@ -102,7 +99,6 @@
 
 
       ;; notice-logger
-
       ".table-view#notice-logger"
       {" .warn" {:-fx-background-color "lemonchiffon"
                  ":selected" {:-fx-background-color "-fx-selection-bar"}}
@@ -126,16 +122,12 @@
 
 
       ;; search
-
       ".table-view#search-addons"
-      {" .description" {:-fx-pref-width 700}
-       " .tags" {:-fx-min-width 230 :-fx-max-width 450}
-       " .updated" {:-fx-min-width 85 :-fx-max-width 120 :-fx-pref-width 100}
-       " .downloads" {:-fx-min-width 100 :-fx-max-width 120}}
+      {" .downloads-column" {:-fx-alignment "center-right"}
+       " .installed" {:-fx-background-color "#99bc6b"}}
 
 
       ;; common table fields
-
       ".table-view .source-column"
       {:-fx-alignment "center-left"
        :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
@@ -600,7 +592,10 @@
 
 (defn search-addons-table
   [{:keys [fx/context]}]
-  (let [addon-list (fx/sub-val context get-in [:app-state :search-results])
+  (let [idx-key #(select-keys % [:source :source-id])
+        installed-addon-idx (mapv idx-key (fx/sub-val context get-in [:app-state :installed-addon-list]))
+
+        addon-list (fx/sub-val context get-in [:app-state :search-results])
         column-list [{:text "source" :min-width 110 :pref-width 120 :max-width 160 :cell-value-factory href-to-hyperlink}
                      {:text "name" :min-width 150 :pref-width 300 :max-width 450 :cell-value-factory :label}
                      {:text "description" :pref-width 700 :cell-value-factory :description}
@@ -613,6 +608,11 @@
              :on-selected-items-changed core/select-addons-search*}
      :desc {:fx/type :table-view
             :id "search-addons"
+            :row-factory {:fx/cell-type :table-row
+                          :describe (fn [row]
+                                      {:style-class ["table-row-cell"
+                                                     (when (utils/in? (idx-key row) installed-addon-idx)
+                                                       "installed")]})}
             :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
             :pref-height 999.0
             :columns (mapv table-column column-list)

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -113,14 +113,14 @@
 
         addon-dir-map-list (-> state :cfg :addon-dir-list (or []))
         selected-addon-dir (-> state :cfg :selected-addon-dir)
-        selected-game-track (core/get-game-track selected-addon-dir)
+        selected-game-track (or (core/get-game-track selected-addon-dir) "")
 
         wow-dir-dropdown {:fx/type :combo-box
                           :value selected-addon-dir
                           :items (mapv :addon-dir addon-dir-map-list)}
 
         game-track-dropdown {:fx/type :combo-box
-                             :value selected-game-track
+                             :value (name selected-game-track)
                              :items ["retail" "classic"]}]
     {:fx/type :h-box
      :padding 10

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -16,7 +16,7 @@
    [javafx.util Callback]
    [javafx.scene.control TableRow]
    [javafx.scene.control TextInputDialog Alert Alert$AlertType ButtonType]
-   [javafx.stage FileChooser DirectoryChooser]
+   [javafx.stage FileChooser DirectoryChooser WindowEvent]
    [javafx.application Platform]
    [javafx.event ActionEvent]
    [javafx.scene Node]))
@@ -337,8 +337,19 @@
 
 ;; todo: reconcile this with the on-close-request handler in the stage
 (defn exit-handler
-  [_]
-  (when-not (core/get-state :in-repl?)
+  [ev]
+  (if (core/get-state :in-repl?)
+    (when-let [stage (try
+                       (-> ev 
+                           .getTarget
+                           .getParentPopup
+                           .getOwnerWindow
+                           .getScene
+                           .getWindow
+                           )
+                       (catch NullPointerException npe
+                         (println "cannot use Ctrl-Q in repl :(")))]
+      (.fireEvent stage (WindowEvent. stage WindowEvent/WINDOW_CLOSE_REQUEST)))
     (System/exit 0)))
 
 (defn switch-tab-handler

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -39,6 +39,29 @@
       ".text"
       {:-fx-font-smoothing-type "gray"}
 
+      ".context-menu" {:-fx-effect "None"}
+      ".combo-box-base" {:-fx-padding "1px"
+                         :-fx-background-radius "0"}
+
+      ".button" {:-fx-background-radius "0"
+                 :-fx-text-fill text-color
+                 ;; vector values are space-separated
+                 :-fx-padding ["6px" "17px"]
+                 ;; nested string key defines new selector: `.button:hover`
+                 ":hover" {:-fx-text-fill :black}}
+
+      ;;".label" {:-fx-text-fill text-color
+      ;;          :-fx-wrap-text true}
+
+      ;; tabber
+
+      ".tab-pane > .tab-header-area > .headers-region > .tab "
+      {:-fx-background-radius "0"
+       ;;:-fx-padding "3px 20px"
+       }
+
+      ;; common tables
+
       ".table-view"
       {:-fx-table-cell-border-color table-border-colour
        :-fx-font-size ".9em"}
@@ -56,7 +79,6 @@
        ":hover" {:-fx-background-color "#eee"}
        ":selected" {:-fx-background-color "-fx-selection-bar"}
 
-       ;; fuck this odd styling
        ":odd" {:-fx-background-color "white"}
        ":odd:hover" {:-fx-background-color "#eee"}
        ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
@@ -64,65 +86,60 @@
 
        ".unsteady" {:-fx-background-color "lightsteelblue"}}
 
+
+      ;; installed-addons table
+
       ".table-view#installed-addons"
       {" .updateable"
        {:-fx-background-color "lemonchiffon"
 
         ;; selected updateable addons are do not look any different
-        ":selected" {:-fx-background-color "-fx-selection-bar"}}}
+        ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
-      ".tab-pane > .tab-header-area > .headers-region > .tab "
-      {:-fx-background-radius "0"
-       ;;:-fx-padding "3px 20px"
-       }
+       " .wow-column" {:-fx-alignment "center"}}
 
-      ".table-view#notice-logger > .column-header-background"
-      {:-fx-max-height 0
-       :-fx-pref-height 0
-       :-fx-min-height 0}
 
-      ".table-view#notice-logger #level"
-      {:-fx-alignment "center"}
-
-      ".label" {:-fx-text-fill text-color
-                :-fx-wrap-text true}
-
-      ".table-view#notice-logger .text"
-      {:-fx-text-fill "green"}
+      ;; notice-logger
 
       ".table-view#notice-logger"
-      {" .warn" {:-fx-background-color "lemonchiffon"}
+      {" .warn" {:-fx-background-color "lemonchiffon"
+                 ":selected" {:-fx-background-color "-fx-selection-bar"}}
        " .error" {:-fx-background-color "tomato"
                   " .text" {:-fx-text-fill "blue"}
-                  ;;:-fx-border-color "black" ;;table-border-colour
-                  ;;:-fx-border-insets "0 0 -1 0"
-                  ;;:-fx-border-width "1 0 1 0"
-                  ;;:-fx-cell-size row-size
-                  }}
+                  ":selected" {:-fx-background-color "-fx-selection-bar"}}
 
-      ".context-menu" {:-fx-effect "None"}
-      ".combo-box-base" {:-fx-padding "1px"
-                         :-fx-background-radius "0"}
+       " #level" {:-fx-alignment "center"
+                  :-fx-border-width "0"}
 
-      ".button" {:-fx-background-radius "0"
-                 :-fx-text-fill text-color
-                 ;; vector values are space-separated
-                 :-fx-padding ["6px" "17px"]
-                 ;; nested string key defines new selector: `.button:hover`
-                 ":hover" {:-fx-text-fill :black}}
+       ;; hide column headers
+       " > .column-header-background"
+       {:-fx-max-height 0
+        :-fx-pref-height 0
+        :-fx-min-height 0}
 
-      ".source"
+       " .table-row-cell"
+       {:-fx-border-color "white"}
+
+       :-fx-font-family "monospace"}
+
+
+      ;; search
+
+      ".table-view#search-addons"
+      {" .description" {:-fx-pref-width 700}
+       " .tags" {:-fx-min-width 230 :-fx-max-width 450}
+       " .updated" {:-fx-min-width 85 :-fx-max-width 120 :-fx-pref-width 100}
+       " .downloads" {:-fx-min-width 100 :-fx-max-width 120}}
+
+
+      ;; common table fields
+
+      ".table-view .source-column"
       {:-fx-alignment "center-left"
        :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
-       :-fx-min-width "120px"
-       :-fx-pref-width "120px"
-       :-fx-max-width "130px"
        " .hyperlink:visited" {:-fx-underline "false"}
        " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
-                                        :-fx-text-fill "blue"}}
-
-      ".wow"
-      {:-fx-alignment "center"}})))
+                                        :-fx-text-fill "blue"}}})))
 
 ;;
 
@@ -469,8 +486,7 @@
 
 (defn table-column
   [column-data]
-  (let [column-data (if (string? column-data) {:text column-data} column-data)
-        column-name (:text column-data)
+  (let [column-name (:text column-data)
 
         default-cvf (fn [row] (get row (keyword column-name)))
         new-cvf (:cell-value-factory column-data)
@@ -481,7 +497,9 @@
                     (or new-cvf default-cvf))
         final-cvf {:cell-value-factory final-cvf}
 
-        final-style {:style-class (into ["table-cell"] (get column-data :style-class))}
+        final-style {:style-class (into ["table-cell"
+                                         (clojure.string/lower-case (str column-name "-column"))]
+                                        (get column-data :style-class))}
 
         default {:fx/type :table-column
                  :min-width 80}]
@@ -523,12 +541,12 @@
         iface-version (fn [row]
                         (some-> row :interface-version str utils/interface-version-to-game-version))
 
-        column-list [{:text "source" :cell-value-factory href-to-hyperlink :style-class ["source"]}
+        column-list [{:text "source" :min-width 110 :pref-width 120 :max-width 160 :cell-value-factory href-to-hyperlink}
                      {:text "name" :min-width 150 :pref-width 300 :max-width 500 :cell-value-factory :label}
                      {:text "description" :pref-width 700 :cell-value-factory :description}
                      {:text "installed" :max-width 150 :cell-value-factory :installed-version}
                      {:text "available" :max-width 150 :cell-value-factory :version}
-                     {:text "WoW" :max-width 100 :style-class ["wow"] :cell-value-factory iface-version}]]
+                     {:text "WoW" :max-width 100 :cell-value-factory iface-version}]]
     {:fx/type fx.ext.table-view/with-selection-props
      :props {:selection-mode :multiple
              ;; unlike gui.clj, we have access to the original data here
@@ -563,6 +581,7 @@
                      {:text "message" :pref-width 500 :cell-value-factory :message}]]
     {:fx/type :table-view
      :id "notice-logger"
+     :selection-mode :multiple
      :row-factory {:fx/cell-type :table-row
                    :describe (fn [row]
                                {:style-class ["table-row-cell" (name (:level row))]})}
@@ -579,7 +598,7 @@
 (defn search-addons-table
   [{:keys [fx/context]}]
   (let [addon-list (fx/sub-val context get-in [:app-state :search-results])
-        column-list [{:text "source" :min-width 100 :max-width 110 :cell-value-factory href-to-hyperlink :style-class ["source"]}
+        column-list [{:text "source" :min-width 110 :pref-width 120 :max-width 160 :cell-value-factory href-to-hyperlink}
                      {:text "name" :min-width 150 :pref-width 300 :max-width 450 :cell-value-factory :label}
                      {:text "description" :pref-width 700 :cell-value-factory :description}
                      {:text "tags" :pref-width 380 :min-width 230 :max-width 450 :cell-value-factory (comp str :tag-list)}
@@ -590,6 +609,7 @@
              ;; unlike gui.clj, we have access to the original data here. and it's an ordered/map ...?
              :on-selected-items-changed core/select-addons-search*}
      :desc {:fx/type :table-view
+            :id "search-addons"
             :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
             :pref-height 999.0
             :columns (mapv table-column column-list)

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -11,7 +11,7 @@
     [core :as core]])
   (:import
    [javafx.stage FileChooser DirectoryChooser]
-   
+   [javafx.application Platform]
    [javafx.event ActionEvent]
    [javafx.scene Node]))
 
@@ -43,6 +43,7 @@
 
 
 ;;
+
 
 (def INSTALLED-TAB 0)
 (def SEARCH-TAB 1)
@@ -101,10 +102,15 @@
   [ev]
   (dir-chooser ev))
 
+
+;; todo: reconcile this with the on-close-request handler in the stage
 (defn exit-handler
-  [ev]
-  nil)
-  ;;(javafx.application.Platform/exit))
+  [event]
+  (println "hit exit handler")
+  ;;(javafx.application.Platform/exit) ;; won't open again
+  (-> event .getTarget .getParentPopup .getOwnerWindow .getScene .getWindow .close) ;; won't open again
+  (when-not (core/get-state :in-repl?)
+    (System/exit 0)))
 
 (def import-addon-handler donothing)
 (def import-addon-list-handler donothing)
@@ -197,7 +203,6 @@
                              :items ["retail" "classic"]}
 
         ;; todo: add upgrade strongbox button
-        
         ]
     {:fx/type :h-box
      :padding 10
@@ -339,6 +344,13 @@
   [_]
   {:fx/type :stage
    :showing true
+   :on-close-request (fn [ev]
+                       ;; called on ctrl-c
+                       (println "got ev" ev)
+                       (println (bean ev))
+                       (when-not (core/get-state :in-repl?)
+                         (System/exit 0)))
+
    :title "strongbox"
    :width 1024
    :height 768
@@ -401,4 +413,5 @@
 
 (defn stop
   []
+  (info "stopping gui") ;; nothing needs to happen ... yet?
   nil)

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -632,3 +632,22 @@
   [url ::sp/url]
   (future-call #((find-browser) url))
   nil)
+
+(defn source-to-href-label-fn
+  "if a source for the addon can be derived, return a label suitable for the link"
+  [url]
+  (let [url-obj (try
+                  (java.net.URL. url)
+                  (catch NullPointerException _
+                    nil)
+                  (catch java.net.MalformedURLException _
+                    nil))]
+    (when url-obj
+      (case (.getHost url-obj)
+        "www.curseforge.com" "curseforge"
+        "www.wowinterface.com" "wowinterface"
+        "www.github.com" "github"
+        "www.tukui.org" (if (= (.getPath url-obj) "/classic-addons.php")
+                          "tukui-classic"
+                          "tukui")
+        nil))))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -633,9 +633,9 @@
   (future-call #((find-browser) url))
   nil)
 
-(defn source-to-href-label-fn
+(defn-spec source-to-href-label-fn (s/or :ok string? :bad-url nil?)
   "if a source for the addon can be derived, return a label suitable for the link"
-  [url]
+  [url (s/nilable string?)]
   (let [url-obj (try
                   (java.net.URL. url)
                   (catch NullPointerException _

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -646,7 +646,7 @@
       (case (.getHost url-obj)
         "www.curseforge.com" "curseforge"
         "www.wowinterface.com" "wowinterface"
-        "www.github.com" "github"
+        "github.com" "github"
         "www.tukui.org" (if (= (.getPath url-obj) "/classic-addons.php")
                           "tukui-classic"
                           "tukui")

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -589,3 +589,46 @@
   (when (and (fs/exists? old-path)
              (not (fs/exists? new-path)))
     (fs/copy old-path new-path)))
+
+;;
+
+(defn-spec browser (s/or :ok fn? :error nil?)
+  "given the name of a binary, returns a function that will open a given URL in a browser or nil if 
+  the binary cannot be found."
+  [bin string?]
+  (try
+    (when (->> bin (clojure.java.shell/sh "which") :exit (= 0))
+      (fn [url]
+        (info (format "opening URL with %s: %s" bin url))
+        (clojure.java.shell/sh bin url)))
+    (catch Exception uncaught-exception
+      (error uncaught-exception "failed to call `which`"))))
+
+(defn-spec java-browser (s/or :ok fn? :error nil?)
+  "returns a function that will open a given URL in a browser, or nil if 
+  current Desktop is not supported"
+  []
+  (when (and (java.awt.Desktop/isDesktopSupported)
+             (.isSupported (java.awt.Desktop/getDesktop) java.awt.Desktop$Action/BROWSE))
+    (fn [url]
+      (info "opening URL:" url)
+      (.browse (java.awt.Desktop/getDesktop) (java.net.URI. url)))))
+
+(defn-spec find-browser fn?
+  "returns a function that attempts to open a given URL in a browser.
+  Prints an error message to console if URL cannot be opened."
+  []
+  (let [xdg-open #(browser "xdg-open")
+        gnome-open #(browser "gnome-open")
+        kde-open #(browser "kde-open")
+        fail (constantly #(error "failed to find a program to open URL:" (str %)))]
+    (loop [lst [java-browser xdg-open gnome-open kde-open fail]]
+      (if-let [browser-fn ((first lst))]
+        browser-fn
+        (recur (rest lst))))))
+
+(defn-spec browse-to nil?
+  "given a URL, open a browser window with it"
+  [url ::sp/url]
+  (future-call #((find-browser) url))
+  nil)

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -14,7 +14,9 @@
 (deftest gui-init
   (testing "the gui can be started and stopped"
     (with-running-app+opts {:ui :gui2}
-      (is (core/get-state :gui-showing?)))))
+      (is (core/get-state :gui-showing?))
+      ;; give time for the init to finish
+      (Thread/sleep 1000))))
 
 (deftest href-to-hyperlink
   (testing "urls are converted to component descriptions. bad urls are safely handled"
@@ -41,3 +43,18 @@
                  [{:style-class ["foo"]} {:fx/type :table-column, :min-width 80, :style-class ["table-cell" "-column" "foo"]}]]]
       (doseq [[given expected] cases]
         (is (= expected (dissoc (jfx/table-column given) :cell-value-factory)))))))
+
+(deftest about-strongbox
+  (testing "'about' dialog is correct and new version text is correctly hidden"
+    (with-running-app
+      (let [expected 
+            {:children [{:text "strongbox", :fx/type :text}
+                        {:text "version 3.0.0-unreleased", :fx/type :text}
+                        {:text "version 0.0.0 is now available to download!",
+                         :visible false,
+                         :fx/type :text}
+                        {:text "https://github.com/ogri-la/strongbox",
+                         :fx/type :hyperlink}
+                        {:text "AGPL v3", :fx/type :text}],
+             :fx/type :v-box}]
+        (is (= expected (jfx/-about-strongbox-dialog)))))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -30,7 +30,7 @@
 
                  [{:url "https://www.curseforge.com/foo/bar"} {:fx/type :hyperlink :text "↪ curseforge"}]
                  [{:url "https://www.wowinterface.com/foo/bar"} {:fx/type :hyperlink :text "↪ wowinterface"}]
-                 [{:url "https://www.github.com/foo/bar"} {:fx/type :hyperlink :text "↪ github"}]
+                 [{:url "https://github.com/teelolws/Altoholic-Classic"} {:fx/type :hyperlink :text "↪ github"}]
                  [{:url "https://www.tukui.org/foo/bar"} {:fx/type :hyperlink :text "↪ tukui"}]
                  [{:url "https://www.tukui.org/classic-addons.php"} {:fx/type :hyperlink :text "↪ tukui-classic"}]]]
       (doseq [[given expected] cases]
@@ -59,5 +59,9 @@
                          :fx/type :hyperlink
                          :id "about-pane-hyperlink"}
                         {:text "AGPL v3", :fx/type :text}],
-             :fx/type :v-box}]
-        (is (= expected (jfx/-about-strongbox-dialog)))))))
+             :fx/type :v-box}
+
+            actual (jfx/-about-strongbox-dialog)
+            actual (update-in actual [:children 3] dissoc :on-action)
+            ]
+        (is (= expected actual))))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -48,13 +48,16 @@
   (testing "'about' dialog is correct and new version text is correctly hidden"
     (with-running-app
       (let [expected
-            {:children [{:text "strongbox", :fx/type :text}
+            {:id "about-dialog"
+             :children [{:text "strongbox", :fx/type :text, :id "about-pane-title"}
                         {:text "version 3.0.0-unreleased", :fx/type :text}
                         {:text "version 0.0.0 is now available to download!",
                          :visible false,
+                         :managed false,
                          :fx/type :text}
                         {:text "https://github.com/ogri-la/strongbox",
-                         :fx/type :hyperlink}
+                         :fx/type :hyperlink
+                         :id "about-pane-hyperlink"}
                         {:text "AGPL v3", :fx/type :text}],
              :fx/type :v-box}]
         (is (= expected (jfx/-about-strongbox-dialog)))))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -1,0 +1,17 @@
+(ns strongbox.jfx-test
+  (:require
+   ;;[clj-http.fake :refer [with-fake-routes-in-isolation]]
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   ;;[strongbox.ui.jfx :as jfx]
+   ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
+   [strongbox
+    [main :as main]
+    [core :as core]
+    [test-helper :as helper :refer [fixture-path with-running-app with-running-app+opts]]]))
+
+(use-fixtures :each helper/fixture-tempcwd)
+
+(deftest gui-init
+  (testing "the gui can be started and stopped"
+    (with-running-app+opts {:ui :gui2}
+      (is (core/get-state :gui-showing?)))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -62,6 +62,5 @@
              :fx/type :v-box}
 
             actual (jfx/-about-strongbox-dialog)
-            actual (update-in actual [:children 3] dissoc :on-action)
-            ]
+            actual (update-in actual [:children 3] dissoc :on-action)]
         (is (= expected actual))))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -22,8 +22,8 @@
   (testing "urls are converted to component descriptions. bad urls are safely handled"
     (let [bad-text {:fx/type :text :text ""}
           cases [[{} bad-text]
-                 [{:url ""} bad-text]
-                 [{:url "http"} bad-text]
+                 ;;[{:url ""} bad-text] ;; caught by spec
+                 ;;[{:url "http"} bad-text] ;; caught by spec
                  [{:url "http://"} bad-text]
                  [{:url "http://foo"} bad-text]
                  [{:url "http://foo.bar"} bad-text]
@@ -47,7 +47,7 @@
 (deftest about-strongbox
   (testing "'about' dialog is correct and new version text is correctly hidden"
     (with-running-app
-      (let [expected 
+      (let [expected
             {:children [{:text "strongbox", :fx/type :text}
                         {:text "version 3.0.0-unreleased", :fx/type :text}
                         {:text "version 0.0.0 is now available to download!",

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -5,7 +5,7 @@
    [envvar.core :refer [env with-env]]
    [taoensso.timbre :as timbre :refer [debug info warn error spy]]
    [me.raynes.fs :as fs :refer [with-cwd]]
-   [clj-http.fake :refer [with-fake-routes-in-isolation]]
+   [clj-http.fake :refer [with-global-fake-routes-in-isolation]]
    [strongbox
     [specs :as sp]
     [main :as main]
@@ -75,7 +75,7 @@
       (debug "stopping application if it hasn't already been stopped")
       (main/stop)
 
-      (with-fake-routes-in-isolation fake-routes
+      (with-global-fake-routes-in-isolation fake-routes
         (with-env [:xdg-data-home (utils/join temp-dir-path helper-data-dir)
                    :xdg-config-home (utils/join temp-dir-path helper-config-dir)]
           (with-cwd temp-dir-path


### PR DESCRIPTION
This is a branch for the replacement GUI.

It uses OpenJFX 11, which means support for Java 8 will be dropped (I'm planning a standalone executable to coincide with the new GUI release so this should be a non-issue).

The Swing UI has had years of polish. I'm hoping this incarnation can borrow some of that.

- [x] notice logger has column headers
- [x] notice logger level is a keyword
- [x] 'WoW' column is interface version formatted, not release formatted
- [x] styling! everything looks fat and rounded and the font is a little blurry
- [x] refresh button, notice logger entries only arrive after action complete (async issue)
- [x] source link is not a hyperlink
- [x] switching addon dirs is not asynced
    - it 'freezes', downloads the updates on the fx thread, then re-renders UI
- [x] notice logger, errors and warnings need highlighting
- [x] missing bottom 'info' bar
- [x] search, install button does nothing
- [x] ignored addons are not highlighted
- [x] targeted rows are not being highlighted as they are being checked
- [x] menu mnemonics and accelerators not implemented
- [x] addons with updates available are not highlighted
- [x] search field needs to be automatically focused
- [x] installed addons are not highlighted in search pane
- [x] add light and dark theme
- [x] search input is slow. input should be decoupled from results
- [x] double update bug, where (occasionally) selecting a directory drop down displays the correct contents, then reverts to previous directory's contents
    - ~I suspect I'm using dirty state actually. only use the state passed to a watcher!~
    - it's not this, it's a race condition between who updates the GUI first and is caused by the application watching changes to the selected addon dir. 
        - the change to the selected-addon-dir causes the gui state to be updated that is delayed by the app updating itself
        - once the app is done updating itself, that (very) old gui state change is delivered with the previous list of addons and we get this weird reversion. (I think)
        - sticking the app state refresh into a future allows the gui update to proceed.
            - I really need to get my head around this ordering though
  - fixed by shifting UI concerns (like `refresh`ing state) to strongbox.ui.cli. This has actually been a long time coming and will be fleshed out more fully in the future.
- [x] 'update all' isn't selecting the addons that are being updated (no visual feedback)
   - css bug, 'updateable' took precedence over 'unsteady' - I guess it was less specific but defined later. /shrug
- [x] changing catalogue blocks UI 
- [x] new strongbox alert button
- [x] new strongbox alert in 'about' dialog
- [x] remove 'refresh' button from menu bar
- [x] fix uberjar hanging issue
- [x] unit tests/coverage bump
- [x] review
- [x] bug, removing an addon directory doesn't update the directory drop down list
- [x] test on mac
  - [x] github addons have no link against them
  - [x] importing an addon from github is pausing the UI thread
  - [x] inconsistent "wrote" vs "wrote:" output
  - [x] 'about' hyperlink not working
  - [ ] mac, changing game track reviews a datastructure rather than a label
- [x] bug, switch tab accelerators not working if you won't select them from the menu first ... ?
