### PR TITLE
gui, 4.0 changes, release list on detail pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * an addon detail tab accessible by double clicking on either an installed addon or a search result.
     - addon detail tabs can be closed.
     - shortcut `ctrl-w` also closes an open tab *except* the installed, search and log tabs.
-    - has a new option `browse local files` if addon is installed locally
+    - has a new option `browse local files` if addon is installed locally.
     - has its own menu of buttons to install/re-install, update, remove, pin and ignore.
-    - has its own logging widget with per-addon logging and adjustable severity level.
+    - a 'raw data' widget with the fields used within the application.
+    - a 'releases' widget that lists all available releases with an install button.
+    ' a 'grouped addons' widget that displays the other addons that came with this addon and a filebrowser link.
+    - a logging widget with per-addon logging and adjustable severity level.
 * dedicated log tab.
     - will display `(warnings)` or `(errors)` if any warnings or errors present in log.
 * `View` menu has a menu option for open addon detail tabs with an additional `close all` button.

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -452,3 +452,7 @@
   [addon map?]
   (and (not (empty? (:release-list addon)))
        (not (pinned? addon))))
+
+(defn-spec releases-visible? boolean?
+  [addon map?]
+  (releases-available? (update-in addon [:release-list] rest)))

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -447,3 +447,8 @@
   [addon map?]
   (and (installed? addon)
        (not (ignored? addon))))
+
+(defn-spec releases-available? boolean?
+  [addon map?]
+  (and (not (empty? (:release-list addon)))
+       (not (pinned? addon))))

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -449,10 +449,13 @@
        (not (ignored? addon))))
 
 (defn-spec releases-available? boolean?
+  "returns `true` if *any* addons are available, including the currently installed version, and the addon isn't pinned.
+  ignored addons shouldn't have a `:release-list`."
   [addon map?]
   (and (not (empty? (:release-list addon)))
        (not (pinned? addon))))
 
 (defn-spec releases-visible? boolean?
+  "returns `true` if there is more than 1 release available and the addon isn't pinned"
   [addon map?]
   (releases-available? (update-in addon [:release-list] rest)))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -369,9 +369,14 @@
                ;;
 
 
+               ".notice-logger-nav-box"
+               {;;:-fx-background-color "pink"
+                }
+               
                "#notice-logger-nav"
                {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
                 :-fx-font-size ".9em"
+
 
                 " .radio-button"
                 {:-fx-padding "0 .5em"}}
@@ -430,6 +435,12 @@
                 {;;:-fx-padding "0 0 0 1em"
                  :-fx-font-size "1.1em"}
 
+                ".section-title"
+                {:-fx-font-size "1.3em"
+                 :-fx-padding "1em 0 .5em 1em"
+                 :-fx-min-width "200px"
+                 }
+
                 ".description"
                 {:-fx-font-size "1.4em"
                  :-fx-padding "0 0 1.5em 1em"
@@ -457,7 +468,13 @@
 
                 "#notice-logger-nav"
                 {:-fx-padding "0 0 .5em 0"
-                 :-fx-alignment "top-right"}} ;; ends .addon-detail
+                 :-fx-alignment "bottom-right"
+                 :-fx-pref-width 9999.0
+                 
+                 ;;:-fx-background-color "yellow"
+
+
+                 }} ;; ends .addon-detail
 
                 ;; ---
                }}))]
@@ -1264,12 +1281,18 @@
 
         log-message-list (filter log-level-filter log-message-list)]
     {:fx/type :border-pane
-     :top {:fx/type radio-group
-           :options log-level-list
-           :value selected-log-level
-           :label-coercer label-coercer
-           :container-id "notice-logger-nav"
-           :on-action log-level-changed-handler}
+     :top {:fx/type :h-box
+           :style-class ["notice-logger-nav-box"]
+           :children [{:fx/type :label
+                       :style-class ["section-title"]
+                       :text "Notices"
+                       }
+                      {:fx/type radio-group
+                       :options log-level-list
+                       :value selected-log-level
+                       :label-coercer label-coercer
+                       :container-id "notice-logger-nav"
+                       :on-action log-level-changed-handler}]}
 
      :center {:fx/type :table-view
               :id "notice-logger"
@@ -1437,6 +1460,26 @@
                       {:disabled? (not (addon/deletable? addon))
                        :tooltip "Permanently delete"})]})
 
