### PR TITLE
use nfo data (if it exists) when catalogue match not made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * better error handling when no network connection is available.
+* a warning when the update available is from a different addon host.
+    - for example, an addon is removed from curseforge and now receives updates on wowinterface exclusively.
 
 ### Changed
+
+* addons that fail to match against the catalogue but have matched against a catalogue previously can now be updated.
+    - for example, addons in these cases are now updateable: 
+        - an addon doesn't get updates any more but still works and is eventually removed from the 'short' catalogue.
+        - you decide to go curseforge-only and have that one addon from wowinterface you can't live without (or vice-versa)
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -70,6 +70,8 @@ see CHANGELOG.md for a more formal list of changes by release
     - failure to contact a host shouldn't prevent addons on other hosts from working
         - done
 
+* add a --version parameter
+
 ## todo bucket (no particular order)
 
 * install addon from local zipfile

--- a/TODO.md
+++ b/TODO.md
@@ -41,9 +41,32 @@ see CHANGELOG.md for a more formal list of changes by release
 * EOL planning, robustness, only download/update the catalogue *after* an existing catalogue has been confirmed
     - github is down, wowman is erroring with a 500
         - 'host not found' errors should be captured
-        - doublecheck behaviour on github 500 responses
+        - all other errors are handled fine
+        - done
     - failure to download a catalogue shouldn't prevent addons from being displayed
         - if a catalogue has been downloaded previously, does it still fail?
+            - no, it behaves so perfectly I'm suspicious. investigating ... yeah, cache.
+            - with no available catalogue the addons are still displayed but obviously not matched.
+        - so:
+            - if we have a match via the nfo file we should still be able to fetch updates
+                - those in the user-catalogue still work for example ...
+            - order of precendence:
+                - nfo file, if it exists. down the bottom.
+                - user-catalogue. prefer matches against addons added
+                - regular catalogue, has final say.
+                    - this would allow matches against specialised catalogues, like wowi, curse, tukui
+                    - could we disable the catalogue altogether?
+                        - a 'no catalogue' option
+                        - just nfo files and user-catalogue (imported addons)
+                            - bit of a debugging feature but why not?
+        - create a catalogue from the nfo data?
+            - then we could merge nfo-catalogue with user-catalogue with regular catalogue
+                - nice and simple ...
+                - failure to download a catalogue with nothing cached lets us continue working normally
+                    - still need to test the case if a catalogue exists and an update fails, what happens
+                        - touch catalogue, in the past, expire it.
+                - switching to a catalogue like tukui shows all the old associations
+                
     - failure to contact a host shouldn't prevent addons on other hosts from working
         - done
 

--- a/TODO.md
+++ b/TODO.md
@@ -34,10 +34,6 @@ see CHANGELOG.md for a more formal list of changes by release
         - https://github.com/ogri-la/strongbox-release-script
         - it will get bugfixed and refined as I go along.
 
-## todo
-
-... need to do a minor version release and I have about a week before next month. what small things can I do?
-
 * EOL planning, robustness, only download/update the catalogue *after* an existing catalogue has been confirmed
     - github is down, wowman is erroring with a 500
         - 'host not found' errors should be captured
@@ -66,13 +62,17 @@ see CHANGELOG.md for a more formal list of changes by release
                     - still need to test the case if a catalogue exists and an update fails, what happens
                         - touch catalogue, in the past, expire it.
                 - switching to a catalogue like tukui shows all the old associations
+        - done
                 
     - failure to contact a host shouldn't prevent addons on other hosts from working
         - done
 
-* add a --version parameter
+## todo
+
 
 ## todo bucket (no particular order)
+
+* add a --version parameter
 
 * install addon from local zipfile
     - *not* the 'reinstallation' feature, but literally selecting a zipfile from somewhere and installing it

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -21,4 +21,5 @@
 (def bullet "\u2022") ;; •
 
 ;; used when a placeholder date/time is needed.
