### PR TITLE
improved aliases

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,9 @@ see CHANGELOG.md for a more formal list of changes by release
     - dirname should have been resolved, compared with install dir and ensured they were not the same as well as dirname being a child of install-dir
     - fixed
 
+* import v2, change addon dir game-track to a compound one prior to importing
+    - this will prevent addons from being skipped
+
 ## todo
 
 * issue #204 "Dark theme - "addon has update" row color could be more clear"
@@ -47,9 +50,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - https://github.com/ogri-la/strongbox/issues/206
     - very fucking mysterious
 
-* import v2, change addon dir game-track to a compound one prior to importing
-    - this will prevent addons from being skipped
-
 * better icon for appimage
 
 * github, if multiple releases available and first fails criteria, check the next and so on
@@ -58,6 +58,13 @@ see CHANGELOG.md for a more formal list of changes by release
 ## todo bucket (no particular order)
 
 * import, skip importing an addon if addon already exists in addon dir
+
+* import, why can't an export record be matched to the catalogue and then installed that way?
+    - no need for padding and dummy dirnames then
+    - installing normally would also include the mutual dependency handling
+
+* toc, add support for x-github key
+    - X-Github: https://github.com/teelolws/Altoholic-Retail 
 
 * create a parser for that shit markup that is preventing reconcilation
     - see aliases

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,13 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* create a parser for that shit markup that is preventing reconcilation
+    - see aliases
+
+* bug, resolve addon directory before attempting to uninstall it
+    - using the import function with a :dirname of './' I managed to delete the addon directory
+    - dirname should have been resolved, compared with install dir and ensured they were not the same as well as dirname being a child of install-dir
+
 * if a match has been made and the addon installed using that match, and then the catalogue changes, addon should still be downloadable
     - right?
         - we have the source and source-id, even the group-id to some extent

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,11 @@ see CHANGELOG.md for a more formal list of changes by release
         - done
     - maybe externalise the list
 
+* bug, resolve addon directory before attempting to uninstall it
+    - using the import function with a :dirname of './' I managed to delete the addon directory
+    - dirname should have been resolved, compared with install dir and ensured they were not the same as well as dirname being a child of install-dir
+    - fixed
+
 ## todo
 
 * issue #204 "Dark theme - "addon has update" row color could be more clear"
@@ -54,10 +59,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * create a parser for that shit markup that is preventing reconcilation
     - see aliases
-
-* bug, resolve addon directory before attempting to uninstall it
-    - using the import function with a :dirname of './' I managed to delete the addon directory
-    - dirname should have been resolved, compared with install dir and ensured they were not the same as well as dirname being a child of install-dir
 
 * if a match has been made and the addon installed using that match, and then the catalogue changes, addon should still be downloadable
     - right?

--- a/TODO.md
+++ b/TODO.md
@@ -57,6 +57,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* import, skip importing an addon if addon already exists in addon dir
+
 * create a parser for that shit markup that is preventing reconcilation
     - see aliases
 

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,11 @@ see CHANGELOG.md for a more formal list of changes by release
 * gui, add confirmation before deleting addon directory
     - language should be 'remove' rather than 'delete'
 
+* reconciliation, revisit aliases
+    - use source and source-id now
+        - done
+    - maybe externalise the list
+
 ## todo
 
 * issue #204 "Dark theme - "addon has update" row color could be more clear"
@@ -39,10 +44,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * import v2, change addon dir game-track to a compound one prior to importing
     - this will prevent addons from being skipped
