### PR TITLE
gui, addon status only considered as far back as last refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - just 'refresh' for now, logged whenever the list of addons are re-read.
 * warnings and errors generated while installing an addon are now captured and displayed in a dialog box.
     - partially addresses points raised in https://github.com/ogri-la/strongbox/issues/231
+* a warning when 'strict' is unticked and an update is available for a mismatched game track
+    - for example, a 'classic' release is available for an addon but the addon directory is set to 'retail'
 
 ### Changed
 
@@ -34,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - asterisks `*` have been replaced with a round black dot `•`
     - line spacing increased
     - fixed minimum width of dialog pane
+* an addon's status (green tick, yellow line, red cross, etc) is limited to just events since the last refresh.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,14 @@ see CHANGELOG.md for a more formal list of changes by release
         - https://api.github.com/repos/teelolws/Altoholic-Retail
     - done
 
+* uber-button, limit status to just those events since the last refresh
+    - and make 'refresh' an app-wide 'notice' to distinguish it from ino/debug/etc
+    - done
+
+* game tracks, add warning if installed addon's interface version deviates from addon directory's game track
+    - for example, if classic is installed in retail, or classic-bc is installed in classic
+    - done
+
 ## todo
 
 ux and polish
@@ -42,9 +50,6 @@ ux and polish
 
 * preferences, "update all addons automatically"
     - update README features
-
-* uber-button, limit status to just those events since the last refresh
-    - and make 'refresh' an app-wide 'notice' to distinguish it from ino/debug/etc
 
 * disable addon update button if it's unsteady
     - interesting stuff happens when you pump that update button!
@@ -61,8 +66,6 @@ ux and polish
 
 * tabber, double clicking a tab closes it
 
-* game tracks, add warning if installed addon's interface version deviates from addon directory's game track
-    - for example, if classic is installed in retail, or classic-bc is installed in classic
 
 * installed, right align version columns and make elipses start at left
     - we're typically interested in comparing the last part of the version

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -76,16 +76,27 @@
 
     source-updates
 
-    (let [;; "no retail release found on github"
-          ;; "no classic release found on wowinterface"
+    (let [;; "no 'Retail' release found on github"
+          ;; "no 'Classic' release found on wowinterface"
+          ;; "no 'Classic (TBC)', 'Classic' or 'Retail' release found on curseforge"
+
+          retail-lbl (sp/game-track-labels-map :retail)
+          classic-lbl (sp/game-track-labels-map :classic)
+          classic-tbc-lbl (sp/game-track-labels-map :classic-tbc)
+          source (:source addon)
+
+          single-template "no '%s' release found on %s."
+          multi-template "no '%s', '%s' or '%s' release found on %s."
+
           msg (case [game-track strict?]
-                [:retail true] "no retail release found on %s."
-                [:classic true] "no classic release found on %s."
-                [:classic-tbc true] "no classic (TBC) release found on %s."
-                [:retail false] "no retail, classic or classic (TBC) release found on %s."
-                [:classic false] "no classic, classic (TBC) or retail release found on %s."
-                [:classic-tbc false] "no classic (TBC), classic or retail release found on %s.")]
-      (warn (format msg (:source addon))))))
+                [:retail true] (format single-template retail-lbl source)
+                [:classic true] (format single-template classic-lbl source)
+                [:classic-tbc true] (format single-template classic-tbc-lbl source)
+
+                [:retail false] (format multi-template retail-lbl classic-lbl source)
+                [:classic false] (format multi-template classic-lbl classic-tbc-lbl retail-lbl source)
+                [:classic-tbc false] (format multi-template classic-tbc-lbl classic-lbl retail-lbl source))]
+      (warn msg))))
 
 
 ;;

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -108,7 +108,6 @@
    :db nil
 
    :log-lines []
-   :log-stats {}
 
    ;; a map of paths whose location may vary according to the cwd and envvars.
    :paths nil