+;; like when we're polyfilling nfo data to create an addon summary.
 (def fake-datetime "2001-01-01T01:01:01")

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -19,3 +19,6 @@
 (def default-interface-version-classic 11300)
 
 (def bullet "\u2022") ;; •
+
+;; used when a placeholder date/time is needed.
+(def fake-datetime "2001-01-01T01:01:01")

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -720,7 +720,7 @@
 
         ]
     (cond-> nfo
-      ;;(= (:source nfo) "wowinterface") (assoc :game-track-list [(:installed-game-track nfo)])
+      (= (:source nfo) "wowinterface") (assoc :game-track-list [(:installed-game-track nfo)])
       (nil? (:url nfo)) sink
       (not (contains? nfo :source)) sink)))
 
@@ -815,8 +815,8 @@
                 (cond
                   (:ignore? addon) (info "not matched to catalogue, addon is being ignored")
 
-                  (and (:source addon)
-                       (:source-id addon)) (info "askdjhfaks;djfskaldjf;ask")
+                  ;;(and (:source addon)
+                  ;;     (:source-id addon)) (info "askdjhfaks;djfskaldjf;ask")
                   
                   :else (do ;; todo: replace these with a :help level and a less scary colour
                           (info "if this is part of a bundle, try \"File -> Re-install all\"")
@@ -852,13 +852,20 @@
           strict? (get-game-track-strictness)]
       (catalogue/expand-summary addon-summary game-track strict?))))
 