-
-* reconciliation, revisit aliases
-    - use source and source-id now
-    - maybe externalise the list
 
 * better icon for appimage
 

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -18,11 +18,13 @@
   "safely removes the given `addon-dirname` from `install-dir`"
   [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname, group-id (s/nilable ::sp/group-id)]
   (let [addon-path (fs/file install-dir (fs/base-name addon-dirname)) ;; `fs/base-name` strips any parents
-        addon-path (-> addon-path fs/absolute fs/normalized)]
+        addon-path (-> addon-path fs/absolute fs/normalized)
+        addon-path (str addon-path)] ;; very important, otherwise a bunch of checks quietly pass
     (cond
       ;; todo: unhandled case here when importing addons into a directory of pre-existing addons.
       ;; what happens when we import the same set of addons over each other? it bypasses the mutual dependency handling for one thing ...
-      (= addon-dirname dummy-dirname) (debug "dummy dirname found, skipping removal")
+      (= addon-dirname dummy-dirname)
+      (debug "dummy dirname found, skipping removal")
 
       ;; directory to remove is not a directory!
       (not (fs/directory? addon-path))
@@ -31,7 +33,7 @@
       ;; directory to remove is outside of addon directory (or exactly equal to it)!
       (or (not (starts-with? addon-path install-dir))
           (= addon-path install-dir))
-      (format "directory '%s' is outside the current installation dir of '%s', not removing" addon-path install-dir)
+      (error (format "directory is outside the current installation dir, not removing: %s" addon-path))
 
       ;; other addons depend on this addon, just remove the nfo file
       (nfo/mutual-dependency? install-dir addon-dirname)

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -27,7 +27,7 @@
       ;; directory to remove is not a directory!
       (not (fs/directory? addon-path))
       (error (str "addon not removed, path is not a directory: " addon-path))
-      
+
       ;; directory to remove is outside of addon directory (or exactly equal to it)!
       (or (not (starts-with? addon-path install-dir))
           (= addon-path install-dir))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -364,6 +364,8 @@
      (-> addon-dir addon-dir-map :game-track))))
 
 (defn-spec get-lenient-game-track ::sp/lenient-game-track
+  "returns the lenient/compound version of the currently selected game track. 
+  if `:retail` then `:retail-classic`, etc"
   []
   (case (get-game-track)
     :classic-retail :classic-retail
@@ -748,9 +750,9 @@
     expanded-installed-addon-list))
 
 (defn-spec match-installed-addons-with-catalogue nil?
-  "compare the list of addons installed with the database of known addons match the two up, merging
+  "compare the list of addons installed with the database of known addons, match the two up, merge
   the two together and update the list of installed addons.
-  Does not attempt matching if there is no catalogue loaded or addon directory loaded."
+  Skipped when no catalogue loaded or no addon directory selected."
   []
   (when (and (db-catalogue-loaded?)
              (selected-addon-dir))
@@ -759,6 +761,7 @@
 
 
 ;;
+
 
 (defn-spec refresh-user-catalogue nil?
   "re-fetch each item in user catalogue using the URI and replace old entry with any updated details"
@@ -1007,8 +1010,9 @@
         ;; this is what v1 does, but it's hidden away in `expand-summary-wrapper`
         ;;default-game-track (get-game-track)
 
-        ;; when no game-track is present in the import record, use the more lenient
+        ;; when no game-track is present in the export record, use the more lenient
         ;; version of the currently selected game track.
+        ;; it's better to have an addon installed with the incorrect game track then missing addons.
         default-game-track (get-lenient-game-track)]
 
     (binding [http/*cache* (cache)]

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -983,7 +983,7 @@
         padding {:label ""
                  :description ""
                  ;; 2020-06: dirname must be a non-empty string
-                 :dirname "not-the-addon-dir-you-are-looking-for"
+                 :dirname addon/dummy-dirname
                  :interface-version 0
                  :installed-version "0"}
         addon-list (map #(merge padding %) addon-list)

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -1006,10 +1006,11 @@
         ;; version of the currently selected game track.
         default-game-track (get-lenient-game-track)]
 
-    (doseq [addon (get-state :installed-addon-list)
-            :let [game-track (get addon :game-track default-game-track)]]
-      (when-let [expanded-addon (catalogue/expand-summary addon game-track)]
-        (install-addon expanded-addon)))))
+    (binding [http/*cache* (cache)]
+      (doseq [addon (get-state :installed-addon-list)
+              :let [game-track (get addon :game-track default-game-track)]]
+        (when-let [expanded-addon (catalogue/expand-summary addon game-track)]
+          (install-addon expanded-addon))))))
 
 (defn-spec import-exported-file nil?
   "imports a file at given `path` created with the export function.

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -363,6 +363,13 @@
    (when addon-dir
      (-> addon-dir addon-dir-map :game-track))))
 
+(defn-spec get-lenient-game-track ::sp/lenient-game-track
+  []
+  (case (get-game-track)
+    :classic-retail :classic-retail
+    :classic :classic-retail
+    :retail-classic))
+
 ;; settings
 
 (defn-spec change-log-level! nil?
@@ -993,7 +1000,11 @@
         _ (match-installed-addons-with-catalogue (get-state :db) addon-list)
 
         ;; this is what v1 does, but it's hidden away in `expand-summary-wrapper`
-        default-game-track (get-game-track)]
+        ;;default-game-track (get-game-track)
+
+        ;; when no game-track is present in the import record, use the more lenient
+        ;; version of the currently selected game track.
+        default-game-track (get-lenient-game-track)]
 
     (doseq [addon (get-state :installed-addon-list)
             :let [game-track (get addon :game-track default-game-track)]]

--- a/src/strongbox/db.clj
+++ b/src/strongbox/db.clj
@@ -26,7 +26,8 @@
         arg-vals (mapv #(get installed-addon %) toc-keys)
         missing-args? (some nil? arg-vals)
 
-        ;; there are cases where the installed-addon is missing an attribute to match on. typically happens on :alias
+        ;; there are cases where the installed-addon is missing an attribute to match on.
+        ;; typically happened on the old `:alias` key that has since been replaced but we also have cases of missing `:title` values.
         _ (when missing-args?
             (debug "failed to find all values for db search, refusing to match against nil values. keys:" toc-keys "; vals:" arg-vals))
 
@@ -72,7 +73,6 @@
         ;; most -> least desirable match
         ;; nest to search across multiple parameters
         match-on-list [[[:source :source-id] [:source :source-id]] ;; source+source-id, perfect case
-                       [:alias :name] ;; alias = name, popular addon's hardcoded name to a catalogue item
                        [:source :name] ;; source+name, we have a source but no source-id (nfo-v1 files)
                        [:name :name]
                        [:label :label]

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -61,9 +61,11 @@
 
 (def game-tracks (->> game-track-labels (into {}) keys set))
 (def selectable-game-tracks (->> selectable-game-track-labels (into {}) keys set))
+(def lenient-game-tracks #{:retail-classic :classic-retail})
 
 (s/def ::game-track game-tracks)
 (s/def ::installed-game-track ::game-track) ;; alias
+(s/def ::lenient-game-track lenient-game-tracks)
 (s/def ::game-track-list (s/coll-of ::game-track :kind vector? :distinct true))
 (s/def ::download-count (s/and int? #(>= % 0)))
 (s/def ::ignore? boolean?)

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -18,21 +18,21 @@
 ;; aliases are maintained for the top-50 downloaded addons (ever) only, and only for those that need it
 ;; best and nicest way to avoid needing an alias is to have your .toc 'Title' attribute match your curseforge addon name
 (def aliases
-  {"AtlasLoot |cFF22B14C[Core]|r" "atlasloot-enhanced"
-   "BigWigs [|cffeda55fCore|r]" "big-wigs"
-   "|cffffd200Deadly Boss Mods|r |cff69ccf0Core|r" "deadly-boss-mods"
-   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Azeroth (Classic)|r" "dbm-bc"
-   "Raider.IO Mythic Plus and Raiding" "raiderio"
-   "HealBot" "heal-bot-continued"
-   "Auc-Auctioneer |cff774422(core)" "auctioneer"
-   "Titan Panel |cff00aa005.17.1.80100|r" "titan-panel"
-   "BadBoy" "bad-boy"
-   "Mik's Scrolling Battle Text" "mik-scrolling-battle-text"
-   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Icecrown Citadel|r" "deadly-boss-mods-wotlk"
-   "Prat |cff8080ff3.0|r" "prat-3-0"
-   "Omen3" "omen-threat-meter"
-   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Firelands|r" "deadly-boss-mods-cataclysm-mods"
-   "X-Perl UnitFrames by |cFFFF8080Zek|r" "xperl"})
+  {"AtlasLoot |cFF22B14C[Core]|r" {:source "curseforge" :source-id 2134}
+   "BigWigs [|cffeda55fCore|r]" {:source "curseforge" :source-id 2382}
+   "|cffffd200Deadly Boss Mods|r |cff69ccf0Core|r" {:source "curseforge" :source-id 8814}
+   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Azeroth (Classic)|r" {:source "curseforge" :source-id 16442}
+   "Raider.IO Mythic Plus and Raiding" {:source "curseforge" :source-id 279257}
+   "HealBot" {:source "curseforge" :source-id 2743}
+   "Auc-Auctioneer |cff774422(core)" {:source "curseforge" :source-id 7879}
+   "Titan Panel |cff00aa005.17.1.80100|r" {:source "curseforge" :source-id 489}
+   "BadBoy" {:source "curseforge" :source-id 5547}
+   "Mik's Scrolling Battle Text" {:source "curseforge" :source-id 2450}
+   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Icecrown Citadel|r" {:source "curseforge" :source-id 43970}
+   "Prat |cff8080ff3.0|r" {:source "curseforge" :source-id 10783}
+   "Omen3" {:source "curseforge" :source-id 4963}
+   "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Firelands|r" {:source "curseforge" :source-id 43971}
+   "X-Perl UnitFrames by |cFFFF8080Zek|r" {:source "curseforge" :source-id 14911}})
 
 (defn-spec -parse-toc-file map?
   [toc-contents string?]
@@ -120,7 +120,7 @@
 
         ;; if :title is present in list of aliases, add that alias to what we return
         alias (when (contains? aliases label)
-                {:alias (get aliases label)})
+                (get aliases label)) ;; `{:source "curseforge" :source-id 12345}`
 
         wowi-source (when-let [x-wowi-id (-> keyvals :x-wowi-id utils/to-int)]
                       {:source "wowinterface"

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -12,12 +12,12 @@
 
 ;; interface version to use if .toc file is missing theirs
 ;; assume addon is compatible with the most recent version
-(def default-interface-version 80200)
+(def default-interface-version 90100)
 
 ;; matches a tocfile's 'Title' (label) to a catalogue's name
 ;; aliases are maintained for the top-50 downloaded addons (ever) only, and only for those that need it
 ;; best and nicest way to avoid needing an alias is to have your .toc 'Title' attribute match your curseforge addon name
-(def aliases
+(def aliases1
   {"AtlasLoot |cFF22B14C[Core]|r" {:source "curseforge" :source-id 2134}
    "BigWigs [|cffeda55fCore|r]" {:source "curseforge" :source-id 2382}
    "|cffffd200Deadly Boss Mods|r |cff69ccf0Core|r" {:source "curseforge" :source-id 8814}
@@ -33,6 +33,19 @@
    "Omen3" {:source "curseforge" :source-id 4963}
    "|cffffe00a<|r|cffff7d0aDBM|r|cffffe00a>|r |cff69ccf0Firelands|r" {:source "curseforge" :source-id 43971}
    "X-Perl UnitFrames by |cFFFF8080Zek|r" {:source "curseforge" :source-id 14911}})
+
+;; 2020-12-13
+;; took the top 50 downloaded addons from curseforge and the top 50 from wowinterface,
+;; installed them, removed the nfo files, reconciled them and below are the ones that were not found.
+;; when multiple sources available, the most recently updated one was picked.
+(def aliases2
+  {"Plater" {:source "curseforge" :source-id 100547}
+   "|cff1784d1ElvUI|r |cff9482c9Shadow & Light|r" {:source "tukui" :source-id 38}
+   "|cff00aeffCharacterStatsClassic|r" {:source "curseforge" :source-id 338856}
+   "Adapt" {:source "wowinterface" :source-id 4729}
+   "Dugi Questing Essential |cffffffff5.504|r" {:source "wowinterface" :source-id 20540}})
+
+(def aliases (merge aliases1 aliases2))
 
 (defn-spec -parse-toc-file map?
   [toc-contents string?]

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -147,6 +147,9 @@
                        {:source "tukui"
                         :source-id x-tukui-id})
 
+        ;; todo: add support for x-github
+        ;; ## X-Github: https://github.com/teelolws/Altoholic-Retail => source "github", source-id "teelolws/Altoholic-Retail"
+
         ignore-flag (when (some->> keyvals :version (clojure.string/includes? "@project-version@"))
                       (warn (format "ignoring '%s': 'Version' field in .toc file is unrendered" dirname))
                       {:ignore? true})

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -98,7 +98,7 @@ SomeAddon.lua")
                      :dirname "EveryAddon"
                      :label "EveryAddon *"
                      :description nil
-                     :interface-version 80200
+                     :interface-version toc/default-interface-version
                      :installed-version nil}
 
           cases [;; empty/no title


### PR DESCRIPTION
Addons with crazy 'title' values in their tocs make it difficult to reconcile that addon against the catalogue. Some popular addons have their source and source-id hardcoded into strongbox.

* toc, aliases now hardcode 'source' and 'source-id' rather than 'name'. The lookup will be more accurate and it gets rid of an ':alias' key that was floating around, unspecced.

- [x] investigate weirdness with dummy directory name when import a list of addons. shouldn't be an error case.
- [x] investigate why the installed addon table is replaced with the addons in the list when importing addons.
- [x] change game track during import process so it's more lenient. if it's set to 'classic', set to 'any, prefer classic' and vice versa. better to install the wrong game track of an addon then not install it at all. **update:** is actually more subtle than this. The preferred game track is picked *if present* but it may still use the current strict game track if selected. The more lenient version of the currently selected game track is now used to avoid addons in other game tracks from being skipped during import.
- [x] review
