### PR TITLE
gui, adds a 'split' option to bring the logging pane back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,7 @@ All notable changes to this project will be documented in this file. This change
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-### Changed
-
-### Fixed
-
-### Removed
-
-## 4.2.0
+## 4.2.0 - unreleased
 
 ### Added
 
@@ -27,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - for example, a 'classic' release is available for an addon but the addon directory is set to 'retail'
 * an 'install' button on the search pane to install addons individually
     - ... which is probably what *most* of us want *most* of the time
+* a 'split' button that brings up the notice logger at the highest current log level
+    - I missed the old split pane layout and decided the "(warnings)" suffix in the log tab title wasn't good enough
+    - it's yellow with warnings, red when errors. 
+    - split doesn't persist between app restarts. If you want to see this let me know.
 
 ### Changed
 
@@ -805,3 +799,13 @@ curseforge if an addon appears in multiple sources.
 - a notice logger for operations that are happening
 - logic to do the occasional large curseforge.com update and smaller incremental updates more regularly
 - CI and releases with Travis-CI
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -122,6 +122,8 @@
    ;; per-tab log-levels are attached to each tab in the `:tab-list`
    :gui-log-level :info
 
+   :gui-split-pane false
+
    ;; addons in an unsteady state (data being updated, addon being installed, etc)
    ;; allows a UI to watch and update with progress
    :unsteady-addon-list #{}
@@ -702,7 +704,7 @@
         unmatched-names (->> unmatched (remove :ignore?) (map :name) set)]
 
     (when-not (= num-installed num-matched)
-      (info "num installed" num-installed ", num matched" num-matched))
+      (info (format "num installed %s, num matched %s" num-installed num-matched)))
 
     (when-not (empty? unmatched-names)
       (warn "you need to manually search for them and then re-install them")

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -121,6 +121,7 @@
    ;; per-tab log-levels are attached to each tab in the `:tab-list`
    :gui-log-level :info
 
+   ;; split the gui in two with the notice logger down the bottom
    :gui-split-pane false
 
    ;; addons in an unsteady state (data being updated, addon being installed, etc)

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -26,6 +26,7 @@
 ;; logging
 
 (def default-log-level :info)
+(def level-map {:debug 0 :info 1 :warn 2 :error 3 :report 4})
 
 ;; https://github.com/ptaoussanis/timbre/blob/56d67dd274d7d11ab31624a70b4b5ae194c03acd/src/taoensso/timbre.cljc#L856-L858
 (def colour-log-map

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -18,6 +18,11 @@
 
 (comment "the UIs pool their logic here, which calls core.clj.")
 
+(defn-spec toggle-split-pane nil?
+  []
+  (swap! core/state update-in [:gui-split-pane] not)
+  nil)
+
 (defn-spec hard-refresh nil?
   "unlike `core/refresh`, `cli/hard-refresh` clears the http cache before checking for addon updates."
   []

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -373,6 +373,18 @@
         addon-id (utils/extract-addon-id addon)]
     (add-tab tab-id (or (:dirname addon) (:label addon) (:name addon) "[bug: missing tab name!]") closable? addon-id)))
 
+(defn-spec log-entries-since-last-refresh ::sp/list-of-maps
+  "returns a list of log entries since last refresh"
+  ([]
+   (log-entries-since-last-refresh (core/get-state :log-lines)))
+  ([log-lines ::sp/list-of-maps]
+   (let [not-report #(-> % :level (= :report) not)]
+     (->> log-lines ;; old->new
+          reverse ;; new->old
+          (take-while not-report)
+          reverse ;; old->new again, but truncated
+          vec))))
+
 (defn-spec addon-log-entries ::sp/list-of-maps
   "returns a list of addon entries for the given `:dirname` since last refresh"
   [addon map?]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -456,11 +456,29 @@
 
                "#status-bar"
                {:-fx-font-size ".9em"
-                :-fx-padding "5px"
+                :-fx-padding "0 5px"
+                :-fx-alignment "center-left"
+                ;;:-fx-background-color "pink"
+                }
 
-                " > .text"
-                {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
-                 :-fx-fill (colour :table-font-colour)}}
+               "#status-bar > .text"
+               {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
+                :-fx-fill (colour :table-font-colour)}
+
+               "#status-bar-left"
+               {;;:-fx-background-color "orange"
+                :-fx-alignment "center-left"
+                :-fx-pref-width 9999.0}
+
+               "#status-bar-right"
+               {:-fx-min-width "100px" ;; about the width of a button for now
+                ;;:-fx-background-color "blue"
+                :-fx-padding "5px 0"
+                :-fx-alignment "center-right"}
+
+               "#status-bar-right .button"
+               {;;:-fx-background-color "green"
+                }
 
 
                ;;
@@ -789,6 +807,7 @@
   "accepts any args, does nothing, returns nil.
   good for placeholder event handlers."
   (constantly nil))
+(def do-nothing donothing)
 
 (defn wow-dir-picker
   "prompts the user to select an addon dir. 
@@ -1882,11 +1901,18 @@
 
     {:fx/type :h-box
      :id "status-bar"
-     :children [{:fx/type :text
-                 :style-class ["text"]
-                 :text (join " " strings)}]}))
+     :children [{:fx/type :h-box
+                 :id "status-bar-left"
+                 :children [{:fx/type :text
+                             :style-class ["text"]
+                             :text (join " " strings)}]}
+                {:fx/type :h-box
+                 :id "status-bar-right"
+                 :children [(button "split" (fn [_]
+                                              (cli/toggle-split-pane)))]}]}))
 
 ;;
+
 
 (defn app
   "returns a description of the javafx Stage, Scene and the 'root' node.
@@ -1895,7 +1921,8 @@
   (let [;; re-render gui whenever style state changes
         style (fx/sub-val context get :style)
         showing? (fx/sub-val context get-in [:app-state :gui-showing?])
-        theme (fx/sub-val context get-in [:app-state :cfg :gui-theme])]
+        theme (fx/sub-val context get-in [:app-state :cfg :gui-theme])
+        split-pane-on? (fx/sub-val context get-in [:app-state :gui-split-pane])]
     {:fx/type :stage
      :showing showing?
      :on-close-request exit-handler
@@ -1919,7 +1946,13 @@
              :root {:fx/type :border-pane
                     :id (name theme)
                     :top {:fx/type menu-bar}
-                    :center {:fx/type tabber}
+                    :center (if split-pane-on?
+                              {:fx/type :split-pane
+                               :orientation :vertical
+                               :divider-positions [0.6]
+                               :items [{:fx/type tabber}
+                                       {:fx/type notice-logger}]}
+                              {:fx/type tabber})
                     :bottom {:fx/type status-bar}}}}))
 
 (defn start


### PR DESCRIPTION
I found myself missing the split pane but can see how it wouldn't be for everybody.

The UX intent is that there is a niggling little reminder that errors/warnings may be present and how many. Clicking the warning button will display them in context with *all* addons - a per-addon error/warning button already exists and the addon detail pane already has a per-addon notice logger. There are also app-level errors that need surfacing to user's attention.

- [x] the button displays number of messages at the current highest log level
  - "2 errors", "4 warnings" or just "split"
- [x] clicking the button takes you to that log level
- [x] the button is coloured, red for errors, yellow for warnings, plain for everything else
  - dark theme must be considered as well
- [x] remove the `(warning)` etc suffix from the log tab
  - or keep it, it's not doing much I think
- [x] status text in dark mode has lost it's formatting
- [x] review
- [x] update CHANGELOG