+(defn expandable?
+  [addon]
+  (if-not (s/valid? :addon/expandable addon)
+    (do (s/explain :addon/expandable addon)
+        false)
+    true))
+
 (defn-spec check-for-update :addon/toc
   "Returns given `addon` with source updates, if any, and sets an `update?` property if a different version is available.
   If addon is pinned to a specific version, `update?` will only be true if pinned version is different from installed version."
   [addon (s/or :unmatched :addon/toc
                :matched :addon/toc+summary+match)]
   (logging/with-addon addon
-    (let [expanded-addon (when (:matched? addon) ;; todo: `when (expandable? addon)`
+    (let [expanded-addon (when (expandable? addon) ;;(when (:matched? addon)
                            (joblib/tick-delay 0.25)
                            (expand-summary-wrapper addon))
           addon (or expanded-addon addon) ;; expanded addon may still be nil

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -647,7 +647,14 @@
   "merges the data from an installed addon with it's match in the catalogue"
   [installed-addon :addon/toc, db-catalogue-addon :addon/summary]
   (let [;; nil fields are removed from the catalogue item because they might override good values in the .toc or .nfo
-        db-catalogue-addon (utils/drop-nils db-catalogue-addon [:description])]
+        db-catalogue-addon (utils/drop-nils db-catalogue-addon [:description])
+
+        inst-source (:source installed-addon)
+        dbc-source (:source db-catalogue-addon)
+        source-mismatch (and inst-source
+                             dbc-source
+                             (not (= inst-source dbc-source)))
+        ]
     ;; merges left->right. catalogue-addon overwrites installed-addon, ':matched' overwrites catalogue-addon, etc
     (logging/addon-log installed-addon :info (format "found in catalogue with source \"%s\" and id \"%s\"" (:source installed-addon) (:source-id installed-addon)))
     (merge installed-addon
@@ -656,8 +663,7 @@
            ;; todo: I really want to disambiguate between where data is coming from.
            ;; it would mean carrying around the toc, nfo, catalogue, source updates and a merged set data.
            ;; all we have right now is the merged set (except this new `nfo/source` key)
-           (when-not (= (:source installed-addon)
-                        (:source db-catalogue-addon))
+           (when source-mismatch
              {:nfo/source (:source installed-addon)}))))
 
 ;;

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -653,8 +653,7 @@
         dbc-source (:source db-catalogue-addon)
         source-mismatch (and inst-source
                              dbc-source
-                             (not (= inst-source dbc-source)))
-        ]
+                             (not (= inst-source dbc-source)))]
     ;; merges left->right. catalogue-addon overwrites installed-addon, ':matched' overwrites catalogue-addon, etc
     (logging/addon-log installed-addon :info (format "found in catalogue with source \"%s\" and id \"%s\"" (:source installed-addon) (:source-id installed-addon)))
     (merge installed-addon
@@ -862,8 +861,9 @@
 (defn expandable?
   [addon]
   (if-not (s/valid? :addon/expandable addon)
-    (do (s/explain :addon/expandable addon)
-        false)
+    ;;(do (s/explain :addon/expandable addon)
+    ;;    false)
+    false
     true))
 
 (defn-spec check-for-update :addon/toc
@@ -893,7 +893,7 @@
 
 (def check-for-update-affective (affects-addon-wrapper check-for-update))
 
-(defn-spec check-for-updates-1 nil?
+(defn-spec check-for-updates-serially nil?
   "downloads full details for all installed addons that can be found in summary list"
   []
   (when (selected-addon-dir)

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -1,6 +1,5 @@
 (ns strongbox.http
   (:require
-   [clj-http.fake :refer [with-global-fake-routes]]
    [strongbox
     [joblib :as joblib]
     [logging :as logging]
@@ -172,11 +171,6 @@
                 _ (debug "requesting" url "with params" params)
 
                 resp (client/get url params)
-                ;;fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
-                ;;             {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
-                ;;resp (with-global-fake-routes fake-routes
-                ;;       (client/get url params))
-
                 _ (debug "response status" (:status resp))
 
                 not-modified (= 304 (:status resp)) ;; 304 is "not modified" (local file is still fresh). only happens when caching

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -1,5 +1,6 @@
 (ns strongbox.http
   (:require
+   [clj-http.fake :refer [with-global-fake-routes]]
    [strongbox
     [joblib :as joblib]
     [logging :as logging]
@@ -171,6 +172,10 @@
                 _ (debug "requesting" url "with params" params)
 
                 resp (client/get url params)
+                ;;fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
+                ;;             {:get (fn [req] {:status 500 :reason-phrase "Internal Server Error"})}}
+                ;;resp (with-global-fake-routes fake-routes
+                ;;       (client/get url params))
 
                 _ (debug "response status" (:status resp))
 

--- a/src/strongbox/joblib.clj
+++ b/src/strongbox/joblib.clj
@@ -18,12 +18,11 @@
 
 (defn-spec tick-delay :joblib/progress
   "ticks but then pauses for a random period no more than 200ms.
-  this gives the illusion that something is happening when literally nothing is happening."
+  this gives the illusion that something is happening when literally nothing is happening.
+  pause only occurs if the `tick` fn is bound."
   [pct :joblib/progress]
-  (try
-    (tick pct)
-    (finally
-      (Thread/sleep (-> (rand-int 100) (* 2))))))
+  (when (tick pct)
+    (Thread/sleep (-> (rand-int 100) (* 2)))))
 
 (defn-spec deref* any?
   [future-obj future?]

--- a/src/strongbox/joblib.clj
+++ b/src/strongbox/joblib.clj
@@ -17,12 +17,11 @@
   (constantly nil))
 
 (defn-spec tick-delay :joblib/progress
-  "ticks but then pauses for a random period no more than 200ms.
-  this gives the illusion that something is happening when literally nothing is happening.
+  "ticks but then pauses for a random period between 50 and 200ms providing an illusion that something is happening.
   pause only occurs if the `tick` fn is bound."
   [pct :joblib/progress]
   (when (tick pct)
-    (Thread/sleep (-> (rand-int 100) (* 2)))))
+    (Thread/sleep (+ 50 (rand-int 150)))))
 
 (defn-spec deref* any?
   [future-obj future?]

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -100,9 +100,13 @@
   (try
     (with-redefs [core/testing? true
                   ;; don't pause while testing. nothing should depend on that pause happening.
+                  ;; note! this is different to `joblib/tick-delay` not delaying when `joblib/tick` is unbound.
+                  ;; tests still bind `joblib/tick` and run things in parallel.
                   joblib/tick-delay joblib/tick
                   ;;main/profile? true
                   ;;main/spec? true
+                  ;;cli/install-update-these-in-parallel cli/install-update-these-serially
+                  ;;core/check-for-updates core/check-for-updates-serially
                   ]
       (core/reset-logging!)
 

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -19,15 +19,23 @@
 (def tukui-proper-url (format proper-url "tukui"))
 (def elvui-proper-url (format proper-url "elvui"))
 
-(defn make-url
-  [{:keys [name source-id interface-version]}]
-  (if (neg? source-id)
+(defn-spec make-url (s/nilable ::sp/url)
+  "given a map of addon data, returns a URL to the addon's tukui page or `nil`"
+  [{:keys [name source-id interface-version]} map?]
+  (cond
+    (not source-id) nil
+
+    (and (neg? source-id) name)
     (str "https://www.tukui.org/download.php?ui=" name)
+
+    (and (pos? source-id) interface-version)
     (case (utils/interface-version-to-game-track interface-version)
       :retail (str "https://www.tukui.org/addons.php?id=" source-id)
       :classic (str "https://www.tukui.org/classic-addons.php?id=" source-id)
       :classic-tbc (str "https://www.tukui.org/classic-tbc-addons.php?id=" source-id)
-      nil)))
+      nil)
+
+    :else nil))
 
 (defn-spec expand-summary (s/or :ok :addon/release-list, :error nil?)
   "given a summary, adds the remaining attributes that couldn't be gleaned from the summary page. one additional look-up per ::addon required"

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -19,6 +19,16 @@
 (def tukui-proper-url (format proper-url "tukui"))
 (def elvui-proper-url (format proper-url "elvui"))
 
+(defn make-url
+  [{:keys [name source-id interface-version]}]
+  (if (neg? source-id)
+    (str "https://www.tukui.org/download.php?ui=" name)
+    (case (utils/interface-version-to-game-track interface-version)
+      :retail (str "https://www.tukui.org/addons.php?id=" source-id)
+      :classic (str "https://www.tukui.org/classic-addons.php?id=" source-id)
+      :classic-tbc (str "https://www.tukui.org/classic-tbc-addons.php?id=" source-id)
+      nil)))
+
 (defn-spec expand-summary (s/or :ok :addon/release-list, :error nil?)
   "given a summary, adds the remaining attributes that couldn't be gleaned from the summary page. one additional look-up per ::addon required"
   [addon :addon/expandable, game-track ::sp/game-track]

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -162,6 +162,7 @@
   [catalogue-name (s/nilable (s/or :simple string?, :named keyword?))]
   (when catalogue-name
     (core/set-catalogue-location! (keyword catalogue-name))
+    (report "switched catalogues")
     (core/db-reload-catalogue)
     (core/empty-search-results)
     (bump-search))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -347,6 +347,7 @@
   ([addon-list :addon/installed-list]
    (run! (fn [addon]
            (logging/with-addon addon
+             ;; todo: `core/selected-addon-dir` should be a param to parent fn
              (addon/clear-ignore (core/selected-addon-dir) addon)
              (info "stopped ignoring")))
          addon-list)

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -343,12 +343,11 @@
   "removes the 'ignore' flag from each addon in given `addon-list`.
   defaults to all addons in `:selected-addon-list` when called without parameters."
   ([]
-   (clear-ignore-selected (get-state :selected-addon-list)))
-  ([addon-list :addon/installed-list]
+   (clear-ignore-selected (get-state :selected-addon-list) (core/selected-addon-dir)))
+  ([addon-list :addon/installed-list, addon-dir ::sp/addon-dir]
    (run! (fn [addon]
            (logging/with-addon addon
-             ;; todo: `core/selected-addon-dir` should be a param to parent fn
-             (addon/clear-ignore (core/selected-addon-dir) addon)
+             (addon/clear-ignore addon-dir addon)
              (info "stopped ignoring")))
          addon-list)
    (core/refresh)))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1690,7 +1690,10 @@
 (defn addon-detail-key-vals
   "displays a two-column table of `key: val` fields for what we know about an addon."
   [{:keys [addon]}]
-  (let [column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 150 :resizable false :cell-value-factory #(-> % :key str (subs 1))}
+  (let [key-col (fn [keypair]
+                  ;; shouldn't ever be nil but better safe than sorry
+                  (-> keypair :key (or ":nil") str (subs 1)))
+        column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 150 :resizable false :cell-value-factory key-col}
                      {:text "val" :cell-value-factory :val}]
 
         blacklist [:group-addons :release-list]

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1675,7 +1675,7 @@
                :orientation :vertical}
 
               (if (addon/ignored? addon)
-                (button "Stop ignoring" (async-handler #(cli/clear-ignore-selected [addon])))
+                (button "Stop ignoring" (async-handler #(cli/clear-ignore-selected [addon] (core/selected-addon-dir))))
                 (button "Ignore" (async-handler #(cli/ignore-selected [addon]))
                         {:tooltip "Prevent all changes"
                          :disabled? (not (addon/ignorable? addon))}))
@@ -1690,7 +1690,7 @@
 (defn addon-detail-key-vals
   "displays a two-column table of `key: val` fields for what we know about an addon."
   [{:keys [addon]}]
-  (let [column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 150 :resizable false :cell-value-factory (comp name :key)}
+  (let [column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 150 :resizable false :cell-value-factory #(-> % :key str (subs 1))}
                      {:text "val" :cell-value-factory :val}]
 
         blacklist [:group-addons :release-list]

--- a/src/strongbox/wowinterface.clj
+++ b/src/strongbox/wowinterface.clj
@@ -77,8 +77,9 @@
   [a]
   (str host "info" (extract-source-id a)))
 
-(defn make-url
-  [{:keys [source-id]}]
+(defn-spec make-url (s/nilable ::sp/url)
+  "given a map of addon data, returns a URL to the addon's wowinterface page or `nil`"
+  [{:keys [source-id]} map?]
   (when source-id
     (str host "info" source-id)))
 

--- a/src/strongbox/wowinterface.clj
+++ b/src/strongbox/wowinterface.clj
@@ -77,6 +77,11 @@
   [a]
   (str host "info" (extract-source-id a)))
 
+(defn make-url
+  [{:keys [source-id]}]
+  (when source-id
+    (str host "info" source-id)))
+
 (defn extract-addon-summary
   [snippet]
   (try

--- a/src/strongbox/wowinterface_api.clj
+++ b/src/strongbox/wowinterface_api.clj
@@ -22,7 +22,7 @@
     (error addon-summary))
 
   ;; todo: this shouldn't be an 'if' if there is no 'else'
-  (if (some #{game-track} (:game-track-list addon-summary))
+  (when (some #{game-track} (:game-track-list addon-summary))
     (let [url (str wowinterface-api "/filedetails/" (:source-id addon-summary) ".json")
           result-list (some-> url http/download http/sink-error utils/from-json)
           result (first result-list)]

--- a/src/strongbox/wowinterface_api.clj
+++ b/src/strongbox/wowinterface_api.clj
@@ -20,6 +20,8 @@
   (when-not (:game-track-list addon-summary)
     (error "given addon-summary has no game track list! please report this if you're not a developer.")
     (error addon-summary))
+
+  ;; todo: this shouldn't be an 'if' if there is no 'else'
   (if (some #{game-track} (:game-track-list addon-summary))
     (let [url (str wowinterface-api "/filedetails/" (:source-id addon-summary) ".json")
           result-list (some-> url http/download http/sink-error utils/from-json)

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -8,6 +8,7 @@
    [taoensso.timbre :as log :refer [debug info warn error spy]]
    [strongbox.ui.cli :as cli]
    [strongbox
+    [constants :as constants]
     [addon :as addon :refer [downloaded-addon-fname]]
     [db :as db]
     [logging :as logging]
@@ -1460,3 +1461,77 @@
         (is (empty? (core/get-state :unsteady-addon-list)))
         (is (true? (addon-fn-affective addon)))
         (is (empty? (core/get-state :unsteady-addon-list)))))))
+
+;;
+
+(deftest toc2summary--plain
+  (testing "plain toc data with no extras can't be coerced into an addon summary"
+    (is (nil? (core/toc2summary toc)))))
+
+(deftest toc2summary--toc+nfo
+  (testing "toc with extra nfo data *can* be coerced into an addon summary with less guessing"
+    (let [toc+nfo (merge toc {:group-id "https://example.org"
+                              :source "wowinterface"
+                              :source-id 123
+                              :interface-version constants/default-interface-version-classic})
+          expected {:label "EveryAddon 1.2.3",
+                    :name "everyaddon",
+                    :source "wowinterface",
+                    :source-id 123
+
+                    ;; synthetic
+                    :url "https://example.org" ;; url won't be derived from source and id
+                    :download-count 0,
+                    :game-track-list [:classic], ;; classic is used
+                    :tag-list [],
+                    :updated-date "2001-01-01T01:01:01"}]
+      (is (= expected (core/toc2summary toc+nfo))))))
+
+(deftest toc2summary--wowinterface
+  (testing "toc data with a wowinterface source and id *can* be coerced to addon summary without a `:url`"
+    (let [wowinterface-toc (merge toc {:source "wowinterface"
+                                       :source-id 123})
+          expected {:label "EveryAddon 1.2.3",
+                    :name "everyaddon",
+                    :source "wowinterface",
+                    :source-id 123
+
+                    ;; synthetic
+                    :url "https://www.wowinterface.com/downloads/info123"
+                    :download-count 0,
+                    :game-track-list [:retail],
+                    :tag-list [],
+                    :updated-date "2001-01-01T01:01:01"}]
+      (is (= expected (core/toc2summary wowinterface-toc))))))
+
+(deftest toc2summary--tukui
+  (testing "toc data with a tukui source and id can be coerced to an addon summary without a `:url`"
+    (let [tukui-toc (merge toc {:source "tukui"
+                                :source-id 123})
+          expected {:source "tukui",
+                    :source-id 123,
+                    :name "everyaddon",
+                    :label "EveryAddon 1.2.3",
+
+                    ;; synthetic
+                    :tag-list [],
+                    :updated-date "2001-01-01T01:01:01",
+                    :url "https://www.tukui.org/addons.php?id=123",
+                    :download-count 0}]
+      (is (= expected (core/toc2summary tukui-toc))))))
+
+(deftest toc2summary--curseforge
+  (testing "toc data with a curseforge source and id cannot be coerced to an addon summary without a `:url`"
+    (let [curseforge-toc (merge toc {:source "curseforge"
+                                     :source-id 123})]
+      (is (nil? (core/toc2summary curseforge-toc))))))
+
+;;
+
+(deftest expandable?
+  (let [cases [[{} false]
+               [{:foo :bar} false]
+               [{:source "wowinterface" :source-id 123} false]
+               [{:name "foo" :label "Foo" :source "wowinterface" :source-id 123} true]]]
+    (doseq [[given expected] cases]
+      (is (= expected (core/expandable? given))))))

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -8,7 +8,6 @@
    [taoensso.timbre :as log :refer [debug info warn error spy]]
    [strongbox.ui.cli :as cli]
    [strongbox
-    [constants :as constants]
     [addon :as addon :refer [downloaded-addon-fname]]
     [db :as db]
     [logging :as logging]
@@ -1448,8 +1447,6 @@
         (with-global-fake-routes-in-isolation fake-routes
           (is (= expected (core/latest-strongbox-release))))))))
 
-;;
-
 (deftest unsteady?
   (testing "a function that operates on addons can be wrapped to mark the addon as 'unsteady'"
     (let [addon {:name "foo"}
@@ -1461,72 +1458,6 @@
         (is (empty? (core/get-state :unsteady-addon-list)))
         (is (true? (addon-fn-affective addon)))
         (is (empty? (core/get-state :unsteady-addon-list)))))))
-
-;;
-
-(deftest toc2summary--plain
-  (testing "plain toc data with no extras can't be coerced into an addon summary"
-    (is (nil? (core/toc2summary toc)))))
-
-(deftest toc2summary--toc+nfo
-  (testing "toc with extra nfo data *can* be coerced into an addon summary with less guessing"
-    (let [toc+nfo (merge toc {:group-id "https://example.org"
-                              :source "wowinterface"
-                              :source-id 123
-                              :interface-version constants/default-interface-version-classic})
-          expected {:label "EveryAddon 1.2.3",
-                    :name "everyaddon",
-                    :source "wowinterface",
-                    :source-id 123
-
-                    ;; synthetic
-                    :url "https://example.org" ;; url won't be derived from source and id
-                    :download-count 0,
-                    :game-track-list [:classic], ;; classic is used
-                    :tag-list [],
-                    :updated-date "2001-01-01T01:01:01"}]
-      (is (= expected (core/toc2summary toc+nfo))))))
-
-(deftest toc2summary--wowinterface
-  (testing "toc data with a wowinterface source and id *can* be coerced to addon summary without a `:url`"
-    (let [wowinterface-toc (merge toc {:source "wowinterface"
-                                       :source-id 123})
-          expected {:label "EveryAddon 1.2.3",
-                    :name "everyaddon",
-                    :source "wowinterface",
-                    :source-id 123
-
-                    ;; synthetic
-                    :url "https://www.wowinterface.com/downloads/info123"
-                    :download-count 0,
-                    :game-track-list [:retail],
-                    :tag-list [],
-                    :updated-date "2001-01-01T01:01:01"}]
-      (is (= expected (core/toc2summary wowinterface-toc))))))
-
-(deftest toc2summary--tukui
-  (testing "toc data with a tukui source and id can be coerced to an addon summary without a `:url`"
-    (let [tukui-toc (merge toc {:source "tukui"
-                                :source-id 123})
-          expected {:source "tukui",
-                    :source-id 123,
-                    :name "everyaddon",
-                    :label "EveryAddon 1.2.3",
-
-                    ;; synthetic
-                    :tag-list [],
-                    :updated-date "2001-01-01T01:01:01",
-                    :url "https://www.tukui.org/addons.php?id=123",
-                    :download-count 0}]
-      (is (= expected (core/toc2summary tukui-toc))))))
-
-(deftest toc2summary--curseforge
-  (testing "toc data with a curseforge source and id cannot be coerced to an addon summary without a `:url`"
-    (let [curseforge-toc (merge toc {:source "curseforge"
-                                     :source-id 123})]
-      (is (nil? (core/toc2summary curseforge-toc))))))
-
-;;
 
 (deftest expandable?
   (let [cases [[{} false]

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -1,6 +1,6 @@
 (ns strongbox.jfx-test
   (:require
-   ;;[clj-http.fake :refer [with-fake-routes-in-isolation]]
+   ;;[clj-http.fake :refer [with-global-fake-routes-in-isolation]]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [strongbox.ui.jfx :as jfx]
    ;;[taoensso.timbre :as log :refer [debug info warn error spy]]

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -12,6 +12,15 @@
     [core :as core]
     [utils :as utils]]))
 
+(def toc
+  "local addon .toc file"
+  {:name "everyaddon",
+   :description "Does what no other addon does, slightly differently"
+   :dirname "EveryAddon",
+   :label "EveryAddon 1.2.3",
+   :interface-version 70000,
+   :installed-version "1.2.3"})
+
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
 
 (def helper-data-dir "data/strongbox")

--- a/test/strongbox/tukui_api_test.clj
+++ b/test/strongbox/tukui_api_test.clj
@@ -217,3 +217,35 @@
 
     (doseq [[given expected] cases]
       (is (= expected (tukui-api/parse-user-string given))))))
+
+(deftest make-url
+  (let [cases [;; retail tukui addon
+               [{:name "foo" :source-id 123 :interface-version 90000} "https://www.tukui.org/addons.php?id=123"]
+               ;; classic tukui addon
+               [{:name "foo" :source-id 123 :interface-version 10000} "https://www.tukui.org/classic-addons.php?id=123"]
+               ;; classic-tbc tukui addon
+               [{:name "foo" :source-id 123 :interface-version 20000} "https://www.tukui.org/classic-tbc-addons.php?id=123"]
+
+               ;; tukui retail proper url
+               [{:name "tukui" :source-id -1 :interface-version 90000} "https://www.tukui.org/download.php?ui=tukui"]
+               ;; elvui retail proper url
+               [{:name "elvui" :source-id -2 :interface-version 90000} "https://www.tukui.org/download.php?ui=elvui"]
+
+               ;; tukui classic url
+               [{:name "tukui" :source-id 1 :interface-version 10000} "https://www.tukui.org/classic-addons.php?id=1"]
+               ;; elvui classic url
+               [{:name "tukui" :source-id 2 :interface-version 10000} "https://www.tukui.org/classic-addons.php?id=2"]
+
+               ;; ..etc
+
+               ;; dodgy url
+               [{:name "foo" :source-id -99 :interface-version 90000} "https://www.tukui.org/download.php?ui=foo"]
+               [{:source-id 1 :interface-version 10000} "https://www.tukui.org/classic-addons.php?id=1"]
+
+               ;; bad urls
+               [{} nil]
+               [{:source-id 1} nil]
+               [{:source-id -1 :interface-version 90000} nil]]]
+
+    (doseq [[given expected] cases]
+      (is (= expected (tukui-api/make-url given)), (str "failed on given: " given)))))

--- a/test/strongbox/wowinterface_test.clj
+++ b/test/strongbox/wowinterface_test.clj
@@ -112,3 +112,10 @@
   (testing "when 'UICompatibility' is `null` we default to `:retail`."
     (let [expected [:retail]]
       (is (= expected (wowinterface/ui-compatibility-to-gametrack-list nil))))))
+
+(deftest make-url
+  (let [cases [[{} nil]
+               [{:source-id nil} nil]
+               [{:source-id 123} "https://www.wowinterface.com/downloads/info123"]]]
+    (doseq [[given expected] cases]
+      (is (= expected (wowinterface/make-url given))))))


### PR DESCRIPTION
I fudged the nfo data to create a 'nfo catalogue' that lives below the user-catalogue and ... it seems to work well! if the main catalogue is unavailable (faked 500 response) or doesn't contain a match, it falls back to the match it had previously.

update: I got a wrong feeling from using the derived data (toc+nfo) as a 'catalogue' despite it being a fairly elegant solution. Instead I did a second pass on the 'unmatched' addons to see if certain required values could be safely polyfilled. This preserves the error messages that the addon failed to match, the list of addons that failed to match, etc and the tests don't need modifying.

- [x] tweak the condition that only matched addons can check for updates
- [x] add warning (like the mismatched game track warning) when the installed addon source doesn't match the catalogue source
  - i.e. the user will be replacing the source of one addon for another
- [x] bug: old addon  with nfo data because it's always been matched against the *full* catalogue and has never had an update, switches to short catalogue and now the db match doesn't happen and we get a warning from nfo2summary (MultiShot on wowi)
- [x] review
- [x] second review
- [x] update CHANGELOG