### PR TITLE
WoW Classic - The Burning Crusade support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## 4.1.0
+
+### Added
+
+* a 'welcome' screen for instances of strongbox with no addon directories selected.
+* 'Classic (TBC)' game track
+
+### Changed
+
+* replaced the 'any, prefer retail' and 'any, prefer classic' in the game track list with a 'strict' checkbox.
+    - 'any, prefer retail' is now just 'retail' and 'not strict'
+    - 'any, prefer classic' is now just 'classic' and 'not strict'
+* the follow widgets and featuers are now disabled if no addon directory is selected:
+    - the search tab
+    - the game track drop down
+    - the addon directory drop down
+    - 
+
+### Fixed
+
+### Removed
+
 ## 4.0.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -131,17 +131,21 @@ bug. *Some* of the details it contains are:
 
 ### classic and retail addon support
 
-Addon developers, addon hosts and addon managers all scrambled to accommodate 'classic' WoW when it was released.
+Classic, Classic (The Burning Crusade) and Retail versions of WoW are all distinct addon systems.
 
-Addons for 'classic' WoW are not the same as very old addons for vanilla WoW. 
+Some addons support all versions in a single download, some support classic as an alternate release of the same addon, some addons support classic only, some addons have been split up into multiple addons.
 
-Some addons support both retail and classic in a single download, some support classic as an 'alternate' download, some support classic only or vice versa, some addons have been split into two.
-
-Click the drop-down next to your addon directory and select either `retail` or `classic` or `any, prefer retail` or `any, prefer classic`.
+Click the drop-down next to your addon directory and select either `retail`, `classic` or `classic (TBC)`.
 
 This will restrict the types of addons that can be installed in the current addon directory. 
 
