### PR TITLE
ux, don't fail silently when installing addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * 'report' level log messages.
     - used to break up and give context to repetitive blocks of log messages.
     - just 'refresh' for now, logged whenever the list of addons are re-read.
+* warnings and errors generated while installing an addon are now captured and displayed in a dialog box.
+    - partially addresses points raised in https://github.com/ogri-la/strongbox/issues/231
 
 ### Changed
 
@@ -28,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * the game track (retail, classic, classic-tbc) + version (1.2.3) is now used to determine if an addon is updateable.
 * 'report' level log messages now appear in an addon's notice logger.
     - used to break up and give context to repetitive blocks of log messages.
+* tweaks to error/information dialog panes so messages are easier to read
+    - asterisks `*` have been replaced with a round black dot `•`
+    - line spacing increased
+    - fixed minimum width of dialog pane
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,12 +21,14 @@ see CHANGELOG.md for a more formal list of changes by release
     - should get a different colour in the log
     - done
 
+* ux, installing (not updating) an addon for an incompatible game track shouldn't fail silently or get lost in log noise
+    - https://github.com/ogri-la/strongbox/issues/231
+    - done
+        - addons that fail to expand get an error after switching back to the installed pane
+
 ## todo
 
 ux and polish
-
-* ux, installing (not updating) an addon for an incompatible game track shouldn't fail silently or get lost in log noise
-    - https://github.com/ogri-la/strongbox/issues/231
 
 * button at bottom of UI to re-add split-pane
     - it's label is the total number of info/warn/errors (whatever is highest) since last notice

--- a/TODO.md
+++ b/TODO.md
@@ -30,6 +30,10 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ux and polish
 
+* bug, 'browse local files' is giving me a spec error
+
+* bug, 'refresh user catalogue' is giving me a spec error
+
 * button at bottom of UI to re-add split-pane
     - it's label is the total number of info/warn/errors (whatever is highest) since last notice
 

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -76,17 +76,16 @@
 
     source-updates
 
-    (let [;; todo: revisit this error message
-          ;; "no release found for 'adibags' (retail) on github"
-          ;; "no release found for 'adibags' (retail or classic) on github"
+    (let [;; "no retail release found on github"
+          ;; "no classic release found on wowinterface"
           msg (case [game-track strict?]
-                [:retail true] "no release found for '%s' (retail) on %s"
-                [:classic true] "no release found for '%s' (classic) on %s"
-                [:classic-tbc true] "no release found for '%s' (classic - TBC) on %s"
-                [:retail false] "no release found for '%s' (retail, classic or classic -TBC) on %s"
-                [:classic false] "no release found for '%s' (classic, classic - TBC or retail) on %s"
-                [:classic-tbc false] "no release found for '%s' (classic - TBC, classic or retail) on %s")]
-      (warn (format msg (:name addon) (:source addon))))))
+                [:retail true] "no retail release found on %s"
+                [:classic true] "no classic release found on %s"
+                [:classic-tbc true] "no classic (TBC) release found on %s"
+                [:retail false] "no retail, classic or classic (TBC) release found on %s"
+                [:classic false] "no classic, classic (TBC) or retail release found on %s"
+                [:classic-tbc false] "no classic (TBC), classic or retail release found on %s")]
+      (warn (format msg (:source addon))))))
 
 
 ;;

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -79,12 +79,12 @@
     (let [;; "no retail release found on github"
           ;; "no classic release found on wowinterface"
           msg (case [game-track strict?]
-                [:retail true] "no retail release found on %s"
-                [:classic true] "no classic release found on %s"
-                [:classic-tbc true] "no classic (TBC) release found on %s"
-                [:retail false] "no retail, classic or classic (TBC) release found on %s"
-                [:classic false] "no classic, classic (TBC) or retail release found on %s"
-                [:classic-tbc false] "no classic (TBC), classic or retail release found on %s")]
+                [:retail true] "no retail release found on %s."
+                [:classic true] "no classic release found on %s."
+                [:classic-tbc true] "no classic (TBC) release found on %s."
+                [:retail false] "no retail, classic or classic (TBC) release found on %s."
+                [:classic false] "no classic, classic (TBC) or retail release found on %s."
+                [:classic-tbc false] "no classic (TBC), classic or retail release found on %s.")]
       (warn (format msg (:source addon))))))
 
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -481,21 +481,21 @@
          (not (zip/valid-zip-file? downloaded-file))
          (do (error "failed to read addon zip file, possibly corrupt or not a zip file.")
              (fs/delete downloaded-file)
-             (warn "removed bad zip file"))
+             (warn "removed bad zip file."))
 
          (not (zip/valid-addon-zip-file? downloaded-file))
          (do (error "refusing to install, addon zip file contains top-level files or a top-level directory missing a .toc file.")
              (fs/delete downloaded-file)
-             (warn "removed bad addon"))
+             (warn "removed bad addon."))
 
          (not (s/valid? ::sp/writeable-dir install-dir))
          (error (format "addon directory is not writable: %s" install-dir))
 
          (addon/overwrites-ignored? downloaded-file (get-state :installed-addon-list))