+(defn addon-detail-release-widget
+  [{:keys [fx/context addon tab-idx]}]
+  (let [column-list [{:text "name" :min-width 150 :pref-width 300 :max-width 500 :cell-value-factory :release-label}
+                     {:text "version" :cell-value-factory :version}
+                     {:text "" :cell-value-factory (constantly "install")}]
+        row-list (:release-list addon)
+        ]
+    {:fx/type :border-pane
+     :top {:fx/type :label
+           :style-class ["section-title"]
+           :text "Releases"}
+     :center {:fx/type :table-view
+              :id "release-list"
+              :placeholder {:fx/type :text
+                            :style-class ["table-placeholder-text"]
+                            :text "No releases found."}
+              :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
+              :columns (mapv table-column column-list)
+              :items (or row-list [])}}))
+
 (defn addon-detail-pane
   "a place to elaborate on what we know about an addon as well somewhere we can put lots of buttons and widgets."
   [{:keys [fx/context addon-id tab-idx]}]
@@ -1515,11 +1558,17 @@
                      (when-not (empty? (:description addon))
                        {:fx/type :label
                         :style-class ["description"]
+                        :wrap-text true
                         :text (:description addon)})
 
                      {:fx/type addon-detail-button-menu
                       :addon addon}
 
+                     {:fx/type addon-detail-release-widget
+                      :addon addon}
+
+                     
+                     
                      {:fx/type notice-logger
                       :tab-idx tab-idx
                       :filter-fn notice-pane-filter}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -478,38 +478,38 @@
                  :-fx-alignment "bottom-right"
                  :-fx-pref-width 9999.0}
 
+                ".table-view#key-vals .column-header .label"
+                {:-fx-font-style "normal" ;; column values except the header should be italic
+                 }
+
                 ".table-view#key-vals .key-column"
                 {:-fx-alignment "center-right"
                  :-fx-padding "0 1em 0 0"
                  :-fx-font-style "italic"}
 
                 ".table-view#release-list .install-button-column"
-                {:-fx-alignment "center"
-                 :-fx-pref-width 120}
+                {:-fx-alignment "center"}
 
                 ".table-view#release-list .install-button-column.table-cell"
-                {:-fx-padding "-2"
-                 }
-                
+                {:-fx-padding "-2"}
+
                 ".table-view#release-list .install-button-column .button"
-                {:-fx-pref-width 120
-                 }
+                {:-fx-pref-width 120}
 
                 ".table-view#notice-logger"
                 {:-fx-pref-height "12pc"}
 
-                ".table-view#group-addons .open-link-column"
-                {:-fx-pref-width 140}
 
                 ;; ---
-
-                } ;; ends .addon-detail
+} ;; ends .addon-detail
 
                 ;; ---
                }}))]
 
      ;; return a single map with all themes in it.
      ;; themes are separated by their top-level 'root' key.
+
+
      (into {} (for [[theme-key _] themes]
                 (generate-style theme-key))))))
 
@@ -1318,7 +1318,7 @@
                          {:fx/type :label
                           :style-class ["section-title"]
                           :text section-title})
