### PR TITLE
4.0, per-addon logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 4.0.0
+
+### Added
+
+* an addon detail tab accessible by double clicking on either an installed addon or a search result.
+    - addon detail tabs can be closed.
+    - shortcut `ctrl-w` also closes an open tab *except* the installed, search and log tabs.
+    - has a new option `browse local files` if addon is installed locally
+    - has its own menu of buttons to install/re-install, update, remove, pin and ignore.
+    - has its own logging widget with per-addon logging and adjustable severity level.
+* dedicated log tab.
+    - will display `(warnings)` or `(errors)` if any warnings or errors present in log.
+* `View` menu has a menu option for open addon detail tabs with an additional `close all` button.
+* a column on the `installed` tab that shows the status of an addon.
+    - a tick if everything is ok
+    - an arrow if an update is available
+    - 
+
+### Changed
+
+* console logging is now colour coded
+* console log line now excludes a number of fields including the machine's 'hostname'
+* many error messages have been truncated or made less verbose now they have that context built-in
+* switched from Travis CI to Circle CI
+    - I can't package an `AppImage` from Circle CI however, something to do with their Docker config.
+
+### Fixed
+
+* errant debug statement I accidentally left in that may have been confusing
+    - https://github.com/ogri-la/strongbox/issues/240
+* looks like the the gap between the `File` menu labels and their submenus is now gone with the update to JavaFX 15
+
+### Removed
+
+* original Swing GUI
+* window split with tab pane in one half and the log in the other half
+
 ## 3.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Running strongbox with `--debug` will generate a file called "debug.log" that I 
 bug. *Some* of the details it contains are:
 
 * addons detected in the currently selected addon directory
-* your machine's `hostname`
+* ~your machine's `hostname`~
+    - removed in 4.0
 * paths to strongbox configuration and data:
     - `/home/torkus/.local/share/strongbox`
     - `/home/torkus/.config/strongbox`

--- a/TODO.md
+++ b/TODO.md
@@ -46,6 +46,8 @@ see CHANGELOG.md for a more formal list of changes by release
     - we now have console colours!
         - they'll probably be tweakd in future after the logging frenzy has calmed down
     - done
+* highlight new log pane or status bar when there is an non-addon error or warning
+    - done
 
 ## todo
 
@@ -57,7 +59,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - dark theme styling for addon-detail
         - use derived colours rather than hardcode
     - bug, addon detail, description box may grow or shrink after finding a match in the catalogue, bumping the content below up or down
-* highlight new log pane or status bar when there is an non-addon error or warning
+
 
 * uber-button
     - new column that displays overall health of addon

--- a/TODO.md
+++ b/TODO.md
@@ -14,23 +14,26 @@ see CHANGELOG.md for a more formal list of changes by release
     - done
 * addon detail pane
     - clicking an addon row opens a new tab with as much detail as we can about that addon
-    - done
-
-## todo
-
+    - done  
+* log pane, filter by log level
+    - log level should have number of instances against it
+        - warn (2)
+        - error (1)
 * per-addon logging
     - I want the user to see a list of messages regarding a *specific* addon
     - when emitting a log line about a particular addon, capture that addon's source and source-id somehow
         - and addon directory
         - and events? like changing game track
+
+## todo
+
+* 4.0 styling
+    - dark theme styling for addon-detail
+        - use derived colours rather than hardcode
+    - bug, addon detail, description box may grow or shrink after finding a match in the catalogue, bumping the content below up or down
 * highlight new log pane or status bar when there is an non-addon error or warning
-* log pane, filter by log level
-    - log level should have number of instances against it
-        - warn (2)
-        - error (1)
 * remove 'hostname' from log output
     - update privacy section in readme
-
 * uber-button
     - new column that displays overall health of addon
         - clicking whatever is in there takes you to a detail pane for that addon
@@ -38,12 +41,25 @@ see CHANGELOG.md for a more formal list of changes by release
         - if addon is up-to-date, it shows a happy green tick
             - if there is something to be concerned about (and that the user can fix), show a warning or error
 
+* bug, 'strongbox.version' in debug output is null when run as a binary
+
+## todo bucket (no particular order)
+
+* zip, better errors for failing to decompress .rar files
+    - see !FREEZING from wowinterface
+        - it's a .rar addon
+        - the full path is emitted in the error, which is impossible to fully read
+        - the extension has been replaced with .zip
+            - if the extension were preserved we could dismiss it immediately as unsupported
+
+        2021-03-20 01:35:58.026 DEBUG [strongbox.zip:23] - failed to open+close zip file: /home/torkus/path/to/wine/dir/drive_c/program files/World of Warcraft/_retail_/Interface/Addons/-freezing--1-04.zip
+        path [] triggered :strongbox.ui.jfx$start$update_gui_state__39204@608569a040151
+        2021-03-20 01:35:58.027 ERROR [strongbox.core:419] - failed to read zip file '/home/torkus/path/to/wine/dir/drive_c/program files/World of Warcraft/_retail_/Interface/Addons/-freezing--1-04.zip', could not install -freezing
+
+
 * gui, download progress bar *inside* the grid ...?
     - pure fantasy?
     - defer until after job queue
-
---
-
 * greater parallelism
     - internal job queue
     - replace log at bottom of screen with a list of jobs being processed and how far along they are
@@ -61,11 +77,6 @@ see CHANGELOG.md for a more formal list of changes by release
             - we already have a match!
         - this might fit in with the greater-parallelism/queue based infrastructure
 
---
-
-* bug, 'strongbox.version' in debug output is null when run as a binary
-
-## todo bucket (no particular order)
 
 * keep a list of previously installed addons
 

--- a/TODO.md
+++ b/TODO.md
@@ -49,6 +49,10 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+ - [ ] bug, I should be able to re-install a pinned addon if the pinned release is available, but I'm getting an error
+     - "refusing to install addon that will overwrite a pinned addon"
+     - this is actually a bit more involved than it first looks. shifting to it's own ticket
+
 * logging, app level 'help'
     - messages to the user that are not informational, or debug or warnings or errors, but simple helpful messages
     - it should stand out from the other messages, look friendly, etc

--- a/TODO.md
+++ b/TODO.md
@@ -53,15 +53,6 @@ see CHANGELOG.md for a more formal list of changes by release
      - "refusing to install addon that will overwrite a pinned addon"
      - this is actually a bit more involved than it first looks. shifting to it's own ticket
 
-* logging, app level 'help'
-    - messages to the user that are not informational, or debug or warnings or errors, but simple helpful messages
-    - it should stand out from the other messages, look friendly, etc
-
-* logging, app level 'events'
-    - now that the log has been pushed out of the way, it's free to be a bit more verbose
-    - some events like refreshing or changing the game track should be logged
-    - some of these events should be surfaced in an addon's notice logger
-
 * 4.0 styling
     - dark theme styling for addon-detail
         - use derived colours rather than hardcode
@@ -75,9 +66,26 @@ see CHANGELOG.md for a more formal list of changes by release
         - if addon is up-to-date, it shows a happy green tick
             - if there is something to be concerned about (and that the user can fix), show a warning or error
 
+* get log window scrolling in other direction
+ 
 * bug, 'strongbox.version' in debug output is null when run as a binary
 
 ## todo bucket (no particular order)
