### PR TITLE
github, removes the 'classic' suffix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * GUI now disables some actions when no addon directory is selected.
+* the game track (retail, classic, classic-tbc) + version (1.2.3) is now used to determine if an addon is updateable.
 
 ### Fixed
 
 ### Removed
+
+* github addons will no longer have a `-classic` or `-classic-tbc` suffix.
+    - this was added to differentiate two releases using the same name and version but different game tracks.
+    - strongbox will mark affected addons as being updateable because the versions no longer match. The same version will be re-installed.
 
 ## 4.1.0
 

--- a/TODO.md
+++ b/TODO.md
@@ -9,15 +9,17 @@ see CHANGELOG.md for a more formal list of changes by release
 * gui, disable anything that can't be used when no addon dir selected
     - done
 
+* github, revisit the "-classic" suffix naming
+    - this was solved more elegantly in curseforge-api
+        - actually, this is slightly different
+    - done
+
 ## todo
 
 ux and polish
 
 * ux, installing (not updating) an addon for an incompatible game track shouldn't fail silently or get lost in log noise
     - https://github.com/ogri-la/strongbox/issues/231
-
-* github, revisit the "-classic" suffix naming
-    - this was solved more elegantly in curseforge-api
 
 * bug, uber button, identical addons in different addon dirs are causing the warn/error-free version to show warns/errors
 
@@ -56,6 +58,10 @@ ux and polish
     - update README features
 
 ## todo bucket (no particular order)
+
+* addon detail, 'releases' widget, including *all* possible releases to download and install
+    - add an 'WoW' column to know which game-track/interface
+    - disable releases excluded by selected game-track/strictness setting
 
 * logging, app level 'help'
     - messages to the user that are not informational, or debug or warnings or errors, but simple helpful messages

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -403,17 +403,24 @@
 (defn-spec updateable? boolean?
   "returns `true` when given `addon` can be updated to a newer version."
   [addon map?] ;; deliberately lenient
-  (let [{:keys [installed-version pinned-version version]} addon]
-    (boolean
-     (and version
-          (not (:ignore? addon))
-          (if pinned-version
-            ;; a pinned addon can only be *updated* if its installed version doesn't match its pinned version and it's pinned version matches the available version.
-            (and
-             (not= installed-version pinned-version)
-             (= pinned-version version))
+  (let [{:keys [installed-version pinned-version version
+                game-track installed-game-track]} addon]
+    (cond
+      ;; not expanded
+      (not version) false
 
-            (not= version installed-version))))))
+      ;; ignored
+      (:ignore? addon) false
+
+      ;; pinned
+      ;; a pinned addon can only be *updated* if the version installed doesn't match its pinned version and it's pinned version matches the available version.
+      pinned-version (and (not= pinned-version installed-version)
+                          (= pinned-version version))
+
+      (and game-track installed-game-track) (not= [version game-track]
+                                                  [installed-version installed-game-track])
+
+      :else (not= version installed-version))))
 
 (defn-spec re-installable? boolean?
   "returns `true` if given `addon` can be re-installed to its current `:installed-version`."

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -324,7 +324,10 @@
                  ;; update available, explicitly not being ignored
                  {:installed-version "1.2.0" :version "1.2.3" :ignore? false}
                  ;; update available and pinned version matches available version
-                 {:installed-version "1.2.3" :version "1.2.4" :pinned-version "1.2.4"}]]
+                 {:installed-version "1.2.3" :version "1.2.4" :pinned-version "1.2.4"}
+                 ;; update available with same version but different game track
+                 {:installed-version "1.2.3", :installed-game-track :classic
+                  :version "1.2.3" :game-track :retail}]]
 
       (doseq [addon cases]
         (is (addon/updateable? addon)))))
@@ -341,7 +344,9 @@
                  ;; or `:projectFileId` synthetic `:-unique-name` that we set is changed,
                  ;; or the release is simply deleted I suppose.
                  ;; `catalogue.clj` won't be able to find the pinned release and will use the latest release instead.
-                 {:installed-version "1.2.3" :version "1.2.4" :pinned-version "1.2.3"}]]
+                 {:installed-version "1.2.3" :version "1.2.4" :pinned-version "1.2.3"}
+                 ;; update possibly available but no `:installed-game-track` present
+                 {:installed-version "1.2.3", :version "1.2.3" :game-track :retail}]]
 
       (doseq [addon cases]
         (is (not (addon/updateable? addon)))))))

