### PR TITLE
reset short catalogue cutoff date

### DIFF
--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -22,8 +22,9 @@
     [specs :as sp]]))
 
 (def release-of-previous-expansion
-  "'Legion', released August 30th 2016. Used to shorten the 'full' catalogue."
-  "2016-08-30T00:00:00Z")
+  "'Battle for Azeroth (BfA)', released August 14th 2018. Used to shorten the 'full' catalogue.
+  https://en.wikipedia.org/wiki/World_of_Warcraft#Expansions"
+  "2018-08-14T00:00:00Z")
 
 (def game-tracks [:retail :classic])
 


### PR DESCRIPTION
Bumps the cutoff date for the 'short' catalogue from Legion (2016-08) to BfA (2018-08). This removes about ~3k addons that haven't been updated in ~2.5yrs.