### PR TITLE
4.0 bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * looks like the the gap between the `File` menu labels and their submenus is now gone with an update to JavaFX 15.
 * truncated 'source' column in the search results when in dark mode.
+* fixed missing `strongbox.version` value from debug output when run as a binary.
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -66,9 +66,10 @@ see CHANGELOG.md for a more formal list of changes by release
 * bug, regression, --verbosity cli option is reset
     - done
 
+* bug, 'strongbox.version' in debug output is null when run as a binary
+
 ## todo
 
-* bug, 'strongbox.version' in debug output is null when run as a binary
 
 ## todo bucket (no particular order)
 

--- a/TODO.md
+++ b/TODO.md
@@ -63,6 +63,9 @@ see CHANGELOG.md for a more formal list of changes by release
             - if there is something to be concerned about (and that the user can fix), show a warning or error
     - done
 
+* bug, regression, --verbosity cli option is reset
+    - done
+
 ## todo
 
 * bug, 'strongbox.version' in debug output is null when run as a binary

--- a/TODO.md
+++ b/TODO.md
@@ -70,8 +70,16 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
-
 ## todo bucket (no particular order)
+
+* disable addon update if it's unsteady
+    - interesting stuff happens when you pump that update button!
+    - roll this into the action queue work
+        - no more than one update request pending per-addon
+
+* classic addon dir detection
+    - also check for 
+        - '_classic_' '_classic_beta_' '_classic_ptr_'
 
 * game tracks, add warning if installed addon's interface version deviates from addon directory's game track
     - for example, if classic is installed in retail, or classic-bc is installed in classic

--- a/cloverage.clj
+++ b/cloverage.clj
@@ -17,7 +17,7 @@
     (with-redefs [core/testing? true
                   main/profile? true
                   main/spec? true]
-      (logging/reset-logging! core/testing?)
+      (core/reset-logging!)
       (apply require (map symbol ns-list))
       {:errors (reduce + ((juxt :error :fail)
                           (apply test/run-tests ns-list)))})))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -1119,21 +1119,29 @@
   "writes selected system properties to the log.
   mostly concerned with OS, Java and JavaFX versions."
   []
-  (let [useful-keys ["strongbox.version"
-                     "os.name"
-                     "os.version"
-                     "os.arch"
-                     "java.runtime.name"
-                     "java.vm.name"
-                     "java.version"
-                     "java.runtime.version"
-                     "java.vendor.url"
-                     "java.version.date"
-                     "java.awt.graphicsenv"
-                     "javafx.version"
-                     "javafx.runtime.version"]
-        props (System/getProperties)]
-    (run! #(info (format "%s=%s" % (get props %))) useful-keys)))
+  (let [useful-props
+        ["javafx.version" ;; "15.0.1"
+         "javafx.runtime.version" ;; "15.0.1+1"
+         ]
+
+        useful-envvars
+        [:strongbox-version ;; "4.0.0"
+         :os-name ;; "Linux"
+         :os-version ;; "5.11.6-arch1-1"
+         :os-arch ;; "amd64"
+         :java-runtime-name ;; "OpenJDK Runtime Environment"
+         :java-vm-name ;; "OpenJDK 64-Bit Server VM"
+         :java-version ;; "11.0.10"
+         :java-vendor-url ;; "https://openjdk.java.net/"
+         :java-version-date ;; "2021-01-19"
+         :java-awt-graphicsenv ;; "sun.awt.X11GraphicsEnvironment"
+         :gtk-modules ;; "canberra-gtk-module"
+         :xdg-session-desktop ;; "notion"
+         ]
+
+        adhoc-vars {:strongbox-version (strongbox-version)}
+        vars (merge adhoc-vars (System/getProperties) @envvar.core/env)]
+    (run! #(info (format "%s=%s" (name %) (get vars %))) (into useful-envvars useful-props))))
 
 ;;
 

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -99,7 +99,7 @@
     ;; use the file on disk if it's not too old ...
     (if (fresh-cache-file-exists? output-file)
       (do
-        (debug "cache hit for:" url "(" output-file ")")
+        (debug (format "cache hit for: %s (%s)" url output-file))
         output-file)
 
       ;; ... otherwise, we must sing and dance

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -8,7 +8,6 @@
    [clojure.string :refer [lower-case]]
    [me.raynes.fs :as fs]
    [strongbox
-    [logging :as logging]
     [core :as core]
     [utils :as utils :refer [in?]]]
    [gui.diff :refer [with-gui-diff]]
@@ -35,7 +34,7 @@
 
 ;; initial logging setup.
 ;; default log level should be :info before anything starts logging.
-(logging/reset-logging! core/testing?)
+(core/reset-logging!)
 
 (defn jfx
   "dynamically resolve the `strongbox.ui.jfx` ns and call the requisite `action`.
@@ -96,7 +95,7 @@
                   ;;main/profile? true
                   ;;main/spec? true
                   ]
-      (logging/reset-logging! core/testing?)
+      (core/reset-logging!)
 
       (if ns-kw
         (if (some #{ns-kw} [:main :utils :http :tags
@@ -115,7 +114,7 @@
       ;; use case: we run the tests from the repl and afterwards we call `restart` to start the app.
       ;; `stop` inside `restart` will be outside of `with-redefs` and still have logging `:min-level` set to `:debug`
       ;; it will dump a file and yadda yadda.
-      (logging/reset-logging! core/testing?))))
+      (core/reset-logging!))))
 
 ;;
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -134,11 +134,11 @@
 
 (defn init-ui-logger
   []
-  (logging/reset-logging! core/testing? core/state (core/selected-addon-dir))
+  (core/reset-logging!)
   (core/state-bind
    [:cfg :selected-addon-dir]
    (fn [new-state]
-     (logging/reset-logging! core/testing? core/state (core/selected-addon-dir new-state)))))
+     (core/reset-logging!))))
 
 (defn-spec set-preference nil?
   "updates a user preference `preference-key` with given `preference-val` and saves the settings"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -2,7 +2,7 @@
   (:require
    [me.raynes.fs :as fs]
    [clojure.string :refer [lower-case join capitalize replace] :rename {replace str-replace}]
-   [taoensso.timbre :as timbre :refer [spy info debug warn error]]
+   [taoensso.timbre :as timbre :refer [spy]] ;; info debug warn error]]
    [cljfx.ext.table-view :as fx.ext.table-view]
    [cljfx.lifecycle :as fx.lifecycle]
    [cljfx.component :as fx.component]