@@ -777,7 +776,11 @@
           addon (or expanded-addon addon) ;; expanded addon may still be nil
           has-update? (addon/updateable? addon)]
       (when has-update?
-        (info (format "update available \"%s\"" (:version addon))))
+        (info (format "update available \"%s\"" (:version addon)))
+        (when-not (= (get-game-track) (:game-track addon))
+          (warn (format "update is for '%s' and the addon directory is set to '%s'"
+                        (-> addon :game-track sp/game-track-labels-map)
+                        (-> (get-game-track) sp/game-track-labels-map)))))
       (assoc addon :update? has-update?))))
 
 (defn-spec check-for-updates nil?

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -115,8 +115,7 @@
   'report' level logs have no addon information attached to them.
   see `addon-log`, `with-addon` and `with-label`."
   [state-atm ::sp/atom, install-dir (s/nilable ::sp/install-dir)]
-  (let [inc* #(inc (or % 0))
-        func (fn [data]
+  (let [func (fn [data]
                (let [addon (some-> data :context :addon)
                      addon-id (select-keys addon [:dirname :source :source-id :name])
                      ;; {:install-dir "/path/to/addons/dir" :dirname "some-addon" :name "SomeAddon"}
@@ -137,9 +136,8 @@
                    ;; purely to stop infinite feedback loop. not sure how this one is happening but urgh.
                    (println "[dropping duplicate message]")
                    (when state-atm
-                     (swap! state-atm update-in [:log-lines] into [log-line])
-                     (when-let [dirname (:dirname addon)]
-                       (swap! state-atm update-in [:log-stats dirname level] inc*))))))]
+                     (swap! state-atm update-in [:log-lines] into [log-line])))))]
+
     (add-appender! :atom func {:timestamp-opts {:pattern "HH:mm:ss"}}))
   (fn []
     (rm-appender! :atom)))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -372,7 +372,7 @@
   "returns a list of addon entries for the given `:dirname` since last refresh"
   [addon map?]
   (let [not-report #(-> % :level (= :report) not)
-        filter-fn (utils/log-line-filter-with-reports (core/selected-addon-dir) addon)]
+        filter-fn (logging/log-line-filter-with-reports (core/selected-addon-dir) addon)]
     (->> (core/get-state)
          :log-lines ;; oldest first
          reverse ;; newest first

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1733,7 +1733,7 @@
       (do (cli/remove-tab-at-idx tab-idx)
           {:fx/type :label :text "goodbye"})
 
-      (let [notice-pane-filter (utils/log-line-filter-with-reports (core/selected-addon-dir) addon)]
+      (let [notice-pane-filter (logging/log-line-filter-with-reports (core/selected-addon-dir) addon)]
         {:fx/type :border-pane
          :id "addon-detail-pane"
          :style-class ["addon-detail"]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1733,13 +1733,7 @@
       (do (cli/remove-tab-at-idx tab-idx)
           {:fx/type :label :text "goodbye"})
 
-      (let [addon-source {:install-dir (core/selected-addon-dir)}
-            preferred-match (merge addon-source {:dirname (:dirname addon)})
-            alt-match (merge addon-source {:source (:source addon) :source-id (:source-id addon)})
-            notice-pane-filter (fn [log-line]
-                                 (or (-> log-line :level (= :report))
-                                     (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
-                                     (= alt-match (select-keys (:source log-line) [:install-dir :source :source-id]))))]
+      (let [notice-pane-filter (utils/log-line-filter-with-reports (core/selected-addon-dir) addon)]
         {:fx/type :border-pane
          :id "addon-detail-pane"
          :style-class ["addon-detail"]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1315,7 +1315,7 @@
   ;; subscribe to re-render table when addons become unsteady
   (fx/sub-val context get-in [:app-state :unsteady-addon-list])
   ;; subscribe to re-render rows when addons emit warnings or errors
-  (fx/sub-val context get-in [:app-state :log-stats])
+  (fx/sub-val context get-in [:app-state :log-lines])
   (let [row-list (fx/sub-val context get-in [:app-state :installed-addon-list])
         selected (fx/sub-val context get-in [:app-state :selected-addon-list])
         selected-addon-dir (fx/sub-val context get-in [:app-state :cfg :selected-addon-dir])

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -618,9 +618,9 @@
         (re-find classic-regex string) :classic
         (re-find retail-regex string) :retail))))
 
-(defn log-line-filter
+(defn-spec log-line-filter fn?
   "returns a function that matches a log entry to the given `install-dir` + `addon`"
-  [install-dir addon]
+  [install-dir ::sp/install-dir, addon map?]
   (let [;; installed addon
         preferred-match {:install-dir install-dir, :dirname (:dirname addon)}
         ;; addons from the catalogue
@@ -629,8 +629,9 @@
       (or (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
           (= alt-match (select-keys (:source log-line) [:install-dir :source :source-id]))))))
 
-(defn log-line-filter-with-reports
-  [install-dir addon]
+(defn-spec log-line-filter-with-reports fn?
+  "like `log-line-filter`, but conveniently includes 'report' level log lines as well."
+  [install-dir ::sp/install-dir, addon map?]
   (let [filter-fn (log-line-filter install-dir addon)]
     (fn [log-line]
       (or (-> log-line :level (= :report))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -617,3 +617,21 @@
         (re-find classic-tbc-regex string) :classic-tbc
         (re-find classic-regex string) :classic
         (re-find retail-regex string) :retail))))
+
+(defn log-line-filter
+  "returns a function that matches a log entry to the given `install-dir` + `addon`"
+  [install-dir addon]
+  (let [;; installed addon
+        preferred-match {:install-dir install-dir, :dirname (:dirname addon)}
+        ;; addons from the catalogue
+        alt-match {:install-dir install-dir, :source (:source addon), :source-id (:source-id addon)}]
+    (fn [log-line]
+      (or (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
+          (= alt-match (select-keys (:source log-line) [:install-dir :source :source-id]))))))
+
+(defn log-line-filter-with-reports
+  [install-dir addon]
+  (let [filter-fn (log-line-filter install-dir addon)]
+    (fn [log-line]
+      (or (-> log-line :level (= :report))
+          (filter-fn log-line)))))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -617,22 +617,3 @@
         (re-find classic-tbc-regex string) :classic-tbc
         (re-find classic-regex string) :classic
         (re-find retail-regex string) :retail))))
-
-(defn-spec log-line-filter fn?
-  "returns a function that matches a log entry to the given `install-dir` + `addon`"
-  [install-dir ::sp/install-dir, addon map?]
-  (let [;; installed addon
-        preferred-match {:install-dir install-dir, :dirname (:dirname addon)}
-        ;; addons from the catalogue
-        alt-match {:install-dir install-dir, :source (:source addon), :source-id (:source-id addon)}]
-    (fn [log-line]
-      (or (= preferred-match (select-keys (:source log-line) [:install-dir :dirname]))
-          (= alt-match (select-keys (:source log-line) [:install-dir :source :source-id]))))))
-
-(defn-spec log-line-filter-with-reports fn?
-  "like `log-line-filter`, but conveniently includes 'report' level log lines as well."
-  [install-dir ::sp/install-dir, addon map?]
-  (let [filter-fn (log-line-filter install-dir addon)]
-    (fn [log-line]
-      (or (-> log-line :level (= :report))
-          (filter-fn log-line)))))

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -221,7 +221,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no retail release found on github."]]
+                    "no 'Retail' release found on github."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -234,7 +234,7 @@
                        {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
           expected ["failed to download file 'https://api.github.com/repos/1/releases': Internal Server Error (HTTP 500)"
                     "Github: api is down. Check www.githubstatus.com and try again later."
-                    "no retail release found on github."]]
+                    "no 'Retail' release found on github."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -247,7 +247,7 @@
                        {:get (fn [req] {:status 502 :reason-phrase "Gateway Time-out (HTTP 502)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 502) (HTTP 502)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no retail release found on curseforge."]]
+                    "no 'Retail' release found on curseforge."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -260,7 +260,7 @@
                        {:get (fn [req] {:status 504 :reason-phrase "Gateway Time-out (HTTP 504)"})}}
           expected ["failed to download file 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 504) (HTTP 504)"
                     "Curseforge: the API is having problems right now. Try again later."
-                    "no retail release found on curseforge."]]
+                    "no 'Retail' release found on curseforge."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -256,7 +256,6 @@
     (logging/with-addon {:dirname "EveryAddon"}
       (timbre/warn "wooooooga")) ;; warn #2
 
-    (is (= {"EveryAddon" {:warn 2}} (core/get-state :log-stats)))
     (is (= 2 (cli/addon-num-log-level :warn "EveryAddon")))
     (is (zero? (cli/addon-num-log-level :error "EveryAddon")))
 


### PR DESCRIPTION
UX case for this is that if an addon has warnings/errors that are fixed after a refresh of the addons, then those warnings/errors should not be considered.

For example, if the game track for an addon directory is switched from "Retail, not-strict" to "Retail, strict" and non-retail addons are installed, then they will fail to find a match after the addons are refresh and voila - a legitimate warning. If the reverse happens and the strictness level is relaxed and a match is found then the warning indicator should go away.

- [x] add warning if installed addon's interface version deviates from addon directory's game track
  - for example, if classic is installed in retail, or classic-bc is installed in classic
  - user should be aware that things are not in a good state
- [x] review
- [x] update CHANGELOG