### PR TITLE
be kinder to curseforge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * new columns 'source-id', 'tags', combined 'version' column, 'browse local files' and friendly 'created' and 'updated' columns.
 * handling for hosts that are refusing connections rather than accepting connections but then timing out.
     - happened with Tukui the other day.
+* exponential backoff when talking to curseforge as well as a pause between requests.
+    - shouldn't affect users this release but a future release may see it used more widely.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ contains many addons that haven't been updated in years.
 There are also per-host catalogues, like a 'curseforge' catalogue, and strongbox supports selecting between all of them.
 
 Catalogues are updated weekly. New addons released during the week will not be present until the next week. Addons can 
-be installed using it's URL in these cases.
+be installed using its URL in these cases.
 
 The 'user' catalogue is a little different. It's initially empty but grows as addons are imported from hosts like Github. 
 These addons also appear in search results. Individual addons from the user catalogue are checked for new releases 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ contains many addons that haven't been updated in years.
 
 There are also per-host catalogues, like a 'curseforge' catalogue, and strongbox supports selecting between all of them.
 
-Catalogues are updated weekly.
+Catalogues are updated weekly. New addons released during the week will not be present until the next week. Addons can 
+be installed using it's URL in these cases.
 
 The 'user' catalogue is a little different. It's initially empty but grows as addons are imported from hosts like Github. 
 These addons also appear in search results. Individual addons from the user catalogue are checked for new releases 

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,14 @@ see CHANGELOG.md for a more formal list of changes by release
             - I have handling for a SocketTimeoutException which is different
     - done
 
+* bug, a timeout from curseforge during scraping at page 171 prevent pages 171-182 from being scraped
+    - we should be kinder when scraping. 
+        - add a delay between requests
+        - done
+    - we should be more robust when scraping.
+        - add retries with exponential backoff
+        - done
+
 ## todo
 
 * revisit the 'File -> Export Github addon list' 
@@ -76,16 +84,13 @@ see CHANGELOG.md for a more formal list of changes by release
 ## todo bucket (no particular order)
 
 * http, exponential backoff for failing http requests
-    - perhaps the uberbutton could pause and go 'retrying' ?
+
+* add a 'add to user-catalogue' option to make an addon always available despite selected catalogue
+
+* add a 'catalogue is N days old' somewhere
 
 * gui, try replacing the auto fit columns with something like this:
     - https://stackoverflow.com/questions/14650787/javafx-column-in-tableview-auto-fit-size#answer-49134109
-
-* bug, a timeout from curseforge during scraping at page 171 prevent pages 171-182 from being scraped
-    - we should be kinder when scraping. 
-        - add a delay between requests
-    - we should be more robust when scraping.
-        - add retries with exponential backoff
 
 * multi-toc support
     - https://github.com/Stanzilla/WoWUIBugs/issues/68#issuecomment-830351390

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -358,6 +358,33 @@
        output-file
        resp))))
 
+;;
+
+(defn-spec download-with-backoff (s/or :ok-file ::sp/extant-file, :ok-body string?, :error :http/error)
+  "wrapper around `download` that will pause and retry a download several times with an exponentially increasing duration between each attemp"
+  ([url ::sp/url]
+   (download-with-backoff url nil))
+  ([url ::sp/url, message (s/nilable ::sp/short-string)]
+   (loop [attempt 1
+          pause 1000] ;; ms
+     (let [result (try
+                    (download url message)
+                    (catch Exception e
+                      e))]
+       (if (or (instance? Exception result)
+               (http-error? result))
+         (if (= attempt 3)
+           ;; tried three times and failed three times. raise the exception or return the error.
+           (if (instance? Exception result)
+             (throw result)
+             result)
+           ;; try again after a pause
+           (do (Thread/sleep pause)
+               (recur (inc attempt) (* pause 2))))
+         result)))))
+
+;;
+
 (defn-spec prune-cache-dir nil?
   "deletes files in the given `cache-dir` that are older than the `expiry-offset-hours`"
   [cache-dir ::sp/extant-dir]

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -20,6 +20,7 @@
 
 (def expiry-offset-hours 1) ;; hours
 (def ^:dynamic *cache* nil)
+(def ^:dynamic *default-pause* 1000)
 
 (defn- add-etag-or-not
   [etag-key req]
@@ -366,8 +367,10 @@
    (download-with-backoff url nil))
   ([url ::sp/url, message (s/nilable ::sp/short-string)]
    (loop [attempt 1
-          pause 1000] ;; ms
+          pause *default-pause*]
      (let [result (try
+                    (when (> attempt 1)
+                      (warn (format "trying again (attempt %s of 3)" attempt)))
                     (download url message)
                     (catch Exception e
                       e))]


### PR DESCRIPTION
It tends to flake out a bit towards the end of a long scrape. It's inconvenient for me but probably busting some caches on their end.

* http, adds 'download-with-backoff'
* curseforge-api, uses download-with-backoff while scraping api.
* curseforge-api, adds pause after each request.

- [x] review
- [x] update CHANGELOG