### PR TITLE
3.0 review feedback

### DIFF
--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -48,7 +48,10 @@
    :unsteady "lightsteelblue"
    :row-updateable "lemonchiffon"
    :row-warning "lemonchiffon"
-   :row-error "tomato"})
+   :row-error "tomato"
+   :jfx-hyperlink "blue"
+   :jfx-hyperlink-weight "normal"
+   :table-font-colour "derive(-fx-background,-80%)"})
 
 ;; inverse colours of -colour-map
 (def -dark-colour-map
@@ -63,17 +66,20 @@
    :hyperlink :yellow
 
    ;; jfx
-   :base "#121212"
-   :accent "#443754" ;; dark purple
+   ;; https://github.com/dracula/dracula-theme
+   :base "#1e1f29"
+   :accent "#44475a"
    :button-text-hovering "white"
    :table-border "#333"
-   :row "-fx-control-inner-background"
+   :row "#1e1f29" ;; same as :base
    :row-hover "derive(-fx-control-inner-background,-10%)"
    :unsteady "-fx-selection-bar"
-   :row-updateable "#aaa"
-   :row-warning "#aaa"
+   :row-updateable "#6272a4"
+   :row-warning "#6272a4"
    :row-error "#ce2828"
-   :hyperlink-hover "yellow"})
+   :jfx-hyperlink "#f8f8f2"
+   :jfx-hyperlink-weight "bold"
+   :table-font-colour "white"})
 
 (def themes
   {:light -colour-map

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -51,7 +51,8 @@
    :row-error "tomato"
    :jfx-hyperlink "blue"
    :jfx-hyperlink-weight "normal"
-   :table-font-colour "derive(-fx-background,-80%)"})
+   :table-font-colour "derive(-fx-background,-80%)"
+   :already-installed-row-colour "#99bc6b"})
 
 ;; inverse colours of -colour-map
 (def -dark-colour-map
@@ -79,7 +80,8 @@
    :row-error "#ce2828"
    :jfx-hyperlink "#f8f8f2"
    :jfx-hyperlink-weight "bold"
-   :table-font-colour "white"})
+   :table-font-colour "white"
+   :already-installed-row-colour "#99bc6b"})
 
 (def themes
   {:light -colour-map

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -81,6 +81,10 @@
 
                :-fx-accent (colour :accent) ;; selection colour of backgrounds
 
+               ".table-placeholder-text"
+               {:-fx-font-size "1.5em"
+                :-fx-fill (colour :table-font-colour)}
+
                "#main-menu" {:-fx-background-color (colour :base)}
 
                ".context-menu" {:-fx-effect "None"}
@@ -183,9 +187,14 @@
                {:-fx-padding "8px"}
 
                ;; search
+
+               "#search-text-field "
+               {:-fx-text-fill (colour :table-font-colour)}
+
                ".table-view#search-addons"
                {" .downloads-column" {:-fx-alignment "center-right"}
-                " .installed" {:-fx-background-color "#99bc6b"}}
+                " .installed" {" > .table-cell" {} ;;:-fx-text-fill "black"
+                               :-fx-background-color (colour :already-installed-row-colour)}}
 
                "#status-bar"
                {:-fx-font-size ".9em"
@@ -193,7 +202,8 @@
 
                 " > .text"
                 {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
-                 :-fx-fill (colour :table-font-color)}}
+                 :-fx-fill (colour :table-font-colour)}}
+
 
                ;; common table fields
 
