### PR TITLE
Log level events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* 'report' level log messages.
+    - used to break up and give context to repetitive blocks of log messages.
+    - just 'refresh' for now, logged whenever the list of addons are re-read.
+
 ### Changed
 
 * GUI now disables some actions when no addon directory is selected.
 * the game track (retail, classic, classic-tbc) + version (1.2.3) is now used to determine if an addon is updateable.
+* 'report' level log messages now appear in an addon's notice logger.
+    - used to break up and give context to repetitive blocks of log messages.
 
 ### Fixed
 

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -667,7 +667,6 @@ Additional permission under GNU GPL version 3 section 7
 If you modify this Program, or any covered work, by linking or combining it with any of the below libraries (or a modified version of that library), containing parts covered by the terms of any of the below libraries, the licensors of this Program grant you additional permission to convey the resulting work.
 
 * org.clojure/clojure
-* org.clojure/spec.alpha
 * org.clojure/tools.cli
 * org.clojure/tools.namespace
 * org.clojure/data.json

--- a/TODO.md
+++ b/TODO.md
@@ -14,15 +14,16 @@ see CHANGELOG.md for a more formal list of changes by release
         - actually, this is slightly different
     - done
 
-## todo
-
-ux and polish
-
 * logging, app level 'events' or notices
     - now that the log has been pushed out of the way, it's free to be a bit more verbose
     - some events like refreshing or changing the game track should be logged
     - some of these events should be surfaced in an addon's notice logger
     - should get a different colour in the log
+    - done
+
+## todo
+
+ux and polish
 
 * ux, installing (not updating) an addon for an incompatible game track shouldn't fail silently or get lost in log noise
     - https://github.com/ogri-la/strongbox/issues/231

--- a/TODO.md
+++ b/TODO.md
@@ -18,19 +18,36 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ux and polish
 
+* logging, app level 'events' or notices
+    - now that the log has been pushed out of the way, it's free to be a bit more verbose
+    - some events like refreshing or changing the game track should be logged
+    - some of these events should be surfaced in an addon's notice logger
+    - should get a different colour in the log
+
 * ux, installing (not updating) an addon for an incompatible game track shouldn't fail silently or get lost in log noise
     - https://github.com/ogri-la/strongbox/issues/231
+
+* button at bottom of UI to re-add split-pane
+    - it's label is the total number of info/warn/errors (whatever is highest) since last notice
+
+* preferences, "update all addons automatically"
+    - update README features
+
+* uber-button, limit status to just those events since the last refresh
+    - and make 'refresh' an app-wide 'notice' to distinguish it from ino/debug/etc
+
+* disable addon update button if it's unsteady
+    - interesting stuff happens when you pump that update button!
+    - roll this into the action queue work
+        - no more than one update request pending per-addon
+
+* search, replace 'install selected' with 'install' button on the right
 
 * bug, uber button, identical addons in different addon dirs are causing the warn/error-free version to show warns/errors
 
 * search, comma separate download numbers
     - or figure out the locale-specific separator
     - 1234567890 downloads is less readable than 1,234,567,890
-
-* disable addon update button if it's unsteady
-    - interesting stuff happens when you pump that update button!
-    - roll this into the action queue work
-        - no more than one update request pending per-addon
 
 * tabber, double clicking a tab closes it
 
@@ -39,23 +56,6 @@ ux and polish
 
 * installed, right align version columns and make elipses start at left
     - we're typically interested in comparing the last part of the version
-
-* search, replace 'install selected' with 'install' button on the right
-
-* logging, app level 'events' or notices
-    - now that the log has been pushed out of the way, it's free to be a bit more verbose
-    - some events like refreshing or changing the game track should be logged
-    - some of these events should be surfaced in an addon's notice logger
-    - should get a different colour in the log
-
-* uber-button, limit status to just those events since the last refresh
-    - and make 'refresh' an app-wide 'notice' to distinguish it from ino/debug/etc
-
-* button at bottom of UI to re-add split-pane
-    - it's label is the total number of info/warn/errors (whatever is highest) since last notice
-
-* preferences, "update all addons automatically"
-    - update README features
 
 ## todo bucket (no particular order)
 

--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,9 @@
   :license {:name "GNU Affero General Public License (AGPL)"
             :url "https://www.gnu.org/licenses/agpl-3.0.en.html"}
 
-  :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/spec.alpha "0.2.176"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/tools.cli "1.0.194"] ;; cli arg parsing
-                 [org.clojure/tools.namespace "1.0.0"] ;; reload code
+                 [org.clojure/tools.namespace "1.1.0"] ;; reload code
                  [org.clojure/data.json "1.0.0"] ;; json handling
                  [orchestra "2018.12.06-2"] ;; improved clojure.spec instrumentation
                  ;; see lein deps :tree

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.set :refer [rename-keys]]
    [clojure.string :refer [lower-case starts-with? ends-with? trim]]
-   [taoensso.timbre :as timbre :refer [debug info warn error spy]]
+   [taoensso.timbre :as timbre :refer [debug info warn error report spy]]
    [clojure.spec.alpha :as s]
    [orchestra.core :refer [defn-spec]]
    [taoensso.tufte :as tufte :refer [p profile]]