@@ -1386,8 +1386,8 @@
                                                      (switch-tab-latest))
                                                  (let [remaining-seconds (- 60 (-> (Calendar/getInstance) (.get Calendar/SECOND)))]
                                                    (if (> remaining-seconds 1)
-                                                     (warn (format "self destruction in T-minus %s seconds" remaining-seconds))
-                                                     (error "fah-wooosh ... BOOOOOO ... /oh the humanity/ ... OOOOOOHHHMMM"))))))}))}
+                                                     (timbre/warn (format "self destruction in T-minus %s seconds" remaining-seconds))
+                                                     (timbre/error "fah-wooosh ... BOOOOOO ... /oh the humanity/ ... OOOOOOHHHMMM"))))))}))}
               :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
               :columns (mapv table-column column-list)
               :items (or log-message-list [])}}))
@@ -1835,7 +1835,7 @@
 
 (defn start
   []
-  (info "starting gui")
+  (timbre/info "starting gui")
   (let [;; the gui uses a copy of the application state because the state atom needs to be wrapped
         state-template {:app-state nil,
                         :style (style)}
@@ -1848,7 +1848,6 @@
         _ (doseq [rf [#'style #'major-theme-map #'sub-theme-map #'themes]
                   :let [key (str rf)]]
             (add-watch rf key (fn [_ _ _ _]
-                                (debug "updating gui state")
                                 (swap! gui-state fx/swap-context assoc :style (style))))
             (core/add-cleanup-fn #(remove-watch rf key)))
 
@@ -1905,7 +1904,7 @@
 
 (defn stop
   []
-  (info "stopping gui")
+  (timbre/info "stopping gui")
   (when-let [unmount-renderer (:disable-gui @core/state)]
     ;; only affects tests running from repl apparently
     (unmount-renderer))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -2,7 +2,8 @@
   (:require
    [me.raynes.fs :as fs]
    [clojure.string :refer [lower-case join capitalize replace] :rename {replace str-replace}]
-   [taoensso.timbre :as timbre :refer [spy]] ;; info debug warn error]]
+   ;; logging in the gui should be avoided as it can lead to infinite loops
+   [taoensso.timbre :as timbre :refer [spy]] ;; info debug warn error]] 
    [cljfx.ext.table-view :as fx.ext.table-view]
    [cljfx.lifecycle :as fx.lifecycle]
    [cljfx.component :as fx.component]

--- a/test/strongbox/logging_test.clj
+++ b/test/strongbox/logging_test.clj
@@ -1,21 +1,74 @@
 (ns strongbox.logging-test
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
-   ;;[strongbox
-    ;;[logging :as logging]
-    ;;[core :as core]]
-   ;;[taoensso.timbre :as timbre :refer [debug info warn error spy]]
+   [strongbox
+    [logging :as logging]
+    [core :as core]]
+   [taoensso.timbre :as timbre]
    [strongbox.test-helper :as helper :refer [with-running-app fixture-path]]))
 
 (use-fixtures :each helper/fixture-tempcwd)
 
-(comment
-  (deftest ui-appender
-    (with-running-app
-      (helper/install-dir) ;; sets the addon dir and the UI appender
-      (let [expected {:log-lines [{:foo :bar}] :log-stats {:bar {:baz :bup}}}]
-        (timbre/log :warn "warning message")
-        (is (= expected (core/get-state :log-lines))))))
+(deftest log-level-while-testing
+  (testing "the log level is set to `:debug` while testing"
+    (is (= :debug (-> timbre/*config* :min-level)))))
 
-  ;;(is (= expected (select-keys (core/get-state) [:log-lines :log-stats]))))))
-  )
+(deftest log-level-while-running-app
+  (testing "the default log level is *always* set to `:debug` while testing, even when running an app"
+    (with-running-app
+      (is (not (= logging/default-log-level (-> timbre/*config* :min-level))))
+      (is (= :debug (-> timbre/*config* :min-level))))))
+
+(deftest changing-log-level-while-testing
+  (let [current-log-level #(-> timbre/*config* :min-level)]
+    (testing "it is possible to change the log level while testing"
+      (core/change-log-level! :warn)
+      (is (= :warn (current-log-level))))
+
+    (testing "it will revert to `:debug` on `start` and `restart` however"
+      (is (= :warn (current-log-level)))
+      (with-running-app
+        (is (= :debug (current-log-level)))
+        (core/change-log-level! :warn)
+        (is (= :warn (current-log-level)))))
+
+    (testing "it will also revert when changing the addon dir"
+      (with-running-app
+        (is (= :debug (current-log-level)))
+        (core/change-log-level! :warn)
+        (is (= :warn (current-log-level)))
+        (helper/install-dir)
+        (is (= :debug (current-log-level)))))))
+
+(deftest stateful-logging--no-state
+  (testing "stateful logging just needs a place to store it's log lines"
+    (timbre/warn "some test message")
+    (is (nil? (-> @core/state :log-lines)))))
+
+(deftest stateful-logging--basic
+  (testing "stateful logging just needs a place to store it's log lines"
+    (with-running-app
+      (timbre/warn "some test message")
+      (let [expected {:level :warn, :message "some test message", :source {:install-dir nil}}
+            actual (->> (core/get-state :log-lines) (filter #(= :warn (:level %))) last)
+            actual (dissoc actual :time)]
+        (is (= expected actual))))))
+
+(deftest stateful-logging--basic-w.addon
+  (testing "addon logging is possible without a selected addon directory, but you probably want to avoid it"
+    (with-running-app
+      (logging/addon-log {:dirname "EveryAddon"} :warn "some test message")
+      (let [expected {:level :warn, :message "some test message", :source {:install-dir nil, :dirname "EveryAddon"}}
+            actual (->> (core/get-state :log-lines) (filter #(= :warn (:level %))) last)
+            actual (dissoc actual :time)]
+        (is (= expected actual))))))
+
+(deftest stateful-logging--addon-dir-w.addon
+  (testing "addon logging is possible without a selected addon directory, but you probably want to avoid it"
+    (with-running-app
+      (let [install-dir (helper/install-dir)
+            expected {:level :warn, :message "some test message", :source {:install-dir install-dir, :dirname "EveryAddon"}}
+            _ (logging/addon-log {:dirname "EveryAddon"} :warn "some test message")
+            actual (->> (core/get-state :log-lines) (filter #(= :warn (:level %))) last)
+            actual (dissoc actual :time)]
+        (is (= expected actual))))))

--- a/test/strongbox/logging_test.clj
+++ b/test/strongbox/logging_test.clj
@@ -15,13 +15,7 @@
       (helper/install-dir) ;; sets the addon dir and the UI appender
       (let [expected {:log-lines [{:foo :bar}] :log-stats {:bar {:baz :bup}}}]
         (timbre/log :warn "warning message")
-        (is (= expected (core/get-state :log-lines)))
-        (is (= expected (-> timbre/*config*
-                            :appenders
-                            :atom
-                            :atm
-                            deref
-                            (select-keys [:log-lines :log-stats])))))))
+        (is (= expected (core/get-state :log-lines))))))
 
   ;;(is (= expected (select-keys (core/get-state) [:log-lines :log-stats]))))))
   )


### PR DESCRIPTION
* logging, worked around issue with timbre 'timbre/with-config' and mutable 'timbre/*config* causing much Weirdness.
* core/reset-logging now brings all logging back into a predictable state.

- [x] fixed missing version from debug output when run as a binary
- [x] review
- [x] changelog