@@ -705,6 +715,9 @@
              :on-selected-items-changed core/select-addons*}
      :desc {:fx/type :table-view
             :id "installed-addons"
+            :placeholder {:fx/type :text
+                          :style-class ["table-placeholder-text"]
+                          :text "No addons found."}
             :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
             :pref-height 999.0
             :row-factory {:fx/cell-type :table-row
@@ -767,6 +780,9 @@
              :on-selected-items-changed core/select-addons-search*}
      :desc {:fx/type :table-view
             :id "search-addons"
+            :placeholder {:fx/type :text
+                          :style-class ["table-placeholder-text"]
+                          :text "No search results."}
             :row-factory {:fx/cell-type :table-row
                           :describe (fn [row]
                                       {:style-class ["table-row-cell"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -82,8 +82,12 @@
                :-fx-accent (colour :accent) ;; selection colour of backgrounds
 
                ".context-menu" {:-fx-effect "None"}
-               ".combo-box-base" {:-fx-padding "1px"
-                                  :-fx-background-radius "0"}
+               ".combo-box-base"
+               {:-fx-padding "1px"
+                :-fx-background-radius "0"
+                ;; truncation happens from the left. thanks to:
+                ;; https://stackoverflow.com/questions/36264656/scalafx-javafx-how-can-i-change-the-overrun-style-of-a-combobox
+                " > .list-cell" {:-fx-text-overrun "leading-ellipsis"}}
 
                ".button" {:-fx-background-radius "0"
                           :-fx-padding ["6px" "17px"]
@@ -103,8 +107,7 @@
                ".table-view .column-header"
                {;;:-fx-background-color "#ddd" ;; flat colour vs gradient
                 :-fx-font-size "1em"
-                :-fx-font-weight "Normal"
-                :-fx-font-family "Sans"}
+                :-fx-font-weight "Normal"}
 
                ".table-view .table-row-cell"
                {:-fx-border-insets "-1 -1 0 -1"
@@ -125,6 +128,14 @@
                 ".unsteady" {;; '!important' so that it takes precedence over .updateable addons
                              :-fx-background-color (str (colour :unsteady) " !important")}}
 
+
+               ;; installed-addons menu
+
+               ;; prevent truncation and ellipses
+               "#update-all-button "
+               {:-fx-min-width "101px"}
+               "#game-track-combo-box "
+               {:-fx-min-width "100px"}
 
                ;; installed-addons table
 
@@ -606,6 +617,7 @@
   [{:keys [fx/context]}]
   (let [selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])]
     {:fx/type :combo-box
+     :id "game-track-combo-box"
      :value (-> selected-addon-dir core/get-game-track (or "") name)
      :on-value-changed (async-event-handler
                         (fn [new-game-track]
@@ -621,13 +633,15 @@
    :spacing 10
    :children [{:fx/type :button
                :text "Update all"
+               :id "update-all-button"
                :on-action (async-handler core/install-update-all)}
               {:fx/type wow-dir-dropdown}
               {:fx/type game-track-dropdown}
               {:fx/type :button
                :text (str "Update Available: " (core/latest-strongbox-release))
                :on-action (handler #(utils/browse-to "https://github.com/ogri-la/strongbox/releases"))
-               :visible (not (core/latest-strongbox-version?))}]})
+               :visible (not (core/latest-strongbox-version?))
+               :managed (not (core/latest-strongbox-version?))}]})
 
 (defn-spec table-column map?
   "returns a description of a table column that lives within a table"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -81,6 +81,8 @@
 
                :-fx-accent (colour :accent) ;; selection colour of backgrounds
 
+               "#main-menu" {:-fx-background-color (colour :base)}
+
                ".context-menu" {:-fx-effect "None"}
                ".combo-box-base"
                {:-fx-padding "1px"
@@ -106,24 +108,24 @@
 
                ".table-view .column-header"
                {;;:-fx-background-color "#ddd" ;; flat colour vs gradient
-                :-fx-font-size "1em"
-                :-fx-font-weight "Normal"}
+                :-fx-font-size "1em"}
 
                ".table-view .table-row-cell"
                {:-fx-border-insets "-1 -1 0 -1"
                 :-fx-border-color (colour :table-border)
+                " .table-cell" {:-fx-text-fill (colour :table-font-colour)}
 
                 ;; even
                 :-fx-background-color (colour :row)
                 ":hover" {:-fx-background-color (colour :row-hover)}
-                ":selected" {:-fx-background-color "-fx-selection-bar"
+                ":selected" {:-fx-background-color (colour :unsteady)
                              " .table-cell" {:-fx-text-fill "-fx-focused-text-base-color"}
                              :-fx-table-cell-border-color (colour :table-border)}
 
                 ":odd" {:-fx-background-color (colour :row)}
                 ":odd:hover" {:-fx-background-color (colour :row-hover)}
-                ":odd:selected" {:-fx-background-color "-fx-selection-bar"}
-                ":odd:selected:hover" {:-fx-background-color "-fx-selection-bar"}
+                ":odd:selected" {:-fx-background-color (colour :unsteady)}
+                ":odd:selected:hover" {:-fx-background-color (colour :unsteady)}
 
                 ".unsteady" {;; '!important' so that it takes precedence over .updateable addons
                              :-fx-background-color (str (colour :unsteady) " !important")}}
@@ -137,6 +139,7 @@
                "#game-track-combo-box "
                {:-fx-min-width "100px"}
 
+               
                ;; installed-addons table
 
 
@@ -186,15 +189,22 @@
 
                "#status-bar"
                {:-fx-font-size ".9em"
-                :-fx-padding "5px"}
+                :-fx-padding "5px"
+
+                " > .text"
+                {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
+                 :-fx-fill (colour :table-font-color)}}
 
                ;; common table fields
+
+
                ".table-view .source-column"
                {:-fx-alignment "center-left"
                 :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
                 " .hyperlink:visited" {:-fx-underline "false"}
                 " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
-                                                 :-fx-text-fill (colour :hyperlink)}}}}))]
+                                                 :-fx-text-fill (colour :jfx-hyperlink)
+                                                 :-fx-font-weight (colour :jfx-hyperlink-weight)}}}}))]
 
      (merge
       (generate-style :light)
@@ -834,6 +844,7 @@
     {:fx/type :h-box
      :id "status-bar"
      :children [{:fx/type :text
+                 :style-class ["text"]
                  :text (join " " strings)}]}))
 
 ;;


### PR DESCRIPTION
* installed addons menu bar buttons now have a min-width to prevent truncation and ellipses.
* wow-dir dropdown now truncates from the left instead of the right.
* strongbox update button no longer takes up any width despite not being visible.
* minimum app width is now about ~500px
* [improved dark theme](https://github.com/ogri-la/strongbox/issues/192)

- [x] search, text input text should be white
- [x] search, installed addon indicator is green ... it fits but ~perhaps use the 'selected blue' used elsewhere~ kept it green.

* empty installed and search tables now have better placeholder text