-                       
+
                        {:fx/type radio-group
                         :options log-level-list
                         :value selected-log-level
@@ -1497,7 +1497,7 @@
   (let [install-button (fn [release]
                          (component-instance
                           (button "install" (async-handler #(cli/set-version addon release)))))
-        column-list [{:text "" :style-class ["install-button-column"] :pref-width 100 :cell-value-factory install-button}
+        column-list [{:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :max-width 120 :cell-value-factory install-button}
                      {:text "name" :cell-value-factory #(or (:release-label %) (:version %))}]
         row-list (rest (:release-list addon))]
     {:fx/type :border-pane
@@ -1516,13 +1516,14 @@
 
 (defn addon-detail-key-vals
   [{:keys [addon]}]
-  (let [column-list [{:text "key" :min-width 150 :max-width 250 :cell-value-factory (comp name :key)}
+  (let [column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 200 :cell-value-factory (comp name :key)}
                      {:text "val" :cell-value-factory :val}]
 
         blacklist [:group-addons :release-list]
         sanitised (apply dissoc addon blacklist)
 
-        row-list (apply utils/csv-map [:key :val] (vec sanitised))]
+        row-list (apply utils/csv-map [:key :val] (vec sanitised))
+        row-list (sort-by :key row-list)]
     {:fx/type :border-pane
      :top {:fx/type :label
            :style-class ["section-title"]
@@ -1540,7 +1541,7 @@
   [{:keys [addon]}]
   (let [opener (fn [row]
                  (component-instance (addon-fs-link (:dirname row))))
-        column-list [{:text "" :style-class ["open-link-column"] :cell-value-factory opener}
+        column-list [{:text "" :style-class ["open-link-column"] :min-width 80 :pref-width 150 :max-width 150 :cell-value-factory opener}
                      {:text "name" :cell-value-factory :dirname}]
 
         row-list (:group-addons addon)]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1261,7 +1261,7 @@
   "a log widget that displays a list of log lines.
   used by itself as well as embedded into the addon detail page.
   pass it a `filter-fn` to remove entries in the `:log-lines` list."
-  [{:keys [fx/context tab-idx filter-fn]}]
+  [{:keys [fx/context tab-idx filter-fn section-title]}]
   (let [filter-fn (or filter-fn identity)
         level-map {:debug 0 :info 1 :warn 2 :error 3}
         current-log-level (if tab-idx
@@ -1305,15 +1305,18 @@
     {:fx/type :border-pane
      :top {:fx/type :h-box
            :style-class ["notice-logger-nav-box"]
-           :children [{:fx/type :label
-                       :style-class ["section-title"]
-                       :text "notices"}
-                      {:fx/type radio-group
-                       :options log-level-list
-                       :value selected-log-level
-                       :label-coercer label-coercer
-                       :container-id "notice-logger-nav"
-                       :on-action log-level-changed-handler}]}
+           :children (utils/items
+                      [(when section-title
+                         {:fx/type :label
+                          :style-class ["section-title"]
+                          :text section-title})
+                       
+                       {:fx/type radio-group
+                        :options log-level-list
+                        :value selected-log-level
+                        :label-coercer label-coercer
+                        :container-id "notice-logger-nav"
+                        :on-action log-level-changed-handler}])}
 
      :center {:fx/type :table-view
               :id "notice-logger"
@@ -1651,6 +1654,7 @@
 
          :bottom {:fx/type notice-logger
                   :tab-idx tab-idx
+                  :section-title "notices"
                   :filter-fn notice-pane-filter}}))))
 
 (defn addon-detail-tab

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1081,15 +1081,14 @@
 (defn-spec table-column map?
   "returns a description of a table column that lives within a table"
   [column-data :gui/column-data]
-  (let [column-id (some utils/nilable [(:id column-data) (:text column-data) "noid"])
+  (let [column-class (if-let [column-id (some utils/nilable [(:id column-data) (:text column-data)])]
+                       (lower-case (str column-id "-column"))
+                       "column")
         column-name (:text column-data)
         default-cvf (fn [row] (get row (keyword column-name)))
         final-cvf {:cell-value-factory (get column-data :cell-value-factory default-cvf)}
 
-        final-style {:style-class (into ["table-cell"
-                                         "column"
-                                         (lower-case (str column-id "-column"))]
-                                        (get column-data :style-class))}
+        final-style {:style-class (into ["table-cell" column-class] (get column-data :style-class))}
 
         default {:fx/type :table-column
                  :min-width 80}]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -487,6 +487,14 @@
                 {:-fx-alignment "center"
                  :-fx-pref-width 120}
 
+                ".table-view#release-list .install-button-column.table-cell"
+                {:-fx-padding "-2"
+                 }
+                
+                ".table-view#release-list .install-button-column .button"
+                {:-fx-pref-width 120
+                 }
+
                 ".table-view#notice-logger"
                 {:-fx-pref-height "250px"}
 
@@ -1486,7 +1494,10 @@
 
 (defn addon-detail-release-widget
   [{:keys [addon]}]
-  (let [column-list [{:text "" :style-class ["install-button-column"] :pref-width 100 :cell-value-factory (constantly "install")}
+  (let [install-button (fn [release]
+                         (component-instance
+                          (button "install" (async-handler #(cli/set-version addon release)))))
+        column-list [{:text "" :style-class ["install-button-column"] :pref-width 100 :cell-value-factory install-button}
                      {:text "name" :cell-value-factory #(or (:release-label %) (:version %))}]
         row-list (rest (:release-list addon))]
     {:fx/type :border-pane

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -496,7 +496,7 @@
                  }
 
                 ".table-view#notice-logger"
-                {:-fx-pref-height "250px"}
+                {:-fx-pref-height "12pc"}
 
                 ".table-view#group-addons .open-link-column"
                 {:-fx-pref-width 140}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -368,10 +368,6 @@
                ;;
 
 
-               ".notice-logger-nav-box"
-               {;;:-fx-background-color "pink"
-                }
-
                "#notice-logger-nav"
                {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
                 :-fx-font-size ".9em"
@@ -426,12 +422,10 @@
                {".title"
                 {:-fx-font-size "2em"
                  :-fx-padding "1em 0 .25em 1em"
-                 ;;:-fx-background-color "green"
                  :-fx-alignment "center"}
 
                 ".subtitle"
-                {;;:-fx-padding "0 0 0 1em"
-                 :-fx-font-size "1.1em"}
+                {:-fx-font-size "1.1em"}
 
                 ".section-title"
                 {:-fx-font-size "1.3em"
@@ -451,15 +445,8 @@
                 {:-fx-text-fill "blue"
                  :-fx-padding "0 0 0 1em"}
 
-                ".split-pane"
-                {;; https://stackoverflow.com/questions/16856359/how-do-i-get-rid-of-the-border-around-a-split-pane-in-javafx
-                 ;;:-fx-box-border "transparent, -fx-background"
-                 :-fx-background-insets 0
-                 :-fx-padding 0}
-
-                ".split-pane > .split-pane-divider"
-                {:-fx-padding "4px"
-                 :-fx-background-color "transparent"}
+                ".table-view#notice-logger"
+                {:-fx-pref-height "12pc"}
 
                 ;; hide 'source' column in notice-logger in addon-detail pane
                 ".table-view#notice-logger #source"
@@ -494,16 +481,9 @@
                 {:-fx-padding "-2"}
 
                 ".table-view#release-list .install-button-column .button"
-                {:-fx-pref-width 120}
+                {:-fx-pref-width 120}} ;; ends .addon-detail
 
-                ".table-view#notice-logger"
-                {:-fx-pref-height "12pc"}
-
-
-                ;; ---
-} ;; ends .addon-detail
-
-                ;; ---
+               ;; ---
                }}))]
 
      ;; return a single map with all themes in it.
@@ -1493,13 +1473,14 @@
                        :tooltip "Permanently delete"})]})
 
 (defn addon-detail-release-widget
+  "displays a list of installable releases for the given addon"
   [{:keys [addon]}]
   (let [install-button (fn [release]
                          (component-instance
                           (button "install" (async-handler #(cli/set-version addon release)))))
         column-list [{:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :max-width 120 :cell-value-factory install-button}
                      {:text "name" :cell-value-factory #(or (:release-label %) (:version %))}]
-        row-list (rest (:release-list addon))]
+        row-list (or (rest (:release-list addon)) [])]
     {:fx/type :border-pane
      :top {:fx/type :label
            :style-class ["section-title"]
@@ -1511,10 +1492,11 @@
                             :text "(no releases)"}
               :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
               :columns (mapv table-column column-list)
-              :items (or row-list [])
+              :items row-list
               :disable (not (addon/releases-visible? addon))}}))
 
 (defn addon-detail-key-vals
+  "displays a two-column table of `key: val` fields for what we know about an addon."
   [{:keys [addon]}]
   (let [column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 200 :cell-value-factory (comp name :key)}
                      {:text "val" :cell-value-factory :val}]
@@ -1538,9 +1520,9 @@
               :items (or row-list [])}}))
 
 (defn addon-detail-group-addons
+  "displays a list of other addons that came grouped with this addon"
   [{:keys [addon]}]
-  (let [opener (fn [row]
-                 (component-instance (addon-fs-link (:dirname row))))
+  (let [opener #(component-instance (addon-fs-link (:dirname %)))
         column-list [{:text "" :style-class ["open-link-column"] :min-width 80 :pref-width 150 :max-width 150 :cell-value-factory opener}
                      {:text "name" :cell-value-factory :dirname}]
 

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -611,3 +611,9 @@
   (let [-count-occurances (fn [accumulator-m m]
                             (update accumulator-m (get m my-key) (fn [n] (inc (or n 0)))))]
     (reduce -count-occurances {} my-list)))
+
+;; https://clojuredocs.org/clojure.core/zipmap#example-56fbf77de4b069b77203b858
+(defn csv-map
+  "ZipMaps header as keys and values from lines."
+  [head & lines]
+  (map #(zipmap (map keyword head) %1) lines))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -38,9 +38,9 @@
 
 (deftest table-column
   (testing "table-column data is converted to component descriptions"
-    (let [cases [[{} {:fx/type :table-column, :min-width 80, :style-class ["table-cell" "-column"]}]
+    (let [cases [[{} {:fx/type :table-column, :min-width 80, :style-class ["table-cell" "column"]}]
                  [{:text "foo"} {:fx/type :table-column, :text "foo", :min-width 80, :style-class ["table-cell" "foo-column"]}]
-                 [{:style-class ["foo"]} {:fx/type :table-column, :min-width 80, :style-class ["table-cell" "-column" "foo"]}]]]
+                 [{:style-class ["foo"]} {:fx/type :table-column, :min-width 80, :style-class ["table-cell" "column" "foo"]}]]]
       (doseq [[given expected] cases]
         (is (= expected (dissoc (jfx/table-column given) :cell-value-factory)))))))
 

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -221,7 +221,6 @@
                ;; error cases
                ;;[[] -1 []]
                ]]
-
     (doseq [[v idx expected] cases]
       (is (= expected (utils/drop-idx v idx))))))
 
@@ -248,6 +247,19 @@
                ["5.0.4" :retail]
                ;; ...etc
                ["9.0.1" :retail]]]
-
     (doseq [[given expected] cases]
       (is (= expected (utils/game-version-to-game-track given))))))
+
+(deftest csv-map
+  (testing "singular"
+    (let [header [:key :val]
+          row ["foo" "bar"]
+          expected [{:key "foo" :val "bar"}]]
+      (is (= expected (utils/csv-map header row)))))
+
+  (testing "asfd"
+    (let [header [:key :val]
+          row-list [["foo" "bar"] ["baz" "bup"]]
+          expected [{:key "foo" :val "bar"} {:key "baz" :val "bup"}]]
+      (is (= expected (apply utils/csv-map header row-list))))))
+


### PR DESCRIPTION
- [x] clicking the 'install' button in the release list will do just that 
- [x] release list is present but disabled if pinned
- [x] release list is disabled and empty if ignored
- [x] keyvals, sort alphabetically asc by key
- [ ] ~keyvals, values are selectable~
  - believe it or not you can't: https://bugs.openjdk.java.net/browse/JDK-8091997
- [x] keyvals, key column header shouldn't be italicised
- [x] keyvals, right align key
- [x] bug, regression, addon description is no longer wrapping
    - I think it has something to do with the available height ...
- [x] table column widths are not specified in css
    - this leads to a bit of Weirdness
- [x] review
- [x] update changelog
