### PR TITLE
add version parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* a `--version` parameter that prints the name of the app and it's current version.
+
 ### Changed
 
 * bumped dependencies
     - slight increase in performance loading JSON with a newer version of the `data.json` library.
 
 ### Fixed
+
+* fixed warning on startup about `cat` already refering to `clojure.core/cat`.
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,10 @@ see CHANGELOG.md for a more formal list of changes by release
     - about an 80ms improvement in json loading
     - done
 
-## todo
-
 * add a --version parameter
+    -done
+
+## todo
 
 * bug, catalogue loading
     - while updating the catalogue with the new tukui addons I discovered a case where the catalogue *should* be failing validation but it wasn't.

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                  [org.flatland/ordered "1.5.9"] ;; better ordered map
                  [clojure.java-time "0.3.3"] ;; date/time handling library, https://github.com/dm3/clojure.java-time
                  [envvar "1.1.2"] ;; environment variable wrangling
-                 [gui-diff "0.6.7"] ;; pops up a graphical diff for test results
+                 [gui-diff "0.6.7" :exclusions [net.cgrant/parsley]] ;; pops up a graphical diff for test results
                  [com.taoensso/tufte "2.2.0"] ;; profiling
                  [cljfx "1.7.14" :exclusions [org.openjfx/javafx-web
                                               org.openjfx/javafx-media]]
@@ -45,6 +45,12 @@
                  ;;[org.clojure/core.cache "1.0.207"] ;; jfx context caching
 
                  ]
+
+  :managed-dependencies [;; fixes the annoying:
+                         ;; "WARNING: cat already refers to: #'clojure.core/cat in namespace: net.cgrand.parsley.fold, being replaced by: #'net.cgrand.parsley.fold/cat"
+                         ;; https://github.com/cgrand/parsley/issues/15
+                         ;; see `gui-diff` exclusion
+                         [net.cgrand/parsley "0.9.3"]]
 
   :resource-paths ["resources"]
 


### PR DESCRIPTION
* add --version parameter
* fixes annoying warning in transitive dependency.
* shuffles shutdown-hook and a call to reset-logging around so state doesn't exist when calling --help and --version, causing INFO logs to be emitted

- [x] review
- [x] update CHANGELOG