-The last two options allow you to mix classic and retail addons together in the same addon directory. If an addon is available for both retail and classic it will prefer one over the other.
+The `Strict` checkbox allows you to relax restrictions and mix addons means for different addon systems together in the same addon directory. If an addon is available for multiple addon systems it will prefer one over the other:
+
+* `retail` will prefer `retail` addons, then `classic`, then `classic (TBC)`
+* `classic` will prefer `classic` addons, then `classic (TBC)` then `retail`
+* `classic (TBC)` will prefer `classic (TBC)` addons, then `classic`, then `retail`
+
+If in doubt which addon system an installed addon supports, look at the value in `WoW` column on the `installed` tab and compare it to the `Version` value in the list of WoW [public client builds](https://wowpedia.fandom.com/wiki/Public_client_builds).
 
 ### catalogue search
 

--- a/README.md
+++ b/README.md
@@ -131,21 +131,24 @@ bug. *Some* of the details it contains are:
 
 ### classic and retail addon support
 
-Classic, Classic (The Burning Crusade) and Retail versions of WoW are all distinct addon systems.
+"Classic", "Classic (The Burning Crusade)" and "Retail" versions of WoW are all distinct addon systems.
 
-Some addons support all versions in a single download, some support classic as an alternate release of the same addon, some addons support classic only, some addons have been split up into multiple addons.
+Some addons support all systems in a single download, some support classic as an alternate release of the same addon, 
+some addons support classic only, some addons have been split up into multiple addons. There is a lot of variation.
 
 Click the drop-down next to your addon directory and select either `retail`, `classic` or `classic (TBC)`.
 
 This will restrict the types of addons that can be installed in the current addon directory. 
 
-The `Strict` checkbox allows you to relax restrictions and mix addons means for different addon systems together in the same addon directory. If an addon is available for multiple addon systems it will prefer one over the other:
+The `Strict` checkbox allows you to enforce or relax restrictions and mix together addons meant for different systems in 
+the same addon directory. If an addon is available for multiple addon systems it will prefer one over another:
 
 * `retail` will prefer `retail` addons, then `classic`, then `classic (TBC)`
 * `classic` will prefer `classic` addons, then `classic (TBC)` then `retail`
 * `classic (TBC)` will prefer `classic (TBC)` addons, then `classic`, then `retail`
 
-If in doubt which addon system an installed addon supports, look at the value in `WoW` column on the `installed` tab and compare it to the `Version` value in the list of WoW [public client builds](https://wowpedia.fandom.com/wiki/Public_client_builds).
+If in doubt which addon system an installed addon supports, look at the value in `WoW` column on the `installed` tab and 
+compare it to the `Version` value in the list of WoW [public client builds](https://wowpedia.fandom.com/wiki/Public_client_builds).
 
 ### catalogue search
 
@@ -161,15 +164,20 @@ When you search for an addon you are searching a list of thousands of addons tha
 
 Click `Catalogue` from the top menu and choose your preferred catalogue.
 
-The default catalogue is the 'short' catalogue. It contains all addons from all supported hosts that have been *updated* since *the beginning of the previous expansion*. This is currently Battle For Azeroth, released 2018-08-14 and the catalogue has approximately 7.5k addons.
+The default catalogue is the 'short' catalogue. It contains all addons from all supported hosts that have been *updated* 
+since *the beginning of the previous expansion*. This is currently Battle For Azeroth, released 2018-08-14 and the 
+catalogue has approximately 7.5k addons.
 
-The 'full' catalogue contains all addons from all supported hosts, ever, and is approximately 15.3k addons large. It contains many addons that haven't been updated in years.
+The 'full' catalogue contains all addons from all supported hosts, ever, and is approximately 15.3k addons large. It 
+contains many addons that haven't been updated in years.
 
 There are also per-host catalogues, like a 'curseforge' catalogue, and strongbox supports selecting between all of them.
 
 Catalogues are updated weekly.
 
-The 'user' catalogue is a little different. It's initially empty but grows as addons are imported from hosts like Github. These addons also appear in search results. Individual addons from the user catalogue are checked for new releases normally, but the catalogue itself can only be updated manually.
+The 'user' catalogue is a little different. It's initially empty but grows as addons are imported from hosts like Github. 
+These addons also appear in search results. Individual addons from the user catalogue are checked for new releases 
+normally, but the catalogue itself can only be updated manually.
 
 Click `Catalogue` from the top menu and select `Refresh user catalogue`.
 
@@ -225,7 +233,8 @@ It is up to the user to decide if this is OK or not.
 
 ### ignore addons to prevent accidental changes
 
-When an addon is ignored strongbox will not attempt to find that addon in the catalogue, look for or download updates or even allow the installation of other addons that may alter the ignored addon or any of its files.
+When an addon is ignored strongbox will not attempt to find that addon in the catalogue, look for or download updates or 
+even allow the installation of other addons that may alter the ignored addon or any of its files.
 
 Right-click an addon and select `Ignore` or `Stop ignoring`.
 
@@ -233,15 +242,18 @@ Addons under development are automatically ('implicitly') ignored.
 
 ### mutual dependency tracking
 
-A 'mutual dependency' in strongbox is when 'Addon A' installs an addon called 'Addon Z' and 'Addon B' *also* installs 'Addon Z'.
+A 'mutual dependency' in strongbox is when 'Addon A' installs an addon called 'Addon Z' and 'Addon B' *also* installs 
+'Addon Z'.
 
 Both 'Addon A' and 'Addon B' depend on 'Addon Z' and if 'Addon A' were uninstalled it would (probably) break 'Addon B'.
 
-In this scenario strongbox allows 'Addon B' to overwrite 'Addon Z' but keeps track of the fact that 'Addon A' is also using it. When either 'Addon A' or 'Addon B' are uninstalled, 'Addon Z' is preserved.
+In this scenario strongbox allows 'Addon B' to overwrite 'Addon Z' but keeps track of the fact that 'Addon A' is also 
+using it. When either 'Addon A' or 'Addon B' are uninstalled, 'Addon Z' is preserved.
 
 The state of 'Addon Z' isn't guaranteed however. 
 
-'Addon A' may install a very old 'Addon Z' while 'Addon B' overwrites that with a brand new version. 'Addon A' is now using a different version of 'Addon Z' than it expects. Or vice versa. 
+'Addon A' may install a very old 'Addon Z' while 'Addon B' overwrites that with a brand new version. 'Addon A' is now 
+using a different version of 'Addon Z' than it expects. Or vice versa. 
 
 It's messy but only one 'Addon Z' can exist at a time.
 
@@ -262,13 +274,15 @@ Once an addon has been installed it can be 'pinned' to that specific release lik
 
 Right-click an addon and select `Pin release`.
 
-Pinned addons won't be marked as having updates available and other addons won't be able to overwrite the files of a pinned addon.
+Pinned addons won't be marked as having updates available and other addons won't be able to overwrite the files of a 
+pinned addon.
 
 ## Misc
 
-Original Swing GUI was last available in v3 using: `./strongbox --ui gui1`
+Original Swing GUI was last available in version 3.x using: `./strongbox --ui gui1`
 
-Prior to `1.0.0`, `strongbox` was known as `wowman`. The [AUR package](https://aur.archlinux.org/packages/wowman) for `wowman` is obsolete.
+Prior to `1.0.0`, `strongbox` was known as `wowman`. The [AUR package](https://aur.archlinux.org/packages/wowman) for 
+`wowman` is obsolete.
 
 User configuration is stored in `~/.config/strongbox` unless run with the envvar `$XDG_CONFIG_HOME` set.
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,8 @@ see CHANGELOG.md for a more formal list of changes by release
 * add support for classic TBC and classic WOTLK and classic Cataclysm
     - really, just figure out a way to support N game tracks with strict/relaxed installation rules
 
+* wowi, add classic-tbc detection
+
 ## todo bucket (no particular order)
 
 * search, comma separate download numbers

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,11 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * wowi, add classic-tbc detection
 
+* tukui, add classic-tbc detection
+
 ## todo bucket (no particular order)
+
+* bug, uber button, identical addons in different addon dirs are causing the warn/error-free version to show warns/errors
 
 * search, comma separate download numbers
     - or figure out the locale-specific separator

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -47,10 +47,9 @@
 
 (defn-spec expand-summary (s/or :ok :addon/expanded, :error nil?)
   "fetches updates from the addon host for the given `addon` and `game-track`.
-  when `:strict?` is false, classic game tracks prefer themselves then each other before retail. 
-  retail prefers retail, then classic then classic-tbc etc.
+  when `strict?` is `false` and an addon fails to match for the given `game-track`, other game tracks will be checked.
   emits warnings to user when no release found."
-  [addon :addon/expandable, game-track :addon-dir/game-track, strict? boolean?]
+  [addon :addon/expandable, game-track :addon-dir/game-track, strict? ::sp/strict?]
   (if-let [source-updates
            (case [game-track strict?]
              [:retail true] (-expand-summary addon :retail)

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -49,20 +49,36 @@
   "fetches updates from the addon host for the given `addon` and `game-track`.
   supports compound game tracks like `:retail-classic` and `:classic-retail`.
   emits warnings to user when no release found."
-  [addon :addon/expandable, game-track :addon-dir/game-track]
+  [addon :addon/expandable, game-track :addon-dir/game-track, lenient? boolean?]
   (if-let [source-updates
-           (case game-track
-             :retail (-expand-summary addon :retail)
-             :classic (-expand-summary addon :classic)
-             :retail-classic (or
-                              (-expand-summary addon :retail)
-                              (-expand-summary addon :classic))
-             :classic-retail (or
-                              (-expand-summary addon :classic)
-                              (-expand-summary addon :retail)))]
+           (case [game-track lenient?]
+             [:retail false] (-expand-summary addon :retail)
+             [:classic false] (-expand-summary addon :classic)
+             [:classic-tbc false] (-expand-summary addon :classic-tbc)
+
+             [:retail true]
+             (or
+              (-expand-summary addon :retail)
+              (-expand-summary addon :classic)
+              (-expand-summary addon :classic-tbc))
+             
+             [:classic true]
+             (or
+              (-expand-summary addon :classic)
+              (-expand-summary addon :classic-tbc)
+              (-expand-summary addon :retail))
+
+             [:classic-tbc true]
+             (or
+              (-expand-summary addon :classic-tbc)
+              (-expand-summary addon :classic)
+              (-expand-summary addon :retail))
+             
+             )]
     source-updates
 
-    (let [;; "no release found for 'adibags' (retail) on github"
+    (let [;; todo: revisit this error message
+          ;; "no release found for 'adibags' (retail) on github"
           ;; "no release found for 'adibags' (retail or classic) on github"
           track-list (-> game-track name (clojure.string/split #"-"))
           track-list (clojure.string/join " or " track-list)]

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -55,7 +55,6 @@
              [:retail true] (-expand-summary addon :retail)
              [:classic true] (-expand-summary addon :classic)
              [:classic-tbc true] (-expand-summary addon :classic-tbc)
-
              [:retail false]
              (or
               (-expand-summary addon :retail)
@@ -79,12 +78,14 @@
     (let [;; todo: revisit this error message
           ;; "no release found for 'adibags' (retail) on github"
           ;; "no release found for 'adibags' (retail or classic) on github"
-          track-list (-> game-track name (clojure.string/split #"-"))
-          track-list (clojure.string/join " or " track-list)]
-      (warn (format "no release found for '%s' (%s) on %s"
-                    (:name addon)
-                    track-list
-                    (:source addon))))))
+          msg (case [game-track strict?]
+                [:retail true] "no release found for '%s' (retail) on %s"
+                [:classic true] "no release found for '%s' (classic) on %s"
+                [:classic-tbc true] "no release found for '%s' (classic - TBC) on %s"
+                [:retail false] "no release found for '%s' (retail, classic or classic -TBC) on %s"
+                [:classic false] "no release found for '%s' (classic, classic - TBC or retail) on %s"
+                [:classic-tbc false] "no release found for '%s' (classic - TBC, classic or retail) on %s")]
+      (warn (format msg (:name addon) (:source addon))))))
 
 
 ;;

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -47,34 +47,34 @@
 
 (defn-spec expand-summary (s/or :ok :addon/expanded, :error nil?)
   "fetches updates from the addon host for the given `addon` and `game-track`.
-  supports compound game tracks like `:retail-classic` and `:classic-retail`.
+  when `:strict?` is false, classic game tracks prefer themselves then each other before retail. 
+  retail prefers retail, then classic then classic-tbc etc.
   emits warnings to user when no release found."
-  [addon :addon/expandable, game-track :addon-dir/game-track, lenient? boolean?]
+  [addon :addon/expandable, game-track :addon-dir/game-track, strict? boolean?]
   (if-let [source-updates
-           (case [game-track lenient?]
-             [:retail false] (-expand-summary addon :retail)
-             [:classic false] (-expand-summary addon :classic)
-             [:classic-tbc false] (-expand-summary addon :classic-tbc)
+           (case [game-track strict?]
+             [:retail true] (-expand-summary addon :retail)
+             [:classic true] (-expand-summary addon :classic)
+             [:classic-tbc true] (-expand-summary addon :classic-tbc)
 
-             [:retail true]
+             [:retail false]
              (or
               (-expand-summary addon :retail)
               (-expand-summary addon :classic)
               (-expand-summary addon :classic-tbc))
-             
-             [:classic true]
+
+             [:classic false]
              (or
               (-expand-summary addon :classic)
               (-expand-summary addon :classic-tbc)
               (-expand-summary addon :retail))
 
-             [:classic-tbc true]
+             [:classic-tbc false]
              (or
               (-expand-summary addon :classic-tbc)
               (-expand-summary addon :classic)
-              (-expand-summary addon :retail))
-             
-             )]
+              (-expand-summary addon :retail)))]
+
     source-updates
 
     (let [;; todo: revisit this error message

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -47,8 +47,10 @@
     ;; finally, ensure :install-dir is absent from whatever we return
     (dissoc cfg :install-dir)))
 
-(defn convert-compound-game-track
-  [game-track]
+(defn-spec convert-compound-game-track ::sp/game-track
+  "takes any game track, new or old, and returns the new version.
+  for example: `:classic` => `:classic` and `:classic-retail` => `:classic`"
+  [game-track (s/or :new-game-track ::sp/game-track, :old-game-track ::sp/old-game-track)]
   (if (some #{game-track} sp/old-game-tracks)
     (-> game-track name (clojure.string/split #"\-") first keyword)
     game-track))
@@ -60,10 +62,10 @@
   (if-let [addon-dir-list (:addon-dir-list cfg)]
     (let [updater (fn [addon-dir-map]
                     (merge addon-dir-map
+                           ;; a :game-track will always be present. see `handle-install-dir`
                            {:game-track (convert-compound-game-track (:game-track addon-dir-map))
                             :strict? (get addon-dir-map :strict?
                                           (not (utils/in? (:game-track addon-dir-map) sp/old-game-tracks)))}))]
-      ;;(update cfg :addon-dir-list (mapv updater)) ;; would this work?
       (assoc cfg :addon-dir-list (mapv updater addon-dir-list)))
     cfg))
 

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -4,6 +4,7 @@
    [clojure.set]
    [orchestra.core :refer [defn-spec]]
    [taoensso.timbre :as timbre :refer [debug info warn error spy]]
+   [clojure.string]
    [strongbox
     [specs :as sp]
     [utils :as utils]]))
@@ -46,9 +47,11 @@
     ;; finally, ensure :install-dir is absent from whatever we return
     (dissoc cfg :install-dir)))
 
-(defn split-compound-game-track
+(defn convert-compound-game-track
   [game-track]
-  (-> game-track name (clojure.string/split #"\-") first keyword))
+  (if (some #{game-track} sp/old-game-tracks)
+    (-> game-track name (clojure.string/split #"\-") first keyword)
+    game-track))
 
 (defn handle-compound-game-tracks
   "addon game track leniency is now handled through a flag rather than encoded into the game track.
@@ -61,7 +64,7 @@
     ;; we have addon dirs
     (let [updater (fn [addon-dir-map]
                     (merge addon-dir-map
-                           {:game-track (split-compound-game-track (:game-track addon-dir-map))
+                           {:game-track (convert-compound-game-track (:game-track addon-dir-map))
                             :strict? (get addon-dir-map :strict?
                                           (not (utils/in? (:game-track addon-dir-map) sp/old-game-tracks)))}))]
       ;;(update cfg :addon-dir-list (mapv updater)) ;; would this work?

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -46,6 +46,19 @@
     ;; finally, ensure :install-dir is absent from whatever we return
     (dissoc cfg :install-dir)))
 
+(defn handle-lenient-game-tracks
+  "addon game track leniency is now handled through a flag rather than encoded into the game track.
+  default is `False`.
+  `:classic-retail` becomes `:classic` and lenient.
+  `:retail-classic` becomes `:retail` and lenient, etc."
+  [cfg]
+  (if-let [addon-dir-list (:addon-dir-list cfg)]
+    (let [updater (fn [addon-dir-map]
+                    (assoc addon-dir-map :lenient? (get addon-dir-map :lenient? false)))]
+      ;;(update cfg :addon-dir-list (mapv updater)) ;; would this work?
+      (assoc cfg :addon-dir-list (mapv updater addon-dir-list)))
+    cfg))
+
 (defn-spec valid-catalogue-location? boolean?
   "returns true if given `catalogue-location` is a valid `:catalogue/location`"
   [catalogue-location any?]
@@ -110,6 +123,7 @@
   (let [cfg (-> cfg-a
                 (merge cfg-b)
                 handle-install-dir
+                handle-lenient-game-tracks
                 remove-invalid-addon-dirs
                 handle-selected-addon-dir
                 remove-invalid-catalogue-location-entries

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -54,14 +54,10 @@
     game-track))
 
 (defn handle-compound-game-tracks
-  "addon game track leniency is now handled through a flag rather than encoded into the game track.
-  default is `False`.
-  `:classic` stays `:classic` but gets a strict flag.
-  `:classic-retail` becomes `:classic` and lenient.
-  `:retail-classic` becomes `:retail` and lenient, etc."
+  "addon game track leniency is now handled through the flag `strict?` rather than encoded into the game track.
+  default strictness is `true`."
   [cfg]
   (if-let [addon-dir-list (:addon-dir-list cfg)]
-    ;; we have addon dirs
     (let [updater (fn [addon-dir-map]
                     (merge addon-dir-map
                            {:game-track (convert-compound-game-track (:game-track addon-dir-map))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -282,9 +282,10 @@
   ([]
    (when-let [addon-dir (selected-addon-dir)]
      (addon-dir-map addon-dir)))
-  ([addon-dir ::sp/addon-dir]
+  ([addon-dir (s/nilable ::sp/addon-dir)]
    (let [addon-dir-list (get-state :cfg :addon-dir-list)]
-     (when-not (empty? addon-dir-list)
+     (when (and addon-dir
+                (not (empty? addon-dir-list)))
        (first (filter #(= addon-dir (:addon-dir %)) addon-dir-list))))))
 
 (defn-spec set-game-track! nil?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -310,9 +310,10 @@
    (when addon-dir
      (-> addon-dir addon-dir-map :game-track))))
 
-(defn-spec get-game-track-strictness ::sp/strict?
+(defn-spec get-game-track-strictness (s/or :addon-dir ::sp/strict?, :no-addon-dir nil?)
   []
-  (get (addon-dir-map) :strict? true))
+  (when-let [addon-dir-map (addon-dir-map)]
+    (get addon-dir-map :strict? default-game-track-strictness)))
 
 ;; todo: this is almost identical with `get-game-track`.
 ;; come up with a better solution if we repeat ourselves again.

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -305,7 +305,8 @@
    (when addon-dir
      (-> addon-dir addon-dir-map :game-track))))
 
-(defn-spec get-lenient-game-track ::sp/lenient-game-track
+;;(defn-spec get-lenient-game-track ::sp/lenient-game-track
+(defn get-lenient-game-track
   "returns the lenient/compound version of the currently selected game track. 
   if `:retail` then `:retail-classic`, etc"
   []
@@ -983,7 +984,11 @@
         ;; when no game-track is present in the export record, use the more lenient
         ;; version of the currently selected game track.
         ;; it's better to have an addon installed with the incorrect game track then missing addons.
-        default-game-track (get-lenient-game-track)]
+        ;;default-game-track (get-lenient-game-track)
+
+        ;; todo: set leniency flag to true
+        default-game-track :retail
+        ]
 
     (binding [http/*cache* (cache)]
       (doseq [addon matching-addon-list

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -74,6 +74,7 @@
 ;; needed to update config
 (def old-game-tracks #{:retail-classic, :classic-retail})
 
+(s/def ::old-game-track old-game-tracks)
 (s/def ::game-track game-tracks)
 (s/def ::installed-game-track ::game-track) ;; alias
 (s/def ::game-track-list (s/coll-of ::game-track :kind vector? :distinct true))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -63,9 +63,9 @@
 (s/def ::log-level #{:debug :info :warn :error})
 
 ;; preserve order here
-(def game-track-labels [[:retail "WoW Retail"]
-                        [:classic "WoW Classic"]
-                        [:classic-tbc "WoW Classic - The Burning Crusade"]
+(def game-track-labels [[:retail "Retail"]
+                        [:classic "Classic"]
+                        [:classic-tbc "Classic (TBC)"]
                         ;;[:classic-wotlk "WoW Classic - Wrath of the Lich King"]
                         ])
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -62,24 +62,30 @@
 (s/def ::closable? boolean?)
 (s/def ::log-level #{:debug :info :warn :error})
 
-;; preserve order, used in GUI
-(def game-track-labels [[:retail "retail"]
-                        [:classic "classic"]])
-(def selectable-game-track-labels (into game-track-labels
-                                        [[:retail-classic "any, prefer retail"]
-                                         [:classic-retail "any, prefer classic"]]))
+;; preserve order here
+(def game-track-labels [[:retail "WoW Retail"]
+                        [:classic "WoW Classic"]
+                        [:classic-tbc "WoW Classic - The Burning Crusade"]
+                        ;;[:classic-wotlk "WoW Classic - Wrath of the Lich King"]
+                        ])
 
-(def selectable-game-track-labels-map (into {} selectable-game-track-labels))
-(def selectable-game-track-labels-map-inv (map-invert selectable-game-track-labels))
+(def game-track-labels-map (into {} game-track-labels)) ;; {:retail "WoW Retail", ...}
+(def game-track-labels-map-inv (map-invert game-track-labels)) ;; {"WoW Retail" :retail, ...}
+(def game-tracks (->> game-track-labels-map keys set)) ;; #{:retail, :classic, ...}
 
-(def game-tracks (->> game-track-labels (into {}) keys set))
-(def selectable-game-tracks (->> selectable-game-track-labels (into {}) keys set))
-(def lenient-game-tracks #{:retail-classic :classic-retail})
+;; needed to update config
+(def old-game-tracks (into game-tracks #{:retail-classic, :classic-retail}))
+
+
 
 (s/def ::game-track game-tracks)
 (s/def ::installed-game-track ::game-track) ;; alias
-(s/def ::lenient-game-track lenient-game-tracks)
 (s/def ::game-track-list (s/coll-of ::game-track :kind vector? :distinct true))
+
+(s/def ::lenient? boolean?)
+
+;; ---
+
 (s/def ::download-count (s/and int? #(>= % 0)))
 (s/def ::ignore? boolean?)
 (s/def ::ignore-flag (s/keys :req-un [::ignore?]))
@@ -112,10 +118,9 @@
 
 ;; user config
 
-;; the game tracks *selectable by the user* are mapped to a simpler set internally
-(s/def :addon-dir/game-track selectable-game-tracks)
+(s/def :addon-dir/game-track game-tracks)
 (s/def ::addon-dir ::extant-dir)
-(s/def ::addon-dir-map (s/keys :req-un [::addon-dir :addon-dir/game-track]))
+(s/def ::addon-dir-map (s/keys :req-un [::addon-dir :addon-dir/game-track ::lenient?]))
 (s/def ::addon-dir-list (s/coll-of ::addon-dir-map))
 (s/def ::selected-catalogue keyword?)
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -74,15 +74,13 @@
 (def game-tracks (->> game-track-labels-map keys set)) ;; #{:retail, :classic, ...}
 
 ;; needed to update config
-(def old-game-tracks (into game-tracks #{:retail-classic, :classic-retail}))
-
-
+(def old-game-tracks #{:retail-classic, :classic-retail})
 
 (s/def ::game-track game-tracks)
 (s/def ::installed-game-track ::game-track) ;; alias
 (s/def ::game-track-list (s/coll-of ::game-track :kind vector? :distinct true))
 
-(s/def ::lenient? boolean?)
+(s/def ::strict? boolean?)
 
 ;; ---
 
@@ -120,7 +118,7 @@
 
 (s/def :addon-dir/game-track game-tracks)
 (s/def ::addon-dir ::extant-dir)
-(s/def ::addon-dir-map (s/keys :req-un [::addon-dir :addon-dir/game-track ::lenient?]))
+(s/def ::addon-dir-map (s/keys :req-un [::addon-dir :addon-dir/game-track ::strict?]))
 (s/def ::addon-dir-list (s/coll-of ::addon-dir-map))
 (s/def ::selected-catalogue keyword?)
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -65,9 +65,7 @@
 ;; preserve order here
 (def game-track-labels [[:retail "Retail"]
                         [:classic "Classic"]
-                        [:classic-tbc "Classic (TBC)"]
-                        ;;[:classic-wotlk "WoW Classic - Wrath of the Lich King"]
-                        ])
+                        [:classic-tbc "Classic (TBC)"]])
 
 (def game-track-labels-map (into {} game-track-labels)) ;; {:retail "WoW Retail", ...}
 (def game-track-labels-map-inv (map-invert game-track-labels)) ;; {"WoW Retail" :retail, ...}

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -31,36 +31,33 @@
   (core/delete-http-cache!)
   (core/check-for-updates))
 
-(defn-spec set-addon-dir! nil?
-  "adds/sets an addon-dir, partial refresh of application state"
-  [addon-dir ::sp/addon-dir]
-  (core/set-addon-dir! addon-dir)
+(defn-spec half-refresh nil?
+  "like core/refresh but focuses on loading+matching+checking for updates"
+  []
   (core/load-installed-addons)
   (core/match-installed-addons-with-catalogue)
   (core/check-for-updates)
   (core/save-settings)
   nil)
 
+(defn-spec set-addon-dir! nil?
+  "adds/sets an addon-dir, partial refresh of application state"
+  [addon-dir ::sp/addon-dir]
+  (core/set-addon-dir! addon-dir)
+  (half-refresh))
+
 (defn-spec set-game-track-strictness! nil?
   "toggles the 'strict' flag for the current addon directory and reloads addons"
   [new-strictness-level ::sp/strict?]
   (core/set-game-track-strictness! new-strictness-level)
-  (core/load-installed-addons)
-  (core/match-installed-addons-with-catalogue)
-  (core/check-for-updates)
-  (core/save-settings)
-  nil)
+  (half-refresh))
 
 (defn-spec remove-addon-dir! nil?
   "deletes an addon-dir, selects first available addon dir, partial refresh of application state"
   []
   (core/remove-addon-dir!)
   ;; the next addon dir is selected, if any
-  (core/load-installed-addons)
-  (core/match-installed-addons-with-catalogue)
-  (core/check-for-updates)
-  (core/save-settings)
-  nil)
+  (half-refresh))
 
 (defn-spec set-catalogue-location! nil?
   "changes the catalogue and refreshes application state.

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -41,6 +41,16 @@
   (core/save-settings)
   nil)
 
+(defn-spec set-game-track-strictness! nil?
+  "toggles the 'strict' flag for the current addon directory and reloads addons"
+  [new-strictness-level ::sp/strict?]
+  (core/set-game-track-strictness! new-strictness-level)
+  (core/load-installed-addons)
+  (core/match-installed-addons-with-catalogue)
+  (core/check-for-updates)
+  (core/save-settings)
+  nil)
+
 (defn-spec remove-addon-dir! nil?
   "deletes an addon-dir, selects first available addon dir, partial refresh of application state"
   []

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -296,16 +296,17 @@
 
 
                "#update-all-button"
-               {:-fx-min-width "100px"}
+               {:-fx-min-width "110px"}
 
                "#game-track-container "
                {:-fx-alignment "center"
 
                 "#game-track-check-box"
-                {:-fx-padding "0 0 0 1em"}
-               
+                {:-fx-padding "0 0 0 .6em"
+                 :-fx-min-width "60px"}
+
                 "#game-track-combo-box"
-                {:-fx-min-width "100px"}}
+                {:-fx-min-width "150px"}}
 
                ".table-view#installed-addons "
                {".wow-column"
@@ -1072,29 +1073,24 @@
 (defn game-track-dropdown
   [{:keys [fx/context]}]
   (let [selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])
-        key (-> selected-addon-dir core/get-game-track)
-        
+        key (-> selected-addon-dir core/get-game-track)]
 
-        ]
     {:fx/type :h-box
      :id "game-track-container"
-     :children [
-             {:fx/type :combo-box
-              :id "game-track-combo-box"
-              :value (get sp/game-track-labels-map key)
-              :on-value-changed (async-event-handler
-                                 (fn [new-game-track]
+     :children [{:fx/type :combo-box
+                 :id "game-track-combo-box"
+                 :value (get sp/game-track-labels-map key)
+                 :on-value-changed (async-event-handler
+                                    (fn [new-game-track]
                                    ;; todo: push to cli
-                                   (core/set-game-track! (get sp/game-track-labels-map-inv new-game-track))
-                                   (core/refresh)))
-              :items (mapv second sp/game-track-labels)}
+                                      (core/set-game-track! (get sp/game-track-labels-map-inv new-game-track))
+                                      (core/refresh)))
+                 :items (mapv second sp/game-track-labels)}
 
                 {:fx/type :check-box
                  :id "game-track-check-box"
-                 :text "Any"
-
+                 :text "Strict" ;; we need a tooltip to explain this
                  }]}))
-              
 
 (defn installed-addons-menu-bar
   "returns a description of the installed-addons tab-pane menu"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -302,11 +302,11 @@
                {:-fx-alignment "center"
 
                 "#game-track-check-box"
-                {:-fx-padding "0 0 0 .6em"
-                 :-fx-min-width "60px"}
+                {:-fx-padding "0 0 0 .65em"
+                 :-fx-min-width "70px"}
 
                 "#game-track-combo-box"
-                {:-fx-min-width "150px"}}
+                {:-fx-min-width "121px"}}
 
                ".table-view#installed-addons "
                {".wow-column"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -996,7 +996,7 @@
 (defn menu-bar
   "returns a description of the menu at the top of the application"
   [{:keys [fx/context]}]
-  (let [file-menu [(menu-item "_New addon directory" (event-handler wow-dir-picker) {:key "Ctrl+N"})
+  (let [file-menu [(menu-item "_New addon directory" (async-event-handler wow-dir-picker) {:key "Ctrl+N"})
                    (menu-item "Remove addon directory" (async-handler remove-addon-dir))
                    separator
                    (menu-item "_Update all" (async-handler cli/update-all) {:key "Ctrl+U"})
@@ -1073,7 +1073,7 @@
 (defn game-track-dropdown
   [{:keys [fx/context]}]
   (let [selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])
-        key (-> selected-addon-dir core/get-game-track)]
+        key (core/get-game-track selected-addon-dir)]
 
     {:fx/type :h-box
      :id "game-track-container"
@@ -1090,7 +1090,8 @@
                 {:fx/type :check-box
                  :id "game-track-check-box"
                  :text "Strict" ;; we need a tooltip to explain this
-                 }]}))
+                 :selected (core/get-game-track-strictness)
+                 :on-selected-changed (async-event-handler cli/set-game-track-strictness!)}]}))
 
 (defn installed-addons-menu-bar
   "returns a description of the installed-addons tab-pane menu"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1084,13 +1084,16 @@
 (defn game-track-dropdown
   [{:keys [fx/context]}]
   (let [selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])
-        key (core/get-game-track selected-addon-dir)]
+        addon-dir-map (core/addon-dir-map selected-addon-dir)
+        game-track (:game-track addon-dir-map)
+        strict? (get addon-dir-map :strict? core/default-game-track-strictness)
+        tooltip "restrict or relax the installation of addons for specific WoW versions"]
 
     {:fx/type :h-box
      :id "game-track-container"
      :children [{:fx/type :combo-box
                  :id "game-track-combo-box"
-                 :value (get sp/game-track-labels-map key)
+                 :value (get sp/game-track-labels-map game-track)
                  :on-value-changed (async-event-handler
                                     (fn [new-game-track]
                                       ;; todo: push to cli
@@ -1099,14 +1102,16 @@
                  :items (mapv second sp/game-track-labels)
                  :disable (nil? selected-addon-dir)}
 
-                {:fx/type :check-box
-                 :id "game-track-check-box"
-                 :text "Strict" ;; we need a tooltip to explain this
-                 :selected (or (core/get-game-track-strictness)
-                               ;; we need a value regardless of whether an addon directory is selected
-                               core/default-game-track-strictness)
-                 :disable (nil? (core/get-game-track-strictness))
-                 :on-selected-changed (async-event-handler cli/set-game-track-strictness!)}]}))
+                {:fx/type fx.ext.node/with-tooltip-props
+                 :props {:tooltip {:fx/type :tooltip
+                                   :text tooltip
+                                   :show-delay 200}}
+                 :desc {:fx/type :check-box
+                        :id "game-track-check-box"
+                        :text "Strict"
+                        :selected strict?
+                        :disable (nil? (core/get-game-track-strictness))
+                        :on-selected-changed (async-event-handler cli/set-game-track-strictness!)}}]}))
 
 (defn installed-addons-menu-bar
   "returns a description of the installed-addons tab-pane menu"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -298,8 +298,14 @@
                "#update-all-button"
                {:-fx-min-width "100px"}
 
-               "#game-track-combo-box"
-               {:-fx-min-width "100px"}
+               "#game-track-container "
+               {:-fx-alignment "center"
+
+                "#game-track-check-box"
+                {:-fx-padding "0 0 0 1em"}
+               
+                "#game-track-combo-box"
+                {:-fx-min-width "100px"}}
 
                ".table-view#installed-addons "
                {".wow-column"
@@ -1066,16 +1072,29 @@
 (defn game-track-dropdown
   [{:keys [fx/context]}]
   (let [selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])
-        key (-> selected-addon-dir core/get-game-track)]
-    {:fx/type :combo-box
-     :id "game-track-combo-box"
-     :value (get sp/selectable-game-track-labels-map key)
-     :on-value-changed (async-event-handler
-                        (fn [new-game-track]
-                          ;; todo: push to cli
-                          (core/set-game-track! (get sp/selectable-game-track-labels-map-inv new-game-track))
-                          (core/refresh)))
-     :items (mapv second sp/selectable-game-track-labels)}))
+        key (-> selected-addon-dir core/get-game-track)
+        
+
+        ]
+    {:fx/type :h-box
+     :id "game-track-container"
+     :children [
+             {:fx/type :combo-box
+              :id "game-track-combo-box"
+              :value (get sp/game-track-labels-map key)
+              :on-value-changed (async-event-handler
+                                 (fn [new-game-track]
+                                   ;; todo: push to cli
+                                   (core/set-game-track! (get sp/game-track-labels-map-inv new-game-track))
+                                   (core/refresh)))
+              :items (mapv second sp/game-track-labels)}
+
+                {:fx/type :check-box
+                 :id "game-track-check-box"
+                 :text "Any"
+
+                 }]}))
+              
 
 (defn installed-addons-menu-bar
   "returns a description of the installed-addons tab-pane menu"

--- a/test/fixtures/user-config-4.1.json
+++ b/test/fixtures/user-config-4.1.json
@@ -1,0 +1,48 @@
+{
+  "gui-theme": "dark-green",
+  "addon-dir-list": [
+    {
+      "addon-dir": "/tmp/.strongbox-bar",
+      "game-track": "classic-tbc",
+      "strict?": true
+    },
+    {
+      "addon-dir": "/tmp/.strongbox-foo",
+      "game-track": "retail",
+      "strict?": false
+    }
+  ],
+  "selected-addon-dir": "/tmp/.strongbox-foo",
+  "catalogue-location-list": [
+    {
+      "name": "short",
+      "label": "Short (default)",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+    },
+    {
+      "name": "full",
+      "label": "Full",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
+    },
+    {
+      "name": "tukui",
+      "label": "Tukui",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"
+    },
+    {
+      "name": "curseforge",
+      "label": "Curseforge",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"
+    },
+    {
+      "name": "wowinterface",
+      "label": "WoWInterface",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"
+    }
+  ],
+  "selected-catalogue": "full",
+  "preferences":
+  {
+      "addon-zips-to-keep": 3
+  }
+}

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -216,49 +216,53 @@
   (testing "a github 500 (internal server error) response gets a custom message"
     (let [addon {:name "foo" :label "Foo" :source "github" :source-id "1"}
           game-track :retail
+          strict? true
           fake-routes {"https://api.github.com/repos/1/releases"
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
                     "no release found for 'foo' (retail) on github"]]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track))))))))
+        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
 (deftest github-api-500-error
   (testing "a github api 500 (internal server error) response gets a custom message"
     (let [addon {:name "foo" :label "Foo" :source "github" :source-id "1"}
           game-track :retail
+          strict? true
           fake-routes {"https://api.github.com/repos/1/releases"
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
                     "no release found for 'foo' (retail) on github"]]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track))))))))
+        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
 (deftest curseforge-502-bad-gateway
   (testing "a curseforge 502 (bad gateway) response gets a custom message"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "281321"}
           game-track :retail
+          strict? true
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/281321"
                        {:get (fn [req] {:status 502 :reason-phrase "Gateway Time-out (HTTP 502)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 502) (HTTP 502)"
                     "Curseforge: the API is having problems right now. Try again later."
                     "no release found for 'foo' (retail) on curseforge"]]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track))))))))
+        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
 (deftest curseforge-504-gateway-timeout
   (testing "a 504 (gateway timeout) response gets a custom message"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "281321"}
           game-track :retail
+          strict? true
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/281321"
                        {:get (fn [req] {:status 504 :reason-phrase "Gateway Time-out (HTTP 504)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 504) (HTTP 504)"
                     "Curseforge: the API is having problems right now. Try again later."
                     "no release found for 'foo' (retail) on curseforge"]]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track))))))))
+        (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
 ;; retail
 
@@ -266,6 +270,7 @@
   (testing "when just retail is available, use it"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :retail
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--retail.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -280,21 +285,23 @@
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
 
   (testing "when just classic is available, use nothing"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :retail
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--classic.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
           expected nil]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
 
   (testing "when both retail and classic are available, use retail"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :retail
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--retail-AND-classic.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -309,12 +316,13 @@
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track)))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 (deftest expand-summary--retail-then-classic
   (testing "when just classic is available, use it"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
-          game-track :retail-classic
+          game-track :retail
+          strict? false
           response (slurp (fixture-path "curseforge-api-addon--classic.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -329,7 +337,7 @@
                                     :version "2.4.5 (Classic)"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track)))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 ;; classic
 
@@ -337,6 +345,7 @@
   (testing "when just classic is available, use it"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :classic
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--classic.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -351,21 +360,23 @@
                                     :version "2.4.5 (Classic)"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
 
   (testing "when just retail is available, use nothing"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :classic
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--retail.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
           expected nil]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
 
   (testing "when both retail and classic are available, use classic"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
           game-track :classic
+          strict? true
           response (slurp (fixture-path "curseforge-api-addon--retail-AND-classic.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -380,12 +391,13 @@
                                     :version "2.4.5 (Classic)"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track)))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 (deftest expand-summary--classic-then-retail
   (testing "when just retail is available, use it"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
-          game-track :classic-retail
+          game-track :classic
+          strict? false
           response (slurp (fixture-path "curseforge-api-addon--retail.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
                        {:get (fn [req] {:status 200 :body response})}}
@@ -400,13 +412,14 @@
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track)))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 (deftest expand-summary--pinned
   (testing "when an addon is pinned, look for it's release in the list of releases returned from the host"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"
                  :installed-version "1.2.3" :pinned-version "1.2.0"}
           game-track :retail
+          strict? true
           fixture [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
                     :game-track :retail,
                     :interface-version 90000,
@@ -425,12 +438,13 @@
       (with-fake-routes-in-isolation {}
         ;; omg, with-redefs is fantastic
         (with-redefs [strongbox.curseforge-api/expand-summary (constantly fixture)]
-          (is (= expected (catalogue/expand-summary addon game-track)))))))
+          (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
   (testing "when a pinned addon cannot find it's pinned release, use the latest release available"
     (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"
                  :installed-version "0.9.9" :pinned-version "0.9.9"}
           game-track :retail
+          strict? true
           fixture [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
                     :game-track :retail,
                     :interface-version 90000,
@@ -448,4 +462,4 @@
       (with-fake-routes-in-isolation {}
         ;; omg, with-redefs is fantastic
         (with-redefs [strongbox.curseforge-api/expand-summary (constantly fixture)]
-          (is (= expected (catalogue/expand-summary addon game-track))))))))
+          (is (= expected (catalogue/expand-summary addon game-track strict?))))))))

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -161,6 +161,17 @@
                     :selected-addon-dir nil}]
       (is (= expected (config/handle-selected-addon-dir given))))))
 
+(deftest convert-compound-game-track
+  (let [cases [[:retail :retail]
+               [:classic :classic]
+               [:retail-classic :retail]
+               [:classic-retail :classic]
+               [:classic-tbc :classic-tbc]]]
+    (doseq [[given expected] cases]
+      (is (= expected (config/convert-compound-game-track given))))))
+
+;; ---
+
 (deftest load-settings-0.9
   (testing "a standard config file circa 0.9 is loaded and parsed as expected"
     (let [cli-opts {}
@@ -382,6 +393,43 @@
                                 :selected-catalogue :full
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                                :selected-addon-dir "/tmp/.strongbox-foo"
+
+                                ;; new in 1.0
+                                :catalogue-location-list (:catalogue-location-list config/default-cfg)
+
+                                :preferences {:addon-zips-to-keep 3}}
+
+                    :etag-db {}}]
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
+
+(deftest load-settings-4.1
+  (testing "a standard config file circa 4.1 is loaded and parsed as expected"
+    (let [cli-opts {}
+          cfg-file (fixture-path "user-config-4.1.json")
+          etag-db-file (fixture-path "empty-map.json")
+
+          expected {:cfg {:gui-theme :dark-green ;; new in 0.11, `:dark-green` new in 3.2.0
+                          :selected-catalogue :full ;; new in 0.10
+                          ;;:debug? true ;; removed in 0.12
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc :strict? true} ;; `:classic-tbc` and `:strict?` added in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :retail :strict? false}]
+
+                          ;; new in 1.0
+                          :catalogue-location-list (:catalogue-location-list config/default-cfg)
+
+                          ;; new in 0.12
+                          ;; moved to :cfg in 1.0
+                          :selected-addon-dir "/tmp/.strongbox-foo"
+
+                          ;; new in 3.1.0
+                          :preferences {:addon-zips-to-keep 3}}
+
+                    :cli-opts {}
+                    :file-opts {:gui-theme :dark-green
+                                :selected-catalogue :full
+                                :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc, :strict? true}
+                                                 {:addon-dir "/tmp/.strongbox-foo", :game-track :retail, :strict? false}]
                                 :selected-addon-dir "/tmp/.strongbox-foo"
 
                                 ;; new in 1.0

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -122,7 +122,8 @@
                                        :game-track :classic}]}
           expected (assoc config/default-cfg
                           :addon-dir-list [{:addon-dir (str fs/*cwd*)
-                                            :game-track :classic}]
+                                            :game-track :classic
+                                            :strict? true}]
                           :selected-addon-dir (str fs/*cwd*))]
       (is (= expected (config/merge-config file-opts cli-opts))))))
 
@@ -170,8 +171,8 @@
                           :selected-catalogue :short ;; new in 0.10
                           ;; :debug? true ;; removed in 0.12
                           ;; new in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail, :strict? true}
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic, :strict? true}]
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
@@ -199,8 +200,8 @@
           expected {:cfg {:gui-theme :light ;; new in 0.11
                           :selected-catalogue :full ;; new in 0.10
                           ;; :debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail, :strict? true}
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic, :strict? true}]
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
@@ -229,8 +230,8 @@
           expected {:cfg {:gui-theme :dark ;; new in 0.11
                           :selected-catalogue :full ;; new in 0.10
                           ;;:debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail, :strict? true}
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic, :strict? true}]
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
@@ -245,6 +246,7 @@
                     :file-opts {:gui-theme :dark
                                 :selected-catalogue :full
                                 :debug? true
+                                ;; todo: shouldn't these have `:strict?` in them?
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
@@ -259,8 +261,8 @@
           expected {:cfg {:gui-theme :dark ;; new in 0.11
                           :selected-catalogue :full ;; new in 0.10
                           ;;:debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail, :strict? true}
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic, :strict? true}]
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
@@ -288,8 +290,8 @@
           expected {:cfg {:gui-theme :dark ;; new in 0.11
                           :selected-catalogue :full ;; new in 0.10
                           ;;:debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail, :strict? true}
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic, :strict? true}]
 
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
@@ -323,8 +325,9 @@
           expected {:cfg {:gui-theme :dark ;; new in 0.11
                           :selected-catalogue :full ;; new in 0.10
                           ;;:debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic} ;; compound game tracks added in 3.1
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [;;{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic} ;; compound game tracks added in 3.1
+                                           {:addon-dir "/tmp/.strongbox-bar", :game-track :retail :strict? false} ;; compound game tracks removed in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic :strict? true}]
 
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)
@@ -360,8 +363,9 @@
           expected {:cfg {:gui-theme :dark-green ;; new in 0.11, `:dark-green` new in 3.2.0
                           :selected-catalogue :full ;; new in 0.10
                           ;;:debug? true ;; removed in 0.12
-                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic} ;; compound game tracks added in 3.1
-                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
+                          :addon-dir-list [;;{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic} ;; compound game tracks added in 3.1
+                                           {:addon-dir "/tmp/.strongbox-bar", :game-track :retail :strict? false} ;; compound game tracks removed in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :classic :strict? true}]
 
                           ;; new in 1.0
                           :catalogue-location-list (:catalogue-location-list config/default-cfg)

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -95,6 +95,26 @@
         (core/set-addon-dir! dir4)
         (is (= {:addon-dir dir4 :game-track :classic :strict? true} (core/addon-dir-map dir4)))))))
 
+(deftest game-strictness
+  (with-running-app
+    (testing "default strictness for a running app with no addon directory selected is nil"
+      (is (nil? (core/get-game-track-strictness))))
+
+    (testing "setting strictness with no addon directory selected doesn't change a thing"
+      (core/set-game-track-strictness! false)
+      (is (nil? (core/get-game-track-strictness))))
+
+    (helper/install-dir) ;; adds and selects an addon dir
+
+    (testing "default strictness for new addon directories is 'strict' (true)"
+      (is (true? (core/get-game-track-strictness))))
+
+    (testing "strictness can be toggled to 'lenient' (false)"
+      (core/set-game-track-strictness! false)
+      (is (false? (core/get-game-track-strictness)))
+      (core/set-game-track-strictness! true)
+      (is (true? (core/get-game-track-strictness))))))
+
 (deftest catalogue
   (let [[short-catalogue full-catalogue] (take 2 config/-default-catalogue-list)]
     (with-running-app


### PR DESCRIPTION
- [x] config files convert old compound game tracks back to a regular game track + flag
- [x] gui, checkbox for switching flag on or off
- [x] import+export, switch to lenient mode when importing
- [x] can game track labels be shortened?
- [x] don't truncate 'strict' flag
- [x] gap between strict toggle and game track is a few pixels too narrow
- [x] update [README](https://github.com/ogri-la/strongbox#classic-and-retail-addon-support)
- [x] review
- [x] update CHANGELOG