+
+* nfo, spend some time futzing with nfo files on disk and how they can break the UI
+    - I've managed to get some weird error messages by changing 'source' to an int, to a catalogue that doesn't exist, etc
+
+* search, replace 'install selected' with 'install' button on the right
+
+* logging, app level 'events'
+    - now that the log has been pushed out of the way, it's free to be a bit more verbose
+    - some events like refreshing or changing the game track should be logged
+    - some of these events should be surfaced in an addon's notice logger
+
+
+* logging, app level 'help'
+    - messages to the user that are not informational, or debug or warnings or errors, but simple helpful messages
+    - it should stand out from the other messages, look friendly, etc
 
 * zip, better errors for failing to decompress .rar files
     - see !FREEZING from wowinterface

--- a/TODO.md
+++ b/TODO.md
@@ -19,21 +19,51 @@ see CHANGELOG.md for a more formal list of changes by release
     - log level should have number of instances against it
         - warn (2)
         - error (1)
+    - done
 * per-addon logging
     - I want the user to see a list of messages regarding a *specific* addon
     - when emitting a log line about a particular addon, capture that addon's source and source-id somehow
         - and addon directory
-        - and events? like changing game track
+            - install-dir, dirname, source, source-id are all captured and used.
+                - it got a bit clunky but we got there
+    - done
+
+* remove 'hostname' from log output
+    - done
+    - update privacy section in readme
+        - done
+
+* coloured warnings/errors on console output
+    - when running with :debug on the wall of text is difficult to read
+    - I'm thinking about switching away from timbre to something more traditional
+        - he's not addressing tickets
+            - eh
+        - it may have been simpler to use in 3.x.x but in 4.x.x it's gotten a bit archaic
+            - still trie
+        - I can't drop hostname without leaving pretty-printed stacktraces behind
+            - fixed
+    - despite everything I stick with timbre and it's quite integrated now so it won't be disappearing anytime soon
+    - we now have console colours!
+        - they'll probably be tweakd in future after the logging frenzy has calmed down
+    - done
 
 ## todo
+
+* logging, app level 'help'
+    - messages to the user that are not informational, or debug or warnings or errors, but simple helpful messages
+    - it should stand out from the other messages, look friendly, etc
+
+* logging, app level 'events'
+    - now that the log has been pushed out of the way, it's free to be a bit more verbose
+    - some events like refreshing or changing the game track should be logged
+    - some of these events should be surfaced in an addon's notice logger
 
 * 4.0 styling
     - dark theme styling for addon-detail
         - use derived colours rather than hardcode
     - bug, addon detail, description box may grow or shrink after finding a match in the catalogue, bumping the content below up or down
 * highlight new log pane or status bar when there is an non-addon error or warning
-* remove 'hostname' from log output
-    - update privacy section in readme
+
 * uber-button
     - new column that displays overall health of addon
         - clicking whatever is in there takes you to a detail pane for that addon
@@ -225,12 +255,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - if we make an effort to scrape everyday, we can generate this popularity graph ourselves
 * add a 'tabula rasa' option that wipes *everything* 
     - cache, catalog, config, downloaded zip files
-* coloured warnings/errors on console output
-    - when running with :debug on the wall of text is difficult to read
-    - I'm thinking about switching away from timbre to something more traditional
-        - he's not addressing tickets
-        - it may have been simpler to use in 3.x.x but in 4.x.x it's gotten a bit archaic
-        - I can't drop hostname without leaving pretty-printed stacktraces behind
 * cache, make caching opt-out and remove all those ugly binding calls
     - bind the value at core app start
     - this may not be possible. 

--- a/project.clj
+++ b/project.clj
@@ -53,8 +53,9 @@
                        ;; - https://github.com/cljfx/cljfx/issues/17
                        :injections [(javafx.application.Platform/exit)]}}
 
-  :jvm-opts ["-Djdk.gtk.verbose=true" ;; debug output from JavaFX about which GTK it is looking for
-             ]
+  ;; debug output from JavaFX about which GTK it is looking for. 
+  ;; was useful in figuring out why javafx was failing to initialise even with xvfb.
+  ;;:jvm-opts ["-Djdk.gtk.verbose=true"]
 
   :main strongbox.main
 

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -78,7 +78,7 @@
         unknown-grouping (get addon-groups nil)
         addon-groups (dissoc addon-groups nil)
 
-        expand (fn [[group-id addons]]
+        expand (fn [[_ addons]]
                  (if (= 1 (count addons))
                    ;; perfect case, no grouping.
                    (first addons)
@@ -135,7 +135,7 @@
   [install-dir ::sp/addon-dir]
   (let [addon-dir-list (->> install-dir fs/list-dir (filter fs/directory?) (map str))
         parse-toc (fn [addon-dir]
-                    (logging/with-addon {:dirname addon-dir}
+                    (logging/with-addon {:dirname (-> addon-dir fs/file fs/base-name str)}
                       (toc/parse-addon-toc-guard addon-dir)))]
     (->> addon-dir-list (map parse-toc) (remove nil?) vec)))
 

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -40,7 +40,7 @@
       (nfo/mutual-dependency? install-dir addon-dirname)
       (let [updated-nfo-data (nfo/rm-nfo install-dir addon-dirname group-id)]
         (nfo/write-nfo install-dir addon-dirname updated-nfo-data)
-        (debug (format "removed '%s' as mutual dependency" addon-dirname)))
+        (debug (format "removed \"%s\" as mutual dependency" addon-dirname)))
 
       ;; all good, remove addon
       :else (do (fs/delete-dir addon-path)
@@ -49,7 +49,7 @@
 (defn-spec remove-addon nil?
   "removes the given addon. if addon is part of a group, all addons in group are removed"
   [install-dir ::sp/extant-dir, addon :addon/installed]
-  (info (format "removing '%s' version '%s'" (:label addon) (:installed-version addon)))
+  (info (format "removing \"%s\" version \"%s'" (:label addon) (:installed-version addon)))
   (cond
     ;; if addon is being ignored, refuse to remove addon.
     ;; note: `group-addons` will add a top level `:ignore?` flag if any addon in a bundle is being ignored.
@@ -109,8 +109,7 @@
 
                          addon-str (clojure.string/join ", " (map :dirname addons))]
 
-                     (logging/addon-log addon :info (format "'%s' contains %s addons: %s"
-                                                            (:label addon) (count addons) addon-str))
+                     (logging/addon-log addon :info (format "contains %s addons: %s" (count addons) addon-str))
                      addon)))
 
         ;; this flattens the newly grouped addons from a map into a list and joins the unknowns
@@ -141,7 +140,7 @@
 
 (defn-spec load-installed-addons :addon/toc-list
   "reads the .toc files from the given addon dir, reads any nfo data for 
-  these addons, groups them, returns the mooshed data."
+  these addons, groups them and returns the mooshed data."
   [install-dir ::sp/extant-dir]
   (let [addon-list (-load-installed-addons install-dir)
 
@@ -238,7 +237,7 @@
     (when (s/valid? :addon/toc addon)
       (remove-addon install-dir addon))
 
-    (info (format "installing '%s' version '%s'" (:label addon) (:version addon)))
+    (info (format "installing \"%s\" version \"%s\"" (:label addon) (:version addon)))
     (unzip-addon)
     (update-nfo-files)))
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -653,11 +653,11 @@
                   (info "not matched to catalogue, addon is being ignored")
 
                   (do ;; todo: replace these with a :help level and a less scary colour
-                      (info "if this is part of a bundle, try \"File -> Re-install all\"")
-                      (info "try searching for this addon by name or description")
-                      (warn (format "failed to find %s in the '%s' catalogue"
-                                    (:dirname addon)
-                                    (name (get-state :cfg :selected-catalogue))))))))
+                    (info "if this is part of a bundle, try \"File -> Re-install all\"")
+                    (info "try searching for this addon by name or description")
+                    (warn (format "failed to find %s in the '%s' catalogue"
+                                  (:dirname addon)
+                                  (name (get-state :cfg :selected-catalogue))))))))
 
             unmatched))
 