-         (error "refusing to install addon that will overwrite an ignored addon")
+         (error "refusing to install addon that will overwrite an ignored addon.")
 
          (addon/overwrites-pinned? downloaded-file (get-state :installed-addon-list))
-         (error "refusing to install addon that will overwrite a pinned addon")
+         (error "refusing to install addon that will overwrite a pinned addon.")
 
          test-only? true ;; addon was successfully downloaded and verified as being sound
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -481,12 +481,12 @@
          (not (zip/valid-zip-file? downloaded-file))
          (do (error "failed to read addon zip file, possibly corrupt or not a zip file.")
              (fs/delete downloaded-file)
-             (warn "removed bad zip file" downloaded-file))
+             (warn "removed bad zip file"))
 
          (not (zip/valid-addon-zip-file? downloaded-file))
          (do (error "refusing to install, addon zip file contains top-level files or a top-level directory missing a .toc file.")
              (fs/delete downloaded-file)
-             (warn "removed bad addon" downloaded-file))
+             (warn "removed bad addon"))
 
          (not (s/valid? ::sp/writeable-dir install-dir))
          (error (format "addon directory is not writable: %s" install-dir))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -472,25 +472,21 @@
      (let [;; todo: if -testing-zipfile, move zipfile into download dir
            ;; this will help the zipfile pruning tests
            downloaded-file (or (:-testing-zipfile addon) ;; don't download, install from this file (testing only right now)
-                               (download-addon addon install-dir))
-           bad-zipfile-msg (format "failed to read zip file '%s', could not install %s" downloaded-file (:name addon))
-           bad-addon-msg (format "refusing to install '%s'. It contains top-level files or top-level directories missing .toc files."  (:name addon))]
+                               (download-addon addon install-dir))]
        (cond
-         (map? downloaded-file) (error "failed to download addon, could not install" (:name addon))
+         (map? downloaded-file) (error "failed to download addon.")
 
-         (nil? downloaded-file) (error "non-http error downloading addon, could not install" (:name addon)) ;; I dunno. /shrug
+         (nil? downloaded-file) (error "non-HTTP error downloading addon.") ;; I dunno. /shrug
 
          (not (zip/valid-zip-file? downloaded-file))
-         (do
-           (error bad-zipfile-msg)
-           (fs/delete downloaded-file)
-           (warn "removed bad zip file" downloaded-file))
+         (do (error "failed to read addon zip file, possibly corrupt or not a zip file.")
+             (fs/delete downloaded-file)
+             (warn "removed bad zip file" downloaded-file))
 
          (not (zip/valid-addon-zip-file? downloaded-file))
-         (do
-           (error bad-addon-msg)
-           (fs/delete downloaded-file) ;; I could be more lenient
-           (warn "removed bad addon" downloaded-file))
+         (do (error "refusing to install, addon zip file contains top-level files or a top-level directory missing a .toc file.")
+             (fs/delete downloaded-file)
+             (warn "removed bad addon" downloaded-file))
 
          (not (s/valid? ::sp/writeable-dir install-dir))
          (error (format "addon directory is not writable: %s" install-dir))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -939,8 +939,9 @@
   ((switch-tab-event-handler INSTALLED-TAB) event)
   (doseq [selected (core/get-state :search :selected-result-list)]
     (let [error-messages
-          (logging/buffered-log :warn
-                                (some-> selected core/expand-summary-wrapper vector cli/-install-update-these))]
+          (logging/buffered-log
+           :warn
+           (some-> selected core/expand-summary-wrapper vector cli/-install-update-these))]
       (if (empty? error-messages)
         (core/load-installed-addons)
         (let [msg (str (format "warnings/errors while installing \"%s\":\n* " (:label selected))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -49,6 +49,8 @@
     (delete [_ component opts]
       (fx.lifecycle/delete fx.lifecycle/dynamic (:child component) opts))))
 
+(def blt "\u2022") ;; • bullet
+
 (def major-theme-map
   {:light
    {:base "#ececec"
@@ -140,19 +142,23 @@
               ;; lives outside of main styling for some reason
               ;;
 
-              "#about-dialog "
-              {:-fx-spacing "3"
+              ".dialog-pane"
+              {:-fx-min-width "500px"}
 
-               "#about-pane-hyperlink"
-               {:-fx-font-size "1.1em"
-                :-fx-padding "0 0 4 -1"}
+              ".dialog-pane .content"
+              {:-fx-line-spacing "3"}
 
-               "#about-pane-hyperlink:hover"
-               {:-fx-text-fill "blue"}
+              "#about-dialog #about-pane-hyperlink"
+              {:-fx-font-size "1.1em"
+               :-fx-padding "0 0 4 -1"}
 
-               "#about-pane-title"
-               {:-fx-font-size "1.5em"
-                :-fx-padding "10em"}}
+              "#about-dialog #about-pane-hyperlink:hover"
+              {:-fx-text-fill "blue"}
+
+              "#about-dialog #about-pane-title"
+              {:-fx-font-size "1.6em"
+               :-fx-font-weight "bold"
+               :-fx-padding ".5em 0"}
 
               ;;
               ;; main app styling
@@ -842,13 +848,16 @@
   "imports an addon by parsing a URL"
   [event]
   (let [addon-url (text-input "Enter URL of addon")
-        fail-msg "Failed. URL must be:
-  * valid
-  * originate from github.com
-  * addon uses 'releases'
-  * latest release has a packaged 'asset'
-  * asset must be a .zip file
-  * zip file must be structured like an addon"
+
+        fail-msg ["Failed. URL must be:"
+                  "valid"
+                  "originate from github.com"
+                  "addon uses 'releases'"
+                  "latest release has a packaged 'asset'"
+                  "asset must be a .zip file"
+                  "zip file must be structured like an addon"]
+        fail-msg (clojure.string/join (format "\n %s " blt) fail-msg)
+
         failure #(alert :error fail-msg)
         warn-msg "Failed. Addon successfully added to catalogue but could not be installed."
         warning #(alert :warning warn-msg)]
@@ -892,7 +901,7 @@
   []
   {:fx/type :v-box
    :id "about-dialog"
-   :children [{:fx/type :text
+   :children [{:fx/type :label
                :id "about-pane-title"
                :text "strongbox"}
               {:fx/type :text
@@ -944,8 +953,8 @@
            (some-> selected core/expand-summary-wrapper vector cli/-install-update-these))]
       (if (empty? error-messages)
         (core/load-installed-addons)
-        (let [msg (str (format "warnings/errors while installing \"%s\":\n* " (:label selected))
-                       (clojure.string/join "\n* " error-messages))]
+        (let [msg (str (format "warnings/errors while installing \"%s\":\n %s " (:label selected) blt)
+                       (clojure.string/join (format "\n %s " blt) error-messages))]
           (alert :warning msg {:wait? false}))))
     (core/refresh)))
 

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -649,10 +649,13 @@
                    (.setTitle (:title opt-map))
                    (.setHeaderText (:header opt-map))
                    (.setContentText msg)
-                   (.initOwner (get-window)))]
+                   (.initOwner (get-window)))
+          wait? (get opt-map :wait? true)]
       (when (:content opt-map)
         (.setContent (.getDialogPane widget) (:content opt-map)))
-      (.showAndWait widget))))
+      (if wait?
+        (.showAndWait widget)
+        (.show widget)))))
 
 (defn-spec confirm boolean?
   "displays a confirmation prompt with the given `heading` and `message`.
@@ -938,11 +941,15 @@
   ;;(core/-install-update-these (map curseforge/expand-summary (get-state :search :selected-result-list))) 
   ((switch-tab-event-handler INSTALLED-TAB) event)
   (doseq [selected (core/get-state :search :selected-result-list)]
-    (some-> selected core/expand-summary-wrapper vector cli/-install-update-these)
-    (core/load-installed-addons))
-  ;; deselect rows in search table
-  ;; note: don't know how to do this in jfx
-  ;;(ss/selection! (select-ui :#tbl-search-addons) nil) 
+    (let [addon (core/expand-summary-wrapper selected)]
+      (println "-------" selected)
+      (if addon
+        (do (cli/-install-update-these [addon])
+            (core/load-installed-addons))
+        (let [msg "no release found for '%s' (%s) on %s."
+              msg (format msg (:label selected) (name (core/get-game-track)) (:source selected))]
+
+          (alert :warning msg {:wait? false})))))
   (core/refresh))
 
 ;;

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -943,7 +943,7 @@
                                 (some-> selected core/expand-summary-wrapper vector cli/-install-update-these))]
       (if (empty? error-messages)
         (core/load-installed-addons)
-        (let [msg (str (format "Warnings/errors generated during installation of \"%s\":\n* " (:label selected))
+        (let [msg (str (format "warnings/errors while installing \"%s\":\n* " (:label selected))
                        (clojure.string/join "\n* " error-messages))]
           (alert :warning msg {:wait? false}))))
     (core/refresh)))

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -221,7 +221,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no retail release found on github"]]
+                    "no retail release found on github."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -234,7 +234,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no retail release found on github"]]
+                    "no retail release found on github."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -247,7 +247,7 @@
                        {:get (fn [req] {:status 502 :reason-phrase "Gateway Time-out (HTTP 502)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 502) (HTTP 502)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no retail release found on curseforge"]]
+                    "no retail release found on curseforge."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -260,7 +260,7 @@
                        {:get (fn [req] {:status 504 :reason-phrase "Gateway Time-out (HTTP 504)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 504) (HTTP 504)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no retail release found on curseforge"]]
+                    "no retail release found on curseforge."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -221,7 +221,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no release found for 'foo' (retail) on github"]]
+                    "no retail release found on github"]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -234,7 +234,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no release found for 'foo' (retail) on github"]]
+                    "no retail release found on github"]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -247,7 +247,7 @@
                        {:get (fn [req] {:status 502 :reason-phrase "Gateway Time-out (HTTP 502)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 502) (HTTP 502)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no release found for 'foo' (retail) on curseforge"]]
+                    "no retail release found on curseforge"]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -260,7 +260,7 @@
                        {:get (fn [req] {:status 504 :reason-phrase "Gateway Time-out (HTTP 504)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 504) (HTTP 504)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no release found for 'foo' (retail) on curseforge"]]
+                    "no retail release found on curseforge"]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -57,7 +57,7 @@
     (with-running-app
       (let [expected
             {:id "about-dialog"
-             :children [{:text "strongbox", :fx/type :text, :id "about-pane-title"}
+             :children [{:text "strongbox", :fx/type :label, :id "about-pane-title"}
                         {:text (str "version " (core/strongbox-version)), :fx/type :text}
                         {:text "version 0.0.0 is now available to download!",
                          :visible false,


### PR DESCRIPTION
- [x] display warning when an addon fails to find release information
   - typically because of mismatched game tracks
- [x] display warning when an addon fails to download
- [x] display warning when an addon fails to install
- [x] review
- [x] update CHANGELOG