--- a/test/strongbox/github_api_test.clj
+++ b/test/strongbox/github_api_test.clj
@@ -189,11 +189,11 @@
           game-track :classic
 
           expected [{:download-url "https://github.com/Ravendwyr/Chinchilla/releases/download/v2.10.0/Chinchilla-v2.10.0-classic.zip"
-                     :version "v2.10.0-classic"
-                     :game-track game-track}
+                     :game-track game-track
+                     :version "v2.10.0"}
                     {:download-url "https://github.com/Ravendwyr/Chinchilla/releases/download/v2.10.0-beta3/Chinchilla-v2.10.0-beta3-classic.zip",
-                     :game-track :classic,
-                     :version "v2.10.0-beta3-classic"}]
+                     :game-track game-track,
+                     :version "v2.10.0-beta3"}]
 
           fixture (slurp (fixture-path "github-repo-releases--mixed-game-tracks.json"))
           fake-routes {"https://api.github.com/repos/Ravendwyr/Chinchilla/releases"
@@ -217,10 +217,10 @@
 
           expected [{:download-url "https://github.com/Ravendwyr/Chinchilla/releases/download/v2.10.0/Chinchilla-v2.10.0-classic-tbc.zip",
                      :game-track :classic-tbc,
-                     :version "v2.10.0-classic-tbc"}
+                     :version "v2.10.0"}
                     {:download-url "https://github.com/Ravendwyr/Chinchilla/releases/download/v2.10.0-beta3/Chinchilla-v2.10.0-beta3-classic-tbc.zip",
                      :game-track :classic-tbc,
-                     :version "v2.10.0-beta3-classic-tbc"}]
+                     :version "v2.10.0-beta3"}]
 
           fixture (slurp (fixture-path "github-repo-releases--mixed-game-tracks.json"))
           fake-routes {"https://api.github.com/repos/Foo/Bar/releases"
@@ -290,11 +290,11 @@
 
           game-track :classic
 
-          expected [{:download-url "https://github.com/teelolws/Altoholic-Classic/releases/download/v1.13.2-009/Altoholic.zip",
-                     :game-track :classic,
-                     :version "Teelo's Altoholic Classic Fork-classic"}
-                    {:game-track :classic
-                     :version "Classic-v1.13.6-057-classic"
+          expected [{:game-track game-track
+                     :download-url "https://github.com/teelolws/Altoholic-Classic/releases/download/v1.13.2-009/Altoholic.zip",
+                     :version "Teelo's Altoholic Classic Fork"}
+                    {:game-track game-track
+                     :version "Classic-v1.13.6-057"
                      :download-url "https://github.com/teelolws/Altoholic-Classic/releases/download/Classic-v1.13.6-057/Altoholic-Classic-v1.13.6-057.zip"}]
 
           fake-routes {"https://api.github.com/repos/Bar/Foo/releases"
@@ -341,28 +341,36 @@
 
                  ;; case: game track present in file name, prefer that over `:game-track-list` and any game-track in release name
                  [{} [[:assets 0 :name] "1.2.3-Classic"]
-                  {:classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3-Classic", :game-track :classic, :version "Release 1.2.3-classic" :-mo :track-in-asset-name}]}]
+                  {:classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3-Classic",
+                              :game-track :classic, :version "Release 1.2.3" :-mo :track-in-asset-name}]}]
 
                  ;; case: game track present in release name, prefer that over `:game-track-list`
                  [{} [[:name] "Foo 1.2.3-Classic TBC"]
-                  {:classic-tbc [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :classic-tbc, :version "Foo 1.2.3-Classic TBC-classic-tbc" :-mo :track-in-release-name}]}]
+                  {:classic-tbc [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                                  :game-track :classic-tbc, :version "Foo 1.2.3-Classic TBC" :-mo :track-in-release-name}]}]
 
                  ;; case: no game track present in asset name or release name and no `:game-track-list`. assume `:retail`
                  [{} {}
-                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :retail, :version "Release 1.2.3" :-mo :sa--ngt}]}]
+                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                             :game-track :retail, :version "Release 1.2.3" :-mo :sa--ngt}]}]
 
                  ;; case: no game track present in asset name or release name and just a single entry in `:game-track-list`. use that.
                  [{:game-track-list [:retail]} {}
-                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :retail, :version "Release 1.2.3" :-mo :sa--1gt}]}]
+                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                             :game-track :retail, :version "Release 1.2.3" :-mo :sa--1gt}]}]
                  [{:game-track-list [:classic]} {}
-                  {:classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :classic, :version "Release 1.2.3-classic" :-mo :sa--1gt}]}]
+                  {:classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                              :game-track :classic, :version "Release 1.2.3" :-mo :sa--1gt}]}]
 
                  ;; case: no game track present in asset name or release name with multiple entries in `:game-track-list`.
                  ;; assume all entries in `:game-track-list` supported.
                  [{:game-track-list [:classic-tbc :classic :retail]} {}
-                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :retail, :version "Release 1.2.3" :-mo :sa--Ngt}]
-                   :classic-tbc [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :classic-tbc, :version "Release 1.2.3-classic-tbc" :-mo :sa--Ngt}]
-                   :classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3", :game-track :classic, :version "Release 1.2.3-classic" :-mo :sa--Ngt}]}]]]
+                  {:retail [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                             :game-track :retail, :version "Release 1.2.3" :-mo :sa--Ngt}]
+                   :classic-tbc [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                                  :game-track :classic-tbc, :version "Release 1.2.3" :-mo :sa--Ngt}]
+                   :classic [{:content_type "application/zip", :state "uploaded", :name "1.2.3",
+                              :game-track :classic, :version "Release 1.2.3" :-mo :sa--Ngt}]}]]]
 
       (doseq [[addon-summary-updates, release-updates, expected] cases
               :let [summary (merge addon-summary addon-summary-updates)


### PR DESCRIPTION
I think I introduced it for readability...

- [x] use `:installed game-track` vs `:game-track` when doing the update comparison
- [x] remove suffixes
- [x] review
- [x] update changelog