@@ -974,7 +974,7 @@
    ;; also in `set-addon-dir!`.
    ;; it needs to be updated as the addon dir changes.
    ;; todo: fix this duplication
-   (logging/add-atom-appender! state (selected-addon-dir)) 
+   (logging/add-atom-appender! state (selected-addon-dir))
 
    ;; parse toc files in install-dir. do this first so we see *something* while catalogue downloads (next)
    (load-installed-addons)

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -397,7 +397,7 @@
    (cond
      ;; do some pre-installation checks
      (:ignore? addon) (error "refusing to install addon, addon is being ignored:" (:name addon))
-     (not (fs/writeable? install-dir)) (error "refusing to install addon, directory not writeable:" install-dir)
+     (not (fs/writeable? install-dir)) (error "failed to install addon, directory not writeable:" install-dir)
 
      :else ;; attempt downloading and installing addon
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -190,7 +190,14 @@
     (add-watch state wid
                (fn [_ _ old-state new-state] ;; key, atom, old-state, new-state
                  (when (has-changed old-state new-state)
-                   (debug (format "path %s triggered %s" path wid))
+                   ;; prevents infinite recursion
+                   (when (= :debug (:level timbre/*config*))
+                     ;; this would cause the gui to receive a :debug of "path [] triggered a ..."
+                     ;; this would update the :log-lines in the state
+                     ;; this would cause the gui to receive a :debug of "path [] triggered a ..." ...
+                     ;;(debug (format "path %s triggered %s" path wid)))
+                     ;; instead, if :debug is the log level, print this to stdout
+                     (println (format "path %s triggered %s" path wid)))
                    (try
                      (callback new-state)
                      (catch Exception e

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -117,6 +117,9 @@
    ;; jfx ui showing?
    :gui-showing? false
 
+   ;; log-level for the gui dedicated notice-logger
+   :gui-log-level :info
+
    ;; addons in an unsteady state (data being updated, addon being installed, etc)
    ;; allows a UI to watch and update with progress
    :unsteady-addon-list #{}
@@ -124,6 +127,7 @@
    ;; a sublist of merged toc+addon that are selected
    :selected-addon-list []
 
+   ;; dynamic tabs
    :tab-list []
 
    :search {:term nil

--- a/src/strongbox/curseforge_api.clj
+++ b/src/strongbox/curseforge_api.clj
@@ -109,8 +109,7 @@
       (if (= (:download-url latest-release)
              (:download-url latest-release-by-game-version))
         (concat [latest-release] (rest (rest release-list)))
-        (do (info "no match!" latest-release latest-release-by-game-version)
-            release-list)))))
+        release-list))))
 
 (defn-spec group-releases map?
   "given a curseforge api result, returns a map of release data keyed by `game-track`."

--- a/src/strongbox/db.clj
+++ b/src/strongbox/db.clj
@@ -73,7 +73,7 @@
         ;; most -> least desirable match
         ;; nest to search across multiple parameters
         match-on-list [[[:source :source-id] [:source :source-id]] ;; source+source-id, perfect case
-                       [:source :name] ;; source+name, we have a source but no source-id (nfo-v1 files)
+                       [:source :name] ;; source+name, we have a source but no source-id (nfo v1 files)
                        [:name :name]
                        [:label :label]
                        [:dirname :label]] ;; dirname = label, eg ./AdiBags = AdiBags

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -35,7 +35,7 @@
             toc-file-list (filterv #(-> % :name fs/split-ext last (= ".toc")) contents-listing)
             toc-file (first toc-file-list)]
            (some-> toc-file :download_url http/download toc/-parse-toc-file)
-           (debug (format "failed to find/download/parse remote github '.toc' file for '%s'" source-id))))
+           (warn (format "failed to find/download/parse remote github '.toc' file for '%s'" source-id))))
 
 (defn-spec -find-gametracks-toc-data (s/or :ok ::sp/game-track-list, :empty nil?, :error nil?)
   "returns a set of 'retail' and/or 'classic' after inspecting .toc file contents"

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -73,6 +73,19 @@
     (add-appender! :spit func))
   nil)
 
+(defn add-atom-appender!
+  [atm]
+  (let [path [:log-lines]
+        func (fn [data]
+               (let [log-line {:level (force (:level data))
+                               :msg (force (:msg_ data))
+                               :instance (force (:instant data))
+                               :addon (some-> data :context :addon force)
+                               }]
+                 (swap! atm update-in path into [log-line])))]
+    (add-appender! :atom func))
+  nil)
+
 (defn-spec rm-appender! nil?
   "removes appender at `key` from logging config"
   [key keyword?]

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -36,8 +36,11 @@
   (and (-> timbre/*config* :level (= :debug))
        (not (-> timbre/*config* :testing?))))
 
+;; https://github.com/ptaoussanis/timbre/blob/56d67dd274d7d11ab31624a70b4b5ae194c03acd/src/taoensso/timbre.cljc#L856-L858
 (def colour-log-map
-  {:warn :yellow
+  {:debug :blue
+   :info nil
+   :warn :yellow
    :error :red
    :fatal :purple
    :report :blue})
@@ -45,7 +48,7 @@
 (defn anon-println-appender
   "removes the hostname from the output format string"
   [data]
-  (let [{:keys [?err timestamp_ msg_ level ?ns-str ?line]} data
+  (let [{:keys [?err timestamp_ msg_ level]} data
         level-colour (colour-log-map level)
         addon (some-> data :context :addon)
         label (or (:dirname addon)
@@ -59,7 +62,7 @@
     (when-not (empty? msg)
       ;; looks like: "11:17:57.009 [info] [app] checking for updates"
       (println
-       (timbre/color-str level-colour 
+       (timbre/color-str level-colour
                          (format
                           pattern
                           (force timestamp_)
@@ -74,8 +77,7 @@
                     :pattern "HH:mm:ss.SSS"
                     ;; default is :utc apparently. documented fucking nowhere.
                     ;; nil will set tz to current locale.
-                    :timezone nil
-                    }
+                    :timezone nil}
 
    :appenders {:println {:enabled? true
                          :async? false

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -77,11 +77,14 @@
   [atm]
   (let [path [:log-lines]
         func (fn [data]
-               (let [log-line {:time (force (:timestamp_ data))
+               (let [dirname (some-> data :context :addon :dirname)
+                     install-dir (some-> data :context :install-dir)
+                     source (when (and install-dir dirname)
+                              {:install-dir install-dir :dirname dirname})
+                     log-line {:time (force (:timestamp_ data))
                                :message (force (:msg_ data))
                                :level (force (:level data))
-                               :source (some-> data :context :addon force)
-                               }]
+                               :source source}]
                  (when atm
                    (swap! atm update-in path into [log-line]))))]
     (add-appender! :atom func {:timestamp-opts {:pattern "HH:mm:ss"}}))

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -77,13 +77,14 @@
   [atm]
   (let [path [:log-lines]
         func (fn [data]
-               (let [log-line {:level (force (:level data))
-                               :msg (force (:msg_ data))
-                               :instance (force (:instant data))
-                               :addon (some-> data :context :addon force)
+               (let [log-line {:time (force (:timestamp_ data))
+                               :message (force (:msg_ data))
+                               :level (force (:level data))
+                               :source (some-> data :context :addon force)
                                }]
-                 (swap! atm update-in path into [log-line])))]
-    (add-appender! :atom func))
+                 (when atm
+                   (swap! atm update-in path into [log-line]))))]
+    (add-appender! :atom func {:timestamp-opts {:pattern "HH:mm:ss"}}))
   nil)
 
 (defn-spec rm-appender! nil?

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -77,10 +77,9 @@
   [atm install-dir]
   (let [path [:log-lines]
         func (fn [data]
-               (let [dirname (some-> data :context :addon :dirname)
-                     ;;install-dir (some-> data :context :install-dir)
-                     source (when (and install-dir dirname)
-                              {:install-dir install-dir :dirname dirname})
+               (let [addon (some-> data :context :addon)
+                     addon-id (select-keys addon [:dirname :source :source-id :name])
+                     source (merge {:install-dir install-dir} addon-id)
                      log-line {:time (force (:timestamp_ data))
                                :message (force (:msg_ data))
                                :level (force (:level data))
@@ -103,8 +102,8 @@
          appender# (fn [data#]
                      (swap! stateful-buffer# into [(force (:msg_ data#))]))]
      (timbre/with-merged-config {:level ~level,
-                                  :appenders {:-temp {:fn appender#
-                                                      :enabled? true}}}
+                                 :appenders {:-temp {:fn appender#
+                                                     :enabled? true}}}
        ~@form)
      (deref stateful-buffer#)))
 
@@ -125,4 +124,9 @@
   `(timbre/with-context
      {;;:install-dir (selected-addon-dir)
       :addon ~addon}
+     ~@form))
+
+(defmacro with-label
+  [label & form]
+  `(with-addon {:name ~label}
      ~@form))

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -82,6 +82,7 @@
 
 (defn test
   [& [ns-kw fn-kw]]
+  (stop)
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including strongbox.whatever-test ones
   (utils/instrument true) ;; always test with spec checking ON
   (timbre/with-merged-config {:level :debug, :testing? true

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -126,7 +126,7 @@
         user-ignored (contains? nfo-file-contents :ignore?)
         _ (when (and user-ignored
                      (:ignore? nfo-file-contents))
-            (warn (format "ignoring '%s'" dirname)))
+            (debug (format "ignoring '%s'" dirname))) ;; todo: on ignore, list all dirs that will be ignored
 
         ignore-flag (when (and (not user-ignored)
                                (version-controlled? (join install-dir dirname)))

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -97,10 +97,10 @@
   [install-dir ::sp/extant-dir, dirname ::sp/dirname]
   (let [path (nfo-path install-dir dirname)
         bad-data (fn []
-                   (warn "bad nfo data, deleting file:" path) ;;todo
+                   (warn (format "bad \"%s\" file, deleting: %s" nfo-filename path))
                    (rm-nfo-file path))
         invalid-data (fn []
-                       (warn "invalid nfo data, deleting file:" path) ;;todo
+                       (warn (format "invalid \"%s\" file, deleting:" nfo-filename path))
                        (rm-nfo-file path))
         opts {:bad-data? bad-data
               :invalid-data? invalid-data,
@@ -126,11 +126,11 @@
         user-ignored (contains? nfo-file-contents :ignore?)
         _ (when (and user-ignored
                      (:ignore? nfo-file-contents))
-            (debug (format "ignoring '%s'" dirname))) ;; todo: on ignore, list all dirs that will be ignored
+            (debug (format "ignoring \"%s\"" dirname)))
 
         ignore-flag (when (and (not user-ignored)
                                (version-controlled? (join install-dir dirname)))
-                      (warn (format "ignoring '%s': addon directory contains a .git/.hg/.svn folder" dirname))
+                      (warn (format "ignoring \"%s\": addon directory contains a .git/.hg/.svn folder" dirname))
                       {:ignore? true})]
     (merge nfo-file-contents ignore-flag)))
 
@@ -161,7 +161,7 @@
   [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname, new-nfo-data :addon/nfo]
   (let [user-warning (fn [nfo-data-list]
                        (when-not (empty? nfo-data-list)
-                         (warn (format "addon '%s' is overwriting '%s'" (:name new-nfo-data) (:name (last nfo-data-list))))) ;;todo
+                         (warn (format "addon \"%s\" is overwriting \"%s\"" (:name new-nfo-data) (:name (last nfo-data-list)))))
                        nfo-data-list)]
     (-> (read-nfo-file install-dir addon-dirname)
         (rm-nfo* (:group-id new-nfo-data))
@@ -176,7 +176,7 @@
   [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname, addon ::sp/map-or-list-of-maps]
   (let [path (nfo-path install-dir addon-dirname)]
     (if-not (s/valid? :addon/nfo addon)
-      (error "new nfo data is invalid and won't be written to file")
+      (error (format "new \"%s\" data is invalid and won't be written to file" nfo-filename))
       (utils/dump-json-file path (prune addon)))))
 
 ;; this function could definitely do with a second pass, but not right now.

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -97,10 +97,10 @@
   [install-dir ::sp/extant-dir, dirname ::sp/dirname]
   (let [path (nfo-path install-dir dirname)
         bad-data (fn []
-                   (warn "bad nfo data, deleting file:" path)
+                   (warn "bad nfo data, deleting file:" path) ;;todo
                    (rm-nfo-file path))
         invalid-data (fn []
-                       (warn "invalid nfo data, deleting file:" path)
+                       (warn "invalid nfo data, deleting file:" path) ;;todo
                        (rm-nfo-file path))
         opts {:bad-data? bad-data
               :invalid-data? invalid-data,
@@ -161,7 +161,7 @@
   [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname, new-nfo-data :addon/nfo]
   (let [user-warning (fn [nfo-data-list]
                        (when-not (empty? nfo-data-list)
-                         (warn (format "addon '%s' is overwriting '%s'" (:name new-nfo-data) (:name (last nfo-data-list)))))
+                         (warn (format "addon '%s' is overwriting '%s'" (:name new-nfo-data) (:name (last nfo-data-list))))) ;;todo
                        nfo-data-list)]
     (-> (read-nfo-file install-dir addon-dirname)
         (rm-nfo* (:group-id new-nfo-data))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -23,6 +23,8 @@
         normalise (comp keyword name)]
     (->> spec clojure.spec.alpha/form extract (apply concat) (mapv normalise))))
 
+(s/def ::atom #(instance? clojure.lang.Atom %))
+
 (s/def ::list-of-strings (s/coll-of string?))
 (s/def ::list-of-maps (s/coll-of map?))
 (s/def ::list-of-keywords (s/coll-of keyword?))
@@ -342,6 +344,7 @@
 ;; javafx, cljfx, gui
 ;; no references to cljfx or javafx please!
 ;; requiring cljfx or anything in javafx.scene.control starts the javafx application thread
+(s/def :javafx/node #(instance? javafx.scene.Node %))
 
 (s/def :gui/column-data (s/keys :opt-un [:gui/text :gui/cell-value-factory :gui/style-class]))
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -58,6 +58,7 @@
 (s/def ::selected? boolean?)
 (s/def ::gui-theme #{:light :dark :dark-green :dark-orange})
 (s/def ::closable? boolean?)
+(s/def ::log-level #{:debug :info :warn :error})
 
 ;; preserve order, used in GUI
 (def game-track-labels [[:retail "retail"]
@@ -348,5 +349,5 @@
                        :edge (s/keys :req-in [::dirname]))) ;; unmatched and ignored addons
 (s/def :ui/tab-data :addon/id) ;; for now
 (s/def :ui/tab-id string?)
-(s/def :ui/tab (s/keys :req-un [:ui/tab-id ::label ::closable? :ui/tab-data]))
+(s/def :ui/tab (s/keys :req-un [:ui/tab-id ::label ::closable? :ui/tab-data ::log-level]))
 (s/def :ui/tab-list (s/coll-of :ui/tab))

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -2,6 +2,9 @@
   (:refer-clojure :rename {replace clj-replace})
   (:require
    [strongbox
+    ;; I want to keep higher level logging concerns out of toc.clj and nfo.clj.
+    ;; addon.clj and higher is ok.
+    ;;[logging :as logging] 
     [specs :as sp]
     [utils :as utils]]
    [clojure.spec.alpha :as s]
@@ -195,10 +198,3 @@
       ;; this addon failed somehow. don't propagate the exception, just report it and return nil
       (error "please report this! https://github.com/ogri-la/strongbox/issues")
       (error e (format "unhandled error parsing addon in directory '%s': %s" addon-dir (.getMessage e))))))
-
-(defn-spec installed-addons (s/or :ok :addon/toc-list, :error nil?)
-  "returns a list of addon data scraped from the .toc files of all addons in given `addon-dir`"
-  [addon-dir ::sp/addon-dir]
-  (let [addon-dir-list (->> addon-dir fs/list-dir (filter fs/directory?) (map str))
-        addon-list (->> addon-dir-list (map parse-addon-toc-guard) (remove nil?) vec)]
-    addon-list))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -178,8 +178,9 @@
   [addon :addon/expanded]
   (if-let [matching-release (addon/find-release addon)]
     (merge addon matching-release)
-    (do (warn (format "%s '%s' not found in known releases. Using latest release instead." (:label addon) (:installed-version addon)))
-        addon)))
+    (logging/with-addon addon ;; can this replace the previous `do` ?
+      (warn (format "%s '%s' not found in known releases. Using latest release instead." (:label addon) (:installed-version addon)))
+      addon)))
 
 ;;
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -4,6 +4,7 @@
    [taoensso.timbre :as timbre :refer [spy info warn error debug]]
    [clojure.spec.alpha :as s]
    [strongbox
+    [logging :as logging]
     [addon :as addon]
     [constants :as constants]
     [specs :as sp]
@@ -153,7 +154,7 @@
    (pin (get-state :selected-addon-list)))
   ([addon-list :addon/installed-list]
    (run! (fn [addon]
-           (core/with-addon-log addon
+           (logging/with-addon addon
              (info (format "pinning addon '%s' to version %s" (:label addon) (:installed-version addon)))
              (addon/pin (core/selected-addon-dir) addon)))
          addon-list)
@@ -166,7 +167,7 @@
    (unpin (get-state :selected-addon-list)))
   ([addon-list :addon/installed-list]
    (run! (fn [addon]
-           (core/addon-log :info addon (format "unpinning addon '%s' from %s" (:label addon) (:pinned-version addon)))
+           (logging/addon-log addon :info (format "unpinning addon '%s' from %s" (:label addon) (:pinned-version addon)))
            (addon/unpin (core/selected-addon-dir) addon))
          addon-list)
    (core/refresh)))
@@ -253,7 +254,7 @@
    (->> addon-list
         (filter addon/ignorable?)
         (run! (fn [addon]
-                (core/with-addon-log addon
+                (logging/with-addon addon
                   (info (format "ignoring addon '%s'" (:label addon)))
                   (addon/ignore (core/selected-addon-dir) addon)))))
    (core/refresh)))
@@ -265,7 +266,7 @@
    (clear-ignore-selected (get-state :selected-addon-list)))
   ([addon-list :addon/installed-list]
    (run! (fn [addon]
-           (core/with-addon-log addon
+           (logging/with-addon addon
              (addon/clear-ignore (core/selected-addon-dir) addon)
              (info (format "stopped ignoring addon '%s'" (:label addon)))))
          addon-list)

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -300,12 +300,20 @@
 
 ;; tabs
 
+(defn-spec change-notice-logger-level nil?
+  [tab-idx (s/nilable int?), new-log-level ::sp/log-level]
+  (if tab-idx
+    (swap! core/state assoc-in [:tab-list tab-idx :log-level] new-log-level)
+    (swap! core/state assoc :gui-log-level new-log-level))
+  nil)
+
 (defn-spec remove-all-tabs nil?
   "removes all dynamic addon detail tabs leaving only the static tabs"
   []
   (swap! core/state assoc :tab-list [])
   nil)
 
+;; todo: still being used?
 (defn-spec remove-tab nil?
   "removes a specific tab from the `:tab-list` using that tab's `:tab-id`"
   [tab-id string?]
@@ -326,6 +334,7 @@
   (let [new-tab {:tab-id tab-id
                  :label tab-label
                  :closable? closable?
+                 :log-level :info
                  :tab-data tab-data}
         tab-list (remove (fn [tab]
                            (= (dissoc tab :tab-id)

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -352,7 +352,7 @@
   (let [tab-id (utils/unique-id)
         closable? true
         addon-id (utils/extract-addon-id addon)]
-    (add-tab tab-id (:label addon) closable? addon-id)))
+    (add-tab tab-id (or (:dirname addon) (:label addon) (:name addon) "[bug: missing tab name!]") closable? addon-id)))
 
 
 ;; debug

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1523,6 +1523,21 @@
              :tab-idx tab-idx
              :addon-id (:tab-data tab)}})
 
+(defn log-tab
+  [{:keys [fx/context]}]
+  (let [level-set (->> (fx/sub-val context get-in [:app-state :log-lines])
+                       (map :level)
+                       set)
+        lbl (cond
+              (some #{:error} level-set) " (errors)"
+              (some #{:warn} level-set) " (warnings)"
+              :else "")]
+    {:fx/type :tab
+     :text (str "log" lbl)
+     :id "log-tab"
+     :closable false
+     :content {:fx/type notice-logger}}))
+
 (defn tabber
   [{:keys [fx/context]}]
   (let [dynamic-tab-list (fx/sub-val context get-in [:app-state :tab-list])
@@ -1544,11 +1559,7 @@
                                        (fn []
                                          (-> text-field .requestFocus))))))
           :content {:fx/type search-addons-pane}}
-         {:fx/type :tab
-          :text "log"
-          :id "log-tab"
-          :closable false
-          :content {:fx/type notice-logger}}]
+         {:fx/type log-tab}]
         dynamic-tabs (map-indexed (fn [idx tab] {:fx/type addon-detail-tab :tab tab :tab-idx idx}) dynamic-tab-list)]
     {:fx/type :tab-pane
      :id "tabber"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -422,7 +422,7 @@
                  :-fx-padding "0 0 0 1em"}
 
                 ;; hide 'source' column in notice-logger in addon-detail pane
-                ".table-view#notice-logger#source"
+                ".table-view#notice-logger #source"
                 {:-fx-max-width 0
                  :-fx-pref-width 0
                  :-fx-min-width 0}
@@ -1421,7 +1421,7 @@
   [{:keys [fx/context addon-id tab-idx]}]
   (let [installed-addons (fx/sub-val context get-in [:app-state :installed-addon-list])
         catalogue (fx/sub-val context get-in [:app-state :db]) ;; worst case is actually not so bad ...
-        addon-id-keys (keys addon-id) ;; [dirname] [source source-id], [source source-id dirname]
+        ;;addon-id-keys (keys addon-id) ;; [dirname] [source source-id], [source source-id dirname]
 
         -id-dirname (:dirname addon-id)
         -id-dirname? (not (nil? -id-dirname))
@@ -1448,7 +1448,6 @@
         ;; we can open the addon-detail pane but if we then delete the addon there is no longer any way to tie this addon detail pane
         ;; to addon data in the installed-addon-list (deleted) or the catalogue (no match).
         ;; we're forced to commit harikiri and close ourselves.
-
         ]
     (if (nil? addon)
       ;; this dodgy logic can be pushed back up the stack but we ultimately need to check for an addon and remove/exclude a tab if it exists.

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -323,7 +323,9 @@
                 {:-fx-alignment "center"}
 
                 "#source"
-                {:-fx-alignment "center"}
+                {:-fx-alignment "center"
+                 :-fx-pref-width 150
+                 }
 
                 "#time"
                 {:-fx-alignment "center"}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -215,23 +215,41 @@
                ".table-view .table-row-cell"
                {:-fx-border-insets "-1 -1 0 -1"
                 :-fx-border-color (colour :table-border)
-                " .table-cell" {:-fx-text-fill (colour :table-font-colour)}
+
+                " .table-cell"
+                {:-fx-text-fill (colour :table-font-colour)}
 
                 ;; even
                 :-fx-background-color (colour :row)
-                ":hover" {:-fx-background-color (colour :row-hover)}
-                ":selected" {:-fx-background-color (colour :row-selected)
-                             " .table-cell" {:-fx-text-fill "-fx-focused-text-base-color"}
-                             :-fx-table-cell-border-color (colour :table-border)}
-                ":selected:hover" {:-fx-background-color (colour :row-hover)}
 
-                ":odd" {:-fx-background-color (colour :row)}
-                ":odd:hover" {:-fx-background-color (colour :row-hover)}
-                ":odd:selected" {:-fx-background-color (colour :row-selected)}
-                ":odd:selected:hover" {:-fx-background-color (colour :row-hover)}
+                ":hover"
+                {:-fx-background-color (colour :row-hover)}
 
-                ".unsteady" {;; '!important' so that it takes precedence over .updateable addons
-                             :-fx-background-color (str (colour :unsteady) " !important")}}
+                ":selected"
+                {:-fx-background-color (colour :row-selected)
+
+                 " .table-cell"
+                 {:-fx-text-fill "-fx-focused-text-base-color"}
+                 :-fx-table-cell-border-color (colour :table-border)}
+
+                ":selected:hover"
+                {:-fx-background-color (colour :row-hover)}
+
+                ":odd"
+                {:-fx-background-color (colour :row)}
+
+                ":odd:hover"
+                {:-fx-background-color (colour :row-hover)}
+
+                ":odd:selected"
+                {:-fx-background-color (colour :row-selected)}
+
+                ":odd:selected:hover"
+                {:-fx-background-color (colour :row-hover)}
+
+                ".unsteady"
+                {;; '!important' so that it takes precedence over .updateable addons
+                 :-fx-background-color (str (colour :unsteady) " !important")}}
 
 
                ;;
@@ -346,12 +364,6 @@
                "#notice-logger-nav"
                {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
                 :-fx-font-size ".9em"
-
-                " .label"
-                {:-fx-padding ".25em 1em"
-                 :-fx-border-width "1px"
-                 :-fx-border-color "black"
-                 :-fx-border-radius "30"}
 
                 " .radio-button"
                 {:-fx-padding "0 .5em"}}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -128,55 +128,62 @@
          (fn [theme-kw]
            (let [colour-map (get themes theme-kw)
                  colour #(name (get colour-map % "pink"))]
-             {"#about-dialog "
+             {;;
+              ;; 'about' dialog
+              ;; lives outside of main styling for some reason
+              ;;
 
+              "#about-dialog "
               {:-fx-spacing "3"
 
                "#about-pane-hyperlink"
                {:-fx-font-size "1.1em"
-                :-fx-padding "0 0 4 -1"
+                :-fx-padding "0 0 4 -1"}
 
-                ":hover" {:-fx-text-fill "blue"}}
+               "#about-pane-hyperlink:hover"
+               {:-fx-text-fill "blue"}
 
                "#about-pane-title"
                {:-fx-font-size "1.5em"
                 :-fx-padding "10em"}}
 
+              ;;
+              ;; main app styling
+              ;; 
+
               (format "#%s.root " (name theme-kw))
               {:-fx-padding 0
                :-fx-base (colour :base)
-
-
-               ;; backgrounds
-
-
                :-fx-accent (colour :accent) ;; selection colour of backgrounds
 
-               ".table-placeholder-text"
-               {:-fx-font-size "1.5em"
-                :-fx-fill (colour :table-font-colour)}
-
+               ;; removes gradient from 'File' menu
                "#main-menu"
                {:-fx-background-color (colour :base)}
 
-               "#addon-dir-dropdown"
-               {:-fx-max-width "600px"}
-
-               ".context-menu"
-               {:-fx-effect "None"}
+               ;; todo: what did this do again?
+               ;;".context-menu"
+               ;;{:-fx-effect "None"}
 
                ".combo-box-base"
-               {:-fx-padding "1px"
-                :-fx-background-radius "0"
-                ;; truncation happens from the left. thanks to:
+               {:-fx-background-radius "0"
+                ;; truncation now happens from the left. thanks to:
                 ;; https://stackoverflow.com/questions/36264656/scalafx-javafx-how-can-i-change-the-overrun-style-of-a-combobox
                 " > .list-cell" {:-fx-text-overrun "leading-ellipsis"}}
 
-               ".button" {:-fx-background-radius "0"
-                          :-fx-padding ["6px" "17px"]
-                          ":hover" {:-fx-text-fill (colour :button-text-hovering)}}
+               ".button"
+               {:-fx-background-radius "0"
+                :-fx-padding "5px 17px" ;; makes buttons same height as dropdowns
+                ":hover" {:-fx-text-fill (colour :button-text-hovering)}}
 
+               ;;
                ;; tabber
+               ;;
+
+               ".tab-pane > .tab-header-area"
+               {:-fx-padding ".65em 0 0 .6em"
+                :-fx-background-color "green"}
+
+               ;; tabs
                ".tab-pane > .tab-header-area > .headers-region > .tab"
                {:-fx-background-radius "0"
                 :-fx-padding ".25em 1em"
@@ -186,64 +193,13 @@
 
 
                ;;
-               ;; addon-detail
+               ;; common tables
                ;;
 
 
-               ".addon-detail "
-               {".title"
-                {:-fx-font-size "2em"
-                 :-fx-padding "1em 0 .25em 1em"
-                 ;;:-fx-background-color "green"
-                 :-fx-alignment "center"}
-
-                ".subtitle"
-                {;;:-fx-background-color "green"
-                 ;;:-fx-padding "0 0 0 1em"
-                 :-fx-font-size "1.1em"}
-
-                ".description"
-                {:-fx-font-size "1.4em"
-                 :-fx-padding "0 0 1.5em 1em"
-                 :-fx-wrap-text true
-                 :-fx-font-style "italic"}
-
-                ".ext-links"
-                {:-fx-padding "0 0 1em 1.75em"}
-
-                ".ext-links .hyperlink"
-                {:-fx-text-fill "blue"
-                 :-fx-padding "0 0 0 1em"}
-
-                "#notice-logger#source"
-                ;; hide 'source' column in notice-logger in addon-detail pane
-                {:-fx-max-width 0
-                 :-fx-pref-width 0
-                 :-fx-min-width 0}
-
-                ;; hide column headers in notice-logger in addon-detail pane
-                ".table-view#notice-logger .column-header-background"
-                {:-fx-max-height 0
-                 :-fx-pref-height 0
-                 :-fx-min-height 0}
-
-                "#notice-logger-nav"
-                {:-fx-padding "0 0 .5em 0"
-                 :-fx-alignment "top-right"
-                 :-fx-font-size ".9em"
-
-                 " .label"
-                 {:-fx-padding ".25em 1em"
-                  :-fx-border-width "1px"
-                  :-fx-border-color "black"
-                  :-fx-border-radius "30"}
-
-                 " .radio-button"
-                 {:-fx-padding "0 .5em"}}} ;; ends .addon-detail
-
-
-               ;; common tables
-
+               ".table-placeholder-text"
+               {:-fx-font-size "1.5em"
+                :-fx-fill (colour :table-font-colour)}
 
                ".table-view"
                {:-fx-table-cell-border-color (colour :table-border)
@@ -278,21 +234,32 @@
                              :-fx-background-color (str (colour :unsteady) " !important")}}
 
 
-               ;; installed-addons menu
+               ;;
+               ;; common table fields
+               ;;
 
-               ;; prevent truncation and ellipses
+
+               ".table-view .source-column"
+               {:-fx-alignment "center-left"
+                :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
+                " .hyperlink:visited" {:-fx-underline "false"}
+                " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
+                                                 :-fx-text-fill (colour :jfx-hyperlink)
+                                                 :-fx-font-weight (colour :jfx-hyperlink-weight)}}
 
 
-               "#update-all-button "
+               ;;
+               ;; installed-addons tab
+               ;;
+
+
+               "#update-all-button"
                {:-fx-min-width "101px"}
 
-               "#game-track-combo-box "
+               "#game-track-combo-box"
                {:-fx-min-width "100px"}
 
-
                ;; installed-addons table
-
-
                ".table-view#installed-addons"
                {" .updateable"
                 {:-fx-background-color (colour :row-updateable)
@@ -364,6 +331,19 @@
                 "#message"
                 {:-fx-padding "0 0 0 .5em"}}
 
+               "#notice-logger-nav"
+               {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
+                :-fx-font-size ".9em"
+
+                " .label"
+                {:-fx-padding ".25em 1em"
+                 :-fx-border-width "1px"
+                 :-fx-border-color "black"
+                 :-fx-border-radius "30"}
+
+                " .radio-button"
+                {:-fx-padding "0 .5em"}}
+
 
                ;;
                ;; search
@@ -399,17 +379,54 @@
                 {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
                  :-fx-fill (colour :table-font-colour)}}
 
+
                ;;
-               ;; common table fields ;; move under 'common table' ?
+               ;; addon-detail
                ;;
 
-               ".table-view .source-column"
-               {:-fx-alignment "center-left"
-                :-fx-padding "-2 0 0 0" ;; hyperlinks are just a little bit off .. weird.
-                " .hyperlink:visited" {:-fx-underline "false"}
-                " .hyperlink, .hyperlink:hover" {:-fx-underline "false"
-                                                 :-fx-text-fill (colour :jfx-hyperlink)
-                                                 :-fx-font-weight (colour :jfx-hyperlink-weight)}}}}))]
+
+               ".addon-detail "
+               {".title"
+                {:-fx-font-size "2em"
+                 :-fx-padding "1em 0 .25em 1em"
+                 ;;:-fx-background-color "green"
+                 :-fx-alignment "center"}
+
+                ".subtitle"
+                {;;:-fx-padding "0 0 0 1em"
+                 :-fx-font-size "1.1em"}
+
+                ".description"
+                {:-fx-font-size "1.4em"
+                 :-fx-padding "0 0 1.5em 1em"
+                 :-fx-wrap-text true
+                 :-fx-font-style "italic"}
+
+                ".ext-links"
+                {:-fx-padding "0 0 1em 1.75em"}
+
+                ".ext-links .hyperlink"
+                {:-fx-text-fill "blue"
+                 :-fx-padding "0 0 0 1em"}
+
+                ;; hide 'source' column in notice-logger in addon-detail pane
+                "#notice-logger#source"
+                {:-fx-max-width 0
+                 :-fx-pref-width 0
+                 :-fx-min-width 0}
+
+                ;; hide column headers in notice-logger in addon-detail pane
+                ".table-view#notice-logger .column-header-background"
+                {:-fx-max-height 0
+                 :-fx-pref-height 0
+                 :-fx-min-height 0}
+
+                "#notice-logger-nav"
+                {:-fx-padding "0 0 .5em 0"
+                 :-fx-alignment "top-right"}} ;; ends .addon-detail
+
+                ;; ---
+               }}))]
 
      ;; return a single map with all themes in it.
      ;; themes are separated by their top-level 'root' key.
@@ -1205,8 +1222,7 @@
                         (let [num-occurances (level-occurances log-level)]
                           (format "%s (%s)" (name log-level) (or num-occurances 0))))
 
-        log-message-list (filter log-level-filter log-message-list)
-        ]
+        log-message-list (filter log-level-filter log-message-list)]
     {:fx/type :border-pane
      :top {:fx/type radio-group
            :options log-level-list
@@ -1214,9 +1230,12 @@
            :label-coercer label-coercer
            :container-id "notice-logger-nav"
            :on-action log-level-changed-handler}
-     
+
      :center {:fx/type :table-view
               :id "notice-logger"
+              :placeholder {:fx/type :text
+                            :style-class ["table-placeholder-text"]
+                            :text ""}
               :selection-mode :multiple
               :row-factory {:fx/cell-type :table-row
                             :describe (fn [row]
@@ -1377,8 +1396,7 @@
                   (->> catalogue (filter matcher) first))
         addon-source {:install-dir (core/selected-addon-dir) :dirname (:dirname addon)}
         notice-pane-filter (fn [log-line]
-                             (= addon-source (:source log-line)))
-    ]
+                             (= addon-source (:source log-line)))]
     {:fx/type :v-box
      :id "addon-detail-pane"
      :style-class ["addon-detail"]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1310,7 +1310,14 @@
 
                  {:fx/type :text-area
                   :text (str addon)
-                  :wrap-text true}])}))
+                  :wrap-text true}
+
+                 {:fx/type notice-logger
+                  :addon addon
+                  }
+
+
+                 ])}))
 
 (defn addon-detail-tab
   [{:keys [tab]}]
@@ -1450,6 +1457,7 @@
                        ;;   that causes the notice-logger to update it's rows ->
                        ;;   ...
                        ;; the trade off is duplicate messages are not displayed
+                       ;; sometimes doesn't work when there are pairs of messages displayed
                        (when-not (= prev-msg this-msg)
                          (swap! gui-state fx/swap-context update-in [:log-message-list] conj log-line))))]
     (logging/add-appender! :gui gui-logger {:timestamp-opts {:pattern "HH:mm:ss"}})))
@@ -1466,7 +1474,7 @@
                            (swap! gui-state fx/swap-context assoc :app-state new-state))
         _ (core/state-bind [] update-gui-state)
 
-        _ (init-notice-logger! gui-state)
+        ;;_ (init-notice-logger! gui-state) ;; pushing this into core/log-lines
 
         ;; css watcher for live coding
         _ (doseq [rf [#'style #'major-theme-map #'sub-theme-map #'themes]

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -604,3 +604,10 @@
   "returns a UUID as a string that is guaranteed to always be unique."
   []
   (str (java.util.UUID/randomUUID)))
+
+(defn count-occurances
+  ;; {"Foo-v1.zip" 1, "Foo-v2.zip 1, "Foo.zip" 5}
+  [my-list my-key]
+  (let [-count-occurances (fn [accumulator-m m]
+                            (update accumulator-m (get m my-key) (fn [n] (inc (or n 0)))))]
+    (reduce -count-occurances {} my-list)))

--- a/src/strongbox/zip.clj
+++ b/src/strongbox/zip.clj
@@ -11,6 +11,7 @@
     [utils :as utils]
     [specs :as sp]]))
 
+;; todo
 (defn-spec valid-zip-file? boolean?
   "returns true if there are no apparent problems opening+reading+closing the given zip file."
   [zipfile-path ::sp/extant-archive-file]
@@ -31,6 +32,7 @@
       (debug "failed to open/read/close zip file (IllegalArgumentException):" zipfile-path)
       false)))
 
+;; todo
 (defn-spec unzip-file (s/or :ok ::sp/extant-dir, :failed nil?)
   "unzips the zip file at the `zipfile-path` to the directory `output-dir-path`."
   [zipfile-path ::sp/extant-archive-file, output-dir-path ::sp/extant-dir]

--- a/src/strongbox/zip.clj
+++ b/src/strongbox/zip.clj
@@ -11,7 +11,6 @@
     [utils :as utils]
     [specs :as sp]]))
 
-;; todo
 (defn-spec valid-zip-file? boolean?
   "returns true if there are no apparent problems opening+reading+closing the given zip file."
   [zipfile-path ::sp/extant-archive-file]
@@ -32,7 +31,6 @@
       (debug "failed to open/read/close zip file (IllegalArgumentException):" zipfile-path)
       false)))
 
-;; todo
 (defn-spec unzip-file (s/or :ok ::sp/extant-dir, :failed nil?)
   "unzips the zip file at the `zipfile-path` to the directory `output-dir-path`."
   [zipfile-path ::sp/extant-archive-file, output-dir-path ::sp/extant-dir]

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -204,7 +204,7 @@
 
 (deftest add-tab
   (testing "a generic tab can be created"
-    (let [expected [{:tab-id "foo" :label "Foo!" :closable? false :tab-data {:dirname "EveryAddon"}}]]
+    (let [expected [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}]]
       (with-running-app
         (is (= [] (core/get-state :tab-list)))
         (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
@@ -213,7 +213,7 @@
 (deftest add-addon-tab
   (testing "an addon can be used to create a tab"
     (let [addon {:source "curseforge" :source-id 123 :label "Foo"}
-          expected [{:closable? true, :label "Foo", :tab-data {:source "curseforge", :source-id 123}, :tab-id "foobar"}]]
+          expected [{:closable? true, :label "Foo", :tab-data {:source "curseforge", :source-id 123}, :tab-id "foobar" :log-level :info}]]
       (with-running-app
         (with-redefs [strongbox.utils/unique-id (constantly "foobar")]
           (cli/add-addon-tab addon))
@@ -221,7 +221,7 @@
 
 (deftest remove-tab
   (testing "a single tab can be removed by its `id`"
-    (let [tab [{:tab-id "foo" :label "Foo!" :closable? false :tab-data {:dirname "EveryAddon"}}]
+    (let [tab [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}]
           expected []]
       (with-running-app
         (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
@@ -231,8 +231,8 @@
 
 (deftest remove-all-tabs
   (testing "all tabs can be removed at once"
-    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :tab-data {:dirname "EveryAddon"}}
-                    {:tab-id "bar" :label "Bar!" :closable? true :tab-data {:dirname "EveryOtherAddon"}}]
+    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}
+                    {:tab-id "bar" :label "Bar!" :closable? true :log-level :info :tab-data {:dirname "EveryOtherAddon"}}]
           expected []]
       (with-running-app
         (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
@@ -243,9 +243,9 @@
 
 (deftest remove-tab-at-idx
   (testing "all tabs can be removed at once"
-    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :tab-data {:dirname "EveryAddon"}}
-                    {:tab-id "bar" :label "Bar!" :closable? true :tab-data {:dirname "EveryOtherAddon"}}
-                    {:tab-id "baz" :label "Baz!" :closable? false :tab-data {:dirname "EveryAddonClassic"}}]
+    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}
+                    {:tab-id "bar" :label "Bar!" :closable? true :log-level :info :tab-data {:dirname "EveryOtherAddon"}}
+                    {:tab-id "baz" :label "Baz!" :closable? false :log-level :info :tab-data {:dirname "EveryAddonClassic"}}]
           expected [(first tab-list)
                     (last tab-list)]]
       (with-running-app

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -219,16 +219,6 @@
           (cli/add-addon-tab addon))
         (is (= expected (core/get-state :tab-list)))))))
 
-(deftest remove-tab
-  (testing "a single tab can be removed by its `id`"
-    (let [tab [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}]
-          expected []]
-      (with-running-app
-        (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
-        (is (= tab (core/get-state :tab-list)))
-        (cli/remove-tab "foo")
-        (is (= expected (core/get-state :tab-list)))))))
-
 (deftest remove-all-tabs
   (testing "all tabs can be removed at once"
     (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -909,7 +909,7 @@
                      :source "curseforge" :source-id 2
                      :download-url "https://path/to/remote/addon.zip" :game-track :retail
                      :-testing-zipfile (fixture-path "everyotheraddon--5-6-7.zip")}
-            expected ["addon 'everyotheraddon' is overwriting 'everyaddon'"]]
+            expected ["addon \"everyotheraddon\" is overwriting \"everyaddon\""]]
         (helper/install-dir)
         (core/install-addon addon-1)
         (core/load-installed-addons) ;; refresh our knowledge of what is installed

--- a/test/strongbox/nfo_test.clj
+++ b/test/strongbox/nfo_test.clj
@@ -208,7 +208,7 @@
           updates {:installed-game-track :foo}
 
           expected nfo-data
-          expected-log ["new nfo data is invalid and won't be written to file"]]
+          expected-log ["new \".strongbox.json\" data is invalid and won't be written to file"]]
 
       (nfo/write-nfo (install-dir) addon-dir nfo-data)
       (is (= expected-log


### PR DESCRIPTION
- [x] detail pane filters log messages by addon (directory + source + source-id)
- [x] detail pane filterable by severity (debug, info, warn, err)
   - how to filter by 'debug' when we run at 'info'? perhaps only display 'debug' if 'debug' messages are available.
       - same for 'warn' and 'error'? no, we don't want nav jumping around. 'debug' is the first/last item and won't significantly affect the position of the others
- [x] dedicated log tab has buttons to filter by severity (debug, info, warn, err)
- [x] detail pane displays per-addon log messages
- [x] detail pane displays number of errors or warnings next to severity filter
- [x] log pane has a consistently sized and relevant message when empty
- [x] ensure all per-addon logging now has the correct meta attached to it
- [ ] ~message in log lines wraps to available width rather than truncation~
    - may not be possible. Have a play with the code vlaad came up with
    - it works but styling is messed up because it is using 'text' instead of a 'label'. Doesn't seem possible to have a 'label' wrap at the moment. 
- [x] highlight log tab or status bar or something when there are non-addon errors or warnings
    - does it have to be non-addon? what are we really trying to achieve here?
        - user should be made aware that all is not right. if this is present in an addon's uber-button then app-level errors still need highlighting
        - users may not be able to fix warnings but errors should be preventable/reportable
 - [x] double clicking a row in log pane that has an addon attached opens detail
 - [x] bug, regression, NPE deleting an addon while its tab is open
     - happens when we can't find an addon because our search is too strict given how much we know about an addon
     - reproducible with: install addon, open addon detail, click delete. 
     - is *not* reproducible with: open addon detail from search, click install, click delete.
 - [x] bug, regression, source column displayed in app notice logger
 - [x] logging, console logging now relies on associated addon for context
     - [x] remove 'host' from log line
     - [x] add addon dirname or label - whatever I'm using for the 'source' column
 - [ ] ~bug, I should be able to re-install a pinned addon if the pinned release is available, but I'm getting an error~
     - "refusing to install addon that will overwrite a pinned addon"
     - this is actually a bit more involved than it first looks. shifting to it's own ticket
- [x] review
- [x] update changelog