@@ -1038,6 +1038,8 @@
   []
   (profile
    {:when (get-state :profile?)}
+
+   (report "refresh")
 
    ;; parse toc files in install-dir. do this first so we see *something* while catalogue downloads (next)
    (load-installed-addons)

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -157,5 +157,3 @@
   [label & form]
   `(with-addon {:name ~label}
      ~@form))
-
-;;

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -1,7 +1,7 @@
 (ns strongbox.main
   (:refer-clojure :rename {test clj-test})
   (:require
-   [taoensso.timbre :as timbre :refer [spy info warn error]]
+   [taoensso.timbre :as timbre :refer [spy info warn error report]]
    [clojure.test]
    [clojure.tools.cli]
    [clojure.tools.namespace.repl :as tn :refer [refresh]]

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -60,7 +60,7 @@
 (s/def ::selected? boolean?)
 (s/def ::gui-theme #{:light :dark :dark-green :dark-orange})
 (s/def ::closable? boolean?)
-(s/def ::log-level #{:debug :info :warn :error})
+(s/def ::log-level #{:debug :info :warn :error :report})
 
 ;; preserve order here
 (def game-track-labels [[:retail "Retail"]

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -1,7 +1,7 @@
 (ns strongbox.ui.cli
   (:require
    [orchestra.core :refer [defn-spec]]
-   [taoensso.timbre :as timbre :refer [spy info warn error debug]]
+   [taoensso.timbre :as timbre :refer [debug info warn error report spy]]
    [clojure.spec.alpha :as s]
    [strongbox
     [logging :as logging]
@@ -29,11 +29,13 @@
   ;; this is also removing the etag cache.
   ;; the etag db is pretty worthless and only applies to catalogues and downloaded zip files.
   (core/delete-http-cache!)
+  (report "refresh")
   (core/check-for-updates))
 
 (defn-spec half-refresh nil?
   "like core/refresh but focuses on loading+matching+checking for updates"
   []
+  (report "refresh")
   (core/load-installed-addons)
   (core/match-installed-addons-with-catalogue)
   (core/check-for-updates)

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1370,7 +1370,7 @@
   pass it a `filter-fn` to remove entries in the `:log-lines` list."
   [{:keys [fx/context tab-idx filter-fn section-title]}]
   (let [filter-fn (or filter-fn identity)
-        level-map {:debug 0 :info 1 :warn 2 :error 3}
+        level-map {:debug 0 :info 1 :warn 2 :error 3 :report 4}
         current-log-level (if tab-idx
                             (fx/sub-val context get-in [:app-state :tab-list tab-idx :log-level])
                             (fx/sub-val context get-in [:app-state :gui-log-level]))
@@ -1397,7 +1397,7 @@
                      {:id "time" :text "time" :max-width 100 :cell-value-factory :time}
                      {:id "message" :text "message" :pref-width 500 :cell-value-factory :message}]
 
-        log-level-list [:debug :info :warn :error]
+        log-level-list [:debug :info :warn :error] ;; :report] ;; 'reports' won't be interesting, no need to filter by them right now.
         log-level-list (if-not (contains? level-occurances :debug)
                          (rest log-level-list)
                          log-level-list)

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -383,8 +383,10 @@
                 {:-fx-background-color "-fx-selection-bar"}
 
                 ".report .table-cell"
-                {:-fx-text-fill (colour :row-report-text)
-                 :-fx-font-style "italic"}
+                {:-fx-text-fill (colour :row-report-text)}
+
+                ".report #message"
+                {:-fx-font-style "italic"}
 
                 "#level"
                 {:-fx-alignment "center"}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -64,6 +64,7 @@
     :row-warning-text "black"
     :row-error "tomato"
     :row-error-text "black"
+    :row-report-text "blue"
     :hyperlink "blue"
     :hyperlink-updateable "blue"
     :hyperlink-weight "normal"
@@ -88,6 +89,7 @@
     :row-warning-text "black"
     :row-error "#ff5555"
     :row-error-text "black"
+    :row-report-text "#bd93f9"
     :hyperlink "#f8f8f2"
     :hyperlink-updateable "white"
     :hyperlink-weight "bold"
@@ -379,6 +381,10 @@
 
                 ".error:selected"
                 {:-fx-background-color "-fx-selection-bar"}
+
+                ".report .table-cell"
+                {:-fx-text-fill (colour :row-report-text)
+                 :-fx-font-style "italic"}
 
                 "#level"
                 {:-fx-alignment "center"}
@@ -1716,7 +1722,8 @@
             preferred-match (merge addon-source {:dirname (:dirname addon)})
             alt-match (merge addon-source {:source (:source addon) :source-id (:source-id addon)})
             notice-pane-filter (fn [log-line]
-                                 (or (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
+                                 (or (-> log-line :level (= :report))
+                                     (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
                                      (= alt-match (select-keys (:source log-line) [:install-dir :source :source-id]))))]
         {:fx/type :border-pane
          :id "addon-detail-pane"

--- a/test/strongbox/logging_test.clj
+++ b/test/strongbox/logging_test.clj
@@ -72,3 +72,13 @@
             actual (->> (core/get-state :log-lines) (filter #(= :warn (:level %))) last)
             actual (dissoc actual :time)]
         (is (= expected actual))))))
+
+(deftest stateful-logging--report-level
+  (testing "addon logging at the `:report` is stripped of addon context"
+    (with-running-app
+      (helper/install-dir)
+      (let [expected {:level :report, :message "some test message"}
+            _ (logging/addon-log {:dirname "EveryAddon"} :report "some test message")
+            actual (->> (core/get-state :log-lines) (filter #(= :report (:level %))) last)
+            actual (dissoc actual :time)]
+        (is (= expected actual))))))


### PR DESCRIPTION
- [x] report logs appear in per-addon loggers
- [x] report logs have their own colour in the logger
- [x] report logs have no addons attached to them, even if we explicitly or implicitly try to do so
    - the source for a report log is always 'app'
- [x] add a report log per-refresh.
  - anything else? changed addon directory? changed game track? shutting down? 
- [x] review
- [x] update CHANGELOG