### PR TITLE
source switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * a github catalogue.
     - actually, the catalogue is available right now if you're using the 'short' (default) or 'full' catalogues.
     - an entry in the `Catalogue` menu where you can switch to the Github catalogue exclusively.
+* source switching. 
+    - when an addon has multiple sources (curseforge, wowinterface, github, etc) you can switch between them.
+        - this relies on the `x-project-id` type values in addon `.toc` files.
+    - a 'Source' context menu option for addons with multiple sources.
+    - a 'other sources' column with clickable links.
+        - note: curseforge links are a bit hit or miss as we a direct URL isn't possible from just the source/project ID
+* 'find similar' context menu option. It searches the catalogue for addons that share the addon's name.
+    - this *may* reveal the same addon on different hosts that aren't present in an addon's `.toc` file.
+        - ensure the 'short' or 'full' catalogues are selected for better results.
 
 ### Changed
 
 * the set of catalogues in your `config.json` file will be upgraded to include the new Github catalogue
     - but only if it looks unmodified from the default set of catalogues.
+* curseforge addons not found in the currently selected catalogue can no longer check for updates anyway.
+    - the `group-id` value used to group together multiple addons may not be consistent now source switching is present.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -21,15 +21,15 @@ Curseforge is going away. How to migrate addons off of curseforge?
 * how to disable the completely integrated curseforge?
     - I want curseforge addons to still show as being curseforge addons but just never receive updates after the cut off.
         - when is the cut off again?
-    - I want the catalogue of curseforge addons to not be merged into the short and full catalogues after the cut off
-    - I want the curseforge catalogue to no longer receives updates
+    - I don't want the catalogue of curseforge addons to be merged into the short and full catalogues after the cut off
+    - I done't want the curseforge catalogue to receive updates
     - I want a permanent warning against curseforge addons between now and when the service goes offline
         - I want an error after cut off
 
 * source switching
     - some addons will have multiple sources in the toc file we can switch to.
     - if not, we can search the catalogue for them
-        - exclude curseforge 
+        - exclude curseforge
 
 * strongbox-comrades
     - remove curseforge as a requirement for any category.

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,14 @@ see CHANGELOG.md for a more formal list of changes by release
 * regression, synthetic http errors are no longer retried because they're in the 4xx range
     - bumped the synthetic 408 errors to 608
 
+* source switching
+    - some addons will have multiple sources in the toc file we can switch to.
+    - if not, we can search the catalogue for them
+        - exclude curseforge
+            - not done, curseforge is still supported until Feb 
+                - and search results are thin enough as it is. if it can only be found on curseforge, then that is more helpful than the 'no results' msg.
+    - done
+
 ## todo
 
 Curseforge is going away. How to migrate addons off of curseforge?
@@ -22,19 +30,16 @@ Curseforge is going away. How to migrate addons off of curseforge?
     - I want curseforge addons to still show as being curseforge addons but just never receive updates after the cut off.
         - when is the cut off again?
     - I don't want the catalogue of curseforge addons to be merged into the short and full catalogues after the cut off
-    - I done't want the curseforge catalogue to receive updates
+    - I don't want the curseforge catalogue to receive updates
     - I want a permanent warning against curseforge addons between now and when the service goes offline
         - I want an error after cut off
-
-* source switching
-    - some addons will have multiple sources in the toc file we can switch to.
-    - if not, we can search the catalogue for them
-        - exclude curseforge
 
 * strongbox-comrades
     - remove curseforge as a requirement for any category.
 
 ## todo bucket (no particular order)
+
+* nfo, replace the URL as the group-id with something random
 
 * "developer warnings"
     - a preference that bumps certain debug messages to warnings and errors for developers

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,7 @@ Curseforge is going away. How to migrate addons off of curseforge?
         - rather than once per update
 
 * user catalogue, refresh happens in parallel
+    - write the user-catalogue once, not each time or else we'll get Weirdness
 
 * a more permanent store than just cached files
     - I want to store release data permanently

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -46,31 +46,32 @@
       :else (do (fs/delete-dir addon-path)
                 (debug (format "removed '%s'" addon-path))))))
 
+(defn-spec flatten-addon ::sp/list-of-maps
+  "given an `addon`, returns a list of that addon's members (that includes itself) or the addon wrapped in a list."
+  [addon map?]
+  (if-let [group-members (:group-addons addon)]
+    group-members
+    [addon]))
+
 (defn-spec remove-addon nil?
   "removes the given addon. if addon is part of a group, all addons in group are removed"
   [install-dir ::sp/extant-dir, addon :addon/installed]
   (info (format "removing \"%s\" version \"%s'" (:label addon) (:installed-version addon)))
-  (cond
+  (if (:ignore? addon)
     ;; if addon is being ignored, refuse to remove addon.
     ;; note: `group-addons` will add a top level `:ignore?` flag if any addon in a bundle is being ignored.
-    (:ignore? addon) (error "refusing to delete ignored addon:" install-dir)
+    (error "refusing to delete ignored addon:" install-dir)
 
-    ;; addon is part of a bundle.
-    ;; because the addon is also contained in `:group-addons` we just remove all in list
-    (contains? addon :group-addons) (doseq [grouped-addon (:group-addons addon)]
-                                      (-remove-addon install-dir (:dirname grouped-addon) (:group-id addon)))
-
-    ;; addon is a single directory
-    :else (-remove-addon install-dir (:dirname addon) (:group-id addon))))
+    (doseq [grouped-addon (flatten-addon addon)]
+      (-remove-addon install-dir (:dirname grouped-addon) (:group-id addon)))))
 
 ;;
 
-;; todo: toc-list to installed-list
-(defn-spec group-addons :addon/toc-list
+(defn-spec group-addons :addon/installed-list
   "an addon may actually be many addons bundled together in a single download.
   strongbox tags the bundled addons as they are unzipped and tries to determine the primary one.
   after we've loaded the addons and merged their nfo data, we can then group them"
-  [addon-list :addon/toc-list]
+  [addon-list :addon/installed-list]
   (let [;; group-id comes from the nfo file
         addon-groups (group-by :group-id addon-list)
 
@@ -115,14 +116,6 @@
         ;; this flattens the newly grouped addons from a map into a list and joins the unknowns
         addon-list (apply conj (mapv expand addon-groups) unknown-grouping)]
     addon-list))
-
-(defn-spec ungroup-addon :addon/installed-list
-  "an addon may actually be many addons bundled together with a primary one chosen to represent them.
-  sometimes we want to treat this addon as a list of addons"
-  [addon :addon/installed]
-  (if (empty? (:group-addons addon))
-    [addon]
-    (get addon :group-addons [])))
 
 (defn merge-toc-nfo
   "it's own function because the logic is duplicated in tests otherwise"
@@ -332,8 +325,7 @@
   "marks the given `addon` and all of it's group members (if any) as 'ignored'"
   [install-dir ::sp/extant-dir, addon :addon/installed]
   (->> addon
-       ungroup-addon
-       flatten
+       flatten-addon
        (map :dirname)
        (run! (partial nfo/ignore install-dir))))
 
@@ -346,18 +338,11 @@
                     nfo/stop-ignoring
                     nfo/clear-ignore)]
     (->> addon
-         ungroup-addon
-         (mapv :dirname)
+         flatten-addon
+         (map :dirname)
          (run! (partial ignore-fn install-dir)))))
 
 ;;
-
-(defn flatten-addon
-  "given an `addon`, returns a list of that addon's members (that includes itself) or the addon wrapped in a list."
-  [addon]
-  (if-let [group-members (:group-addons addon)]
-    group-members
-    [addon]))
 
 (defn-spec pin nil?
   "pins an `addon` and all of it's group members (if any) to the given `version` or the `:installed-version` when missing.
@@ -501,3 +486,21 @@
   "returns `true` if there is more than 1 release available and the addon isn't pinned"
   [addon map?]
   (releases-available? (update-in addon [:release-list] rest)))
+
+;;
+
+(defn-spec update-nfo! nil?
+  "updates the nfo data for the given addon and all of it's grouped addons"
+  [install-dir ::sp/extant-dir, addon :addon/toc+nfo, updates map?]
+  (doseq [grouped-addon (flatten-addon addon)]
+    (nfo/update-nfo install-dir (:dirname grouped-addon) updates)))
+
+(defn-spec switch-source! nil?
+  "switches addon from one source (like curseforge) to another (like wowinterface), rewriting nfo data.
+  `new-source` must appear in the addon's `source-map-list`."
+  [install-dir ::sp/extant-dir, addon :addon/toc+nfo, new-source-map :addon/source-map]
+  (when (and (utils/in? new-source-map (:source-map-list addon))
+             (not (ignored? addon))
+             (not (pinned? addon)))
+    ;; todo: update group-id as well?
+    (update-nfo! install-dir addon new-source-map)))

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -516,8 +516,11 @@
   "switches addon from one source (like curseforge) to another (like wowinterface), rewriting nfo data.
   `new-source` must appear in the addon's `source-map-list`."
   [install-dir ::sp/extant-dir, addon :addon/installed, new-source-map :addon/source-map]
-  (when (and (utils/in? new-source-map (:source-map-list addon))
+  (when (and (utils/in? new-source-map (:source-map-list addon)) ;; todo: consider moving this check to cli
              (not (ignored? addon))
              (not (pinned? addon)))
-    ;; todo: update group-id as well?
-    (update-nfo! install-dir addon new-source-map)))
+    ;; todo: update group-id as well
+    (let [new-source-map-list (merge-source-map-lists (extract-source-map-list addon)
+                                                      [new-source-map])
+          nfo-updates (merge new-source-map {:source-map-list new-source-map-list})]
+      (update-nfo! install-dir addon nfo-updates))))

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -121,7 +121,7 @@
   (when-not (:ignore? toc)
     (let [sink nil
           syn (-> toc
-                  (merge {;; :url (:group-id toc) ;; 2021-12-30: can't rely on this value being consistent anymore.
+                  (merge {;; :url (:group-id toc) ;; 2021-12-30: can't rely on `url` being consistent with `source` anymore.
                           :url nil ;; attempt to reconstruct below
                           :tag-list []
                           :updated-date constants/fake-datetime
@@ -140,7 +140,7 @@
           ;; all urls except curseforge can be reconstructed
           syn (if (-> syn :url nil?)
                 (case (:source toc)
-                  ;; "curseforge" ... ;; can't be reconstructed
+                  ;; "curseforge" ... ;; addon page URL can't be reconstructed, so clickable links break.
                   "wowinterface" (assoc syn :url (wowinterface/make-url toc))
                   "tukui" (assoc syn :url (tukui-api/make-url toc))
                   "github" (assoc syn :url (github-api/make-url toc))

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -121,7 +121,8 @@
   (when-not (:ignore? toc)
     (let [sink nil
           syn (-> toc
-                  (merge {:url (:group-id toc)
+                  (merge {;; :url (:group-id toc) ;; 2021-12-30: can't rely on this value being consistent anymore.
+                          :url nil ;; attempt to reconstruct below
                           :tag-list []
                           :updated-date constants/fake-datetime
                           :download-count 0
@@ -136,11 +137,16 @@
                 syn)
 
           ;; we might be able to recover from this.
-          ;; wowi and github urls can be reconstructed
+          ;; all urls except curseforge can be reconstructed
           syn (if (-> syn :url nil?)
                 (case (:source toc)
+                  ;; "curseforge" ... ;; can't be reconstructed
                   "wowinterface" (assoc syn :url (wowinterface/make-url toc))
                   "tukui" (assoc syn :url (tukui-api/make-url toc))
+                  "github" (assoc syn :url (github-api/make-url toc))
+                  ;; gitlab addons only appear in the user catalogue so will only be 'polyfilled' here if
+                  ;; they remain installed but removed from the user-catalogue.
+                  "gitlab" (assoc syn :url (gitlab-api/make-url toc))
                   syn)
                 syn)
 

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -335,3 +335,9 @@
               (assoc addon :description description)
               addon)))]
     (mapv to-summary result-list)))
+
+;;
+
+(defn-spec make-url (s/or :ok ::sp/url, :error nil?)
+  [toc (s/or :just-toc :addon/toc, :mixed :addon/toc+nfo)]
+  (str "https://github.com/" (:source-id toc)))

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -338,6 +338,8 @@
 
 ;;
 
-(defn-spec make-url (s/or :ok ::sp/url, :error nil?)
-  [toc (s/or :just-toc :addon/toc, :mixed :addon/toc+nfo)]
-  (str "https://github.com/" (:source-id toc)))
+(defn make-url
+  "returns a URL to the given addon data"
+  [{:keys [source-id]}]
+  (when source-id
+    (str "https://github.com/" source-id)))

--- a/src/strongbox/gitlab_api.clj
+++ b/src/strongbox/gitlab_api.clj
@@ -265,3 +265,9 @@
                          (clojure.string/split #"/")))] ;; ["group" "owner" "project"]
     (when (> (count bits) 1)
       (clojure.string/join "/" bits))))
+
+;;
+
+(defn-spec make-url (s/or :ok ::sp/url, :error nil?)
+  [toc (s/or :just-toc :addon/toc, :mixed :addon/toc+nfo)]
+  (str "https://gitlab.com/" (:source-id toc)))

--- a/src/strongbox/gitlab_api.clj
+++ b/src/strongbox/gitlab_api.clj
@@ -268,6 +268,8 @@
 
 ;;
 
-(defn-spec make-url (s/or :ok ::sp/url, :error nil?)
-  [toc (s/or :just-toc :addon/toc, :mixed :addon/toc+nfo)]
-  (str "https://gitlab.com/" (:source-id toc)))
+(defn make-url
+  "returns a URL to the given addon data"
+  [{:keys [source-id]}]
+  (when source-id
+    (str "https://gitlab.com/" source-id)))

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -65,6 +65,7 @@
              :source (:source addon)
              :source-id (:source-id addon)
 
+             ;; record the origin and it's ID so we can switch back to it later if other sources present themselves.
              :source-map-list [{:source (:source addon) :source-id (:source-id addon)}]}
 
         ;; users can set this in the nfo file manually or

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -26,15 +26,6 @@
   (when-not (s/valid? spec x)
     (s/explain spec x)))
 
-(defn spec-to-kw-list
-  "very limited. only works for basic specs that have a :req [keys] and :opt [keys]"
-  [spec]
-  (let [required #(nth % 2)
-        optional #(last %)
-        extract (juxt optional required)
-        normalise (comp keyword name)]
-    (->> spec clojure.spec.alpha/form extract (apply concat) (mapv normalise))))
-
 (s/def ::atom #(instance? clojure.lang.Atom %))
 
 (s/def ::list-of-strings (s/coll-of string?))
@@ -246,14 +237,14 @@
 (s/def ::group-addons :addon/toc-list)
 
 ;; 'nfo' files contain extra per-addon data written to addon directories as .strongbox.json.
-;; note! this form is being targeted by `spec-to-kw-list` in nfo.clj to strip unspecced keys before writing to file.
 (s/def :addon/-nfo (s/keys :req-un [::installed-version
                                     ::name
                                     ::group-id
                                     ::primary?
                                     :addon/source
                                     ::installed-game-track
-                                    :addon/source-id]
+                                    :addon/source-id
+                                    :addon/source-map-list]
                            :opt-un [::ignore?
                                     :addon/pinned-version]))
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -273,7 +273,6 @@
           :opt-un [::description ;; wowinterface summaries have no description. github may not have a description.
                    :addon/created-date ;; wowinterface summaries have no created date
                    ::game-track-list   ;; more of a set, really
-                   ;;:addon/source-map-list
                    ]))
 (s/def :addon/summary-list (s/coll-of :addon/summary))
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -219,6 +219,10 @@
                            :unknown string?))
 (s/def :addon/source-id (s/or ::integer-id? int? ;; tukui has negative ids
                               ::string-id? string?))
+
+(s/def :addon/source-map (s/keys :req-un [:addon/source :addon/source-id]))
+(s/def :addon/source-map-list (s/coll-of :addon/source-map :kind vector?))
+
 (s/def :addon/created-date ::inst)
 (s/def :addon/updated-date ::inst)
 
@@ -232,9 +236,10 @@
                    ::interface-version
                    ::installed-version
                    :addon/supported-game-tracks]
-          ;; todo: revisit all of these
-          ;;:opt-un [::group-id ::primary? ::group-addons :addon/source :addon/source-id]
-          ))
+          :opt-un [;; toc file may contain addon host information but it's not guaranteed.
+                   :addon/source
+                   :addon/source-id
+                   :addon/source-map-list]))
 (s/def :addon/toc-list (s/coll-of :addon/toc))
 
 ;; circular dependency? :addon/toc has an optional ::group-addons and ::group-addons is a list of :addon/toc ? oof
@@ -274,9 +279,10 @@
                    ::download-count
                    :addon/source
                    :addon/source-id]
-          :opt-un [::description ;; wowinterface summaries have no description
+          :opt-un [::description ;; wowinterface summaries have no description. github may not have a description.
                    :addon/created-date ;; wowinterface summaries have no created date
-                   ::game-track-list ;; more of a set, really
+                   ::game-track-list   ;; more of a set, really
+                   ;;:addon/source-map-list
                    ]))
 (s/def :addon/summary-list (s/coll-of :addon/summary))
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -134,7 +134,7 @@
 ;; column lists
 
 ;; all known columns. also constitutes the column order.
-(def known-column-list [:browse-local :source :source-id :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
+(def known-column-list [:browse-local :source :source-id :source-map-list :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
 
 ;; default set of columns
 (def default-column-list [:source :name :description :installed-version :available-version :game-version :uber-button])

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -161,11 +161,7 @@
                         {:source "tukui"
                          :source-id x-tukui-id})
 
-         wago-source (when-let [x-wago-id (-> keyvals :x-wago-id)]
-                       {:source "wago"
-                        :source-id x-wago-id})
-
-         source-map-list (when-let [items (->> [wowi-source curse-source tukui-source wago-source]
+         source-map-list (when-let [items (->> [wowi-source curse-source tukui-source]
                                                utils/items
                                                utils/nilable)]
                            {:source-map-list items})

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -161,6 +161,15 @@
                         {:source "tukui"
                          :source-id x-tukui-id})
 
+         wago-source (when-let [x-wago-id (-> keyvals :x-wago-id)]
+                       {:source "wago"
+                        :source-id x-wago-id})
+
+         source-map-list (when-let [items (->> [wowi-source curse-source tukui-source wago-source]
+                                               utils/items
+                                               utils/nilable)]
+                           {:source-map-list items})
+
          ;; todo: add support for x-github
          ;; ## X-Github: https://github.com/teelolws/Altoholic-Retail => source "github", source-id "teelolws/Altoholic-Retail"
 
@@ -199,7 +208,7 @@
 
          ;; yes, this prefers curseforge over wowinterface. and tukui over all others.
          ;; I need to figure out some way of supporting multiple hosts per-addon
-         addon (merge addon alias wowi-source curse-source tukui-source ignore-flag)]
+         addon (merge addon alias wowi-source curse-source tukui-source ignore-flag source-map-list)]
 
      addon)))
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -1,5 +1,6 @@
 (ns strongbox.ui.cli
   (:require
+   [clojure.string]
    [orchestra.core :refer [defn-spec]]
    [taoensso.timbre :as timbre :refer [debug info warn error report spy]]
    [clojure.spec.alpha :as s]
@@ -629,6 +630,14 @@
   {:browse-local {:label "browse" :value-fn :addon-dir}
    :source {:label "source" :value-fn :source}
    :source-id {:label "ID" :value-fn :source-id}
+   :source-map-list {:label "other sources" :value-fn (fn [row]
+                                                        (->> row
+                                                             :source-map-list
+                                                             (map :source)
+                                                             (remove #(= % (:source row)))
+                                                             vec
+                                                             utils/nilable
+                                                             (clojure.string/join ", ")))}
    :name {:label "name" :value-fn (comp utils/no-new-lines :label)}
    :description {:label "description" :value-fn (comp utils/no-new-lines :description)}
    :tag-list {:label "tags" :value-fn (fn [row]

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -679,7 +679,18 @@
   (sort-by (fn [x]
              (.indexOf sp/known-column-list x)) column-list))
 
+;; source switching
+
+(defn-spec switch-source (s/or :ok :addon/toc+nfo, :error nil?)
+  "switches addon from one source (like curseforge) to another (like wowinterface), rewriting nfo data.
+  `new-source` must appear in the addon's `source-map-list`."
+  [addon :addon/toc+nfo, new-source-map :addon/source-map]
+  (addon/switch-source! (core/selected-addon-dir) addon new-source-map)
+  (half-refresh))
+
+
 ;; debug
+
 
 (defn-spec touch nil?
   "used to select each addon in the GUI so the 'unsteady' colour can be tested."

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -56,8 +56,7 @@
         vec
         select-addons*)))
 
-;; unselect? https://english.stackexchange.com/questions/18465/unselect-or-deselect
-(defn-spec deselect-addons! nil?
+(defn-spec clear-selected-addons! nil?
   "removes all addons from the `:selected-addon-list` list"
   []
   (select-addons* []))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1126,7 +1126,7 @@
          :source-map-list {:cell-factory {:fx/cell-type :tree-table-cell
                                           :describe (fn [row]
                                                       (let [urls (for [source-map (:source-map-list row)
-                                                                       :let [url (utils/addon-source-map-to-url row source-map)]
+                                                                       :let [url (cli/addon-source-map-to-url row source-map)]
                                                                        :when (and url
                                                                                   (not (= (:source row) (:source source-map))))]
                                                                    (href-to-hyperlink (assoc source-map :url url)))
@@ -1440,6 +1440,7 @@
         (:release-list addon)))
 
 (defn-spec build-addon-source-menu (s/or :ok ::sp/list-of-maps, :no-sources nil?)
+  "context sub-menu for addons that have multiple sources."
   [addon map?]
   (let [source-map-list (:source-map-list addon)]
     (when (> (count source-map-list) 1) ;; don't bother if the only source we have is the current one

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1466,15 +1466,18 @@
         source-menu (build-addon-source-menu selected-addon)]
 
     {:fx/type :context-menu
-     :items [(menu "Source" (or source-menu []) {:disable (nil? source-menu)})
-             separator
-             (menu-item "Update" (async-handler (juxt cli/update-selected clear-table-selected-items))
+     :items [(menu-item "Update" (async-handler (juxt cli/update-selected clear-table-selected-items))
                         {:disable (or child?
                                       (not (addon/updateable? selected-addon)))})
 
              (menu-item "Re-install" (async-handler (juxt cli/re-install-or-update-selected clear-table-selected-items))
                         {:disable (or child?
                                       (not (addon/re-installable? selected-addon)))})
+             separator
+             (menu "Source" (or source-menu []) {:disable (nil? source-menu)})
+             (menu-item "Find similar" (async-handler (fn []
+                                                        (switch-tab SEARCH-TAB)
+                                                        (cli/search (:label selected-addon)))))
              separator
              (if pinned?
                (menu-item "Unpin release" (async-handler (juxt cli/unpin clear-table-selected-items))
@@ -1505,12 +1508,13 @@
     {:fx/type :context-menu
      :items [(menu-item (str num-selected " addons selected") donothing {:disable true})
              separator
-             (menu-item "Migrate" donothing {:disable true})
-             separator
              (menu-item "Update" (async-handler (juxt cli/update-selected clear-table-selected-items))
                         {:disable none-selected?})
              (menu-item "Re-install" (async-handler (juxt cli/re-install-or-update-selected clear-table-selected-items))
                         {:disable none-selected?})
+             separator
+             (menu "Source" [] {:disable true})
+             (menu-item "Find similar" donothing {:disable true})
              separator
              (if some-pinned?
                (menu-item "Unpin release" (async-handler (juxt cli/unpin clear-table-selected-items)))
@@ -1808,7 +1812,8 @@
      [{:fx/type :text-field
        :id "search-text-field"
        :prompt-text "search"
-       ;;:text (:term search-state) ;; don't do this
+       ;;:text (:term search-state) ;; don't do this, it can go spastic
+       :text (core/get-state :search :term) ;; this seems ok, probably has it's own drawbacks
        :on-text-changed cli/search}
 
       {:fx/type :button

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -657,7 +657,7 @@
 
 (defn-spec clear-table-selected-items nil?
   "the context menu isn't being refreshed with new data when selected or installed addons change. 
-  It should be, but isn't. 
+  It should be, but isn't.
   A way around this is to clear the selected items in the table after a context menu action forcing a re-selection."
   []
   (.clearSelection (.getSelectionModel (find-installed-addons-table))))
@@ -1447,7 +1447,9 @@
               {:fx/type :check-menu-item
                :text (:source source-map)
                :selected (-> addon :source (= (:source source-map)))
-               :on-action (async-handler (partial cli/switch-source addon source-map))})
+               :on-action (async-handler (fn []
+                                           (cli/switch-source addon source-map)
+                                           (clear-table-selected-items)))})
             source-map-list))))
 
 (defn singular-context-menu

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1123,6 +1123,21 @@
                                              {:graphic (href-to-hyperlink row)})}
                   :cell-value-factory identity}
          :source-id {:min-width 60 :pref-width 150}
+         :source-map-list {:cell-factory {:fx/cell-type :tree-table-cell
+                                          :describe (fn [row]
+                                                      (let [urls (for [source-map (:source-map-list row)
+                                                                       :let [url (utils/addon-source-map-to-url row source-map)]
+                                                                       :when (and url
+                                                                                  (not (= (:source row) (:source source-map))))]
+                                                                   (href-to-hyperlink (assoc source-map :url url)))
+                                                            urls (utils/nilable (vec urls))]
+                                                        (if urls
+                                                          {:graphic {:fx/type :h-box
+                                                                     :children urls}}
+                                                          {:graphic {:fx/type :label
+                                                                     :text ""}})))}
+                           :cell-value-factory identity}
+
          :name {:min-width 100 :pref-width 300}
          :description {:min-width 150 :pref-width 450}
          :tag-list {:min-width 200 :pref-width 300}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1432,8 +1432,7 @@
               {:fx/type :check-menu-item
                :text (:source source-map)
                :selected (-> addon :source (= (:source source-map)))
-               :on-action (async-handler (partial cli/switch-source addon source-map))
-               })
+               :on-action (async-handler (partial cli/switch-source addon source-map))})
             source-map-list))))
 
 (defn singular-context-menu

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -684,28 +684,6 @@
                     nil)
       nil)))
 
-(defn url-encode
-  [string]
-  (if string
-    (java.net.URLEncoder/encode string "UTF-8")
-    ""))
-
-(defn-spec addon-source-map-to-url (s/or :ok ::sp/url, :error nil?)
-  "construct a URL given a `source`, `source-id` and toc data only.
-  caveats: 
-  * curseforge, can't go directly to an addon with just the source-id, so we use the slug and hope for the best.
-  * tukui, we also need the game track to know which url"
-  [addon :addon/toc, source-map :addon/source-map]
-  (case (:source source-map)
-    ;;"curseforge" (str "https://www.curseforge.com/wow/addons/search?search=" (-> addon :label java.net.URLEncoder/encode))
-    "curseforge" (str "https://www.curseforge.com/wow/addons/" (-> addon :name)) ;; still not great but about ~80% hit rate.
-    "wowinterface" (str "https://www.wowinterface.com/downloads/info" (-> source-map :source-id))
-    "tukui" (str "https://www.tukui.org/addons.php?search=" (-> addon :label url-encode))
-    "github" (str "https://github.com/" (-> source-map :source-id))
-    "gitlab" (str "https://gitlab.com/" (-> source-map :source-id))
-
-    nil))
-
 (defn-spec message-list string?
   "returns a multi-line string with the given `msg` on top and each message in `msg-list` bulleted beneath it"
   [msg string?, msg-list ::sp/list-of-strings]

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -684,6 +684,28 @@
                     nil)
       nil)))
 
+(defn url-encode
+  [string]
+  (if string
+    (java.net.URLEncoder/encode string "UTF-8")
+    ""))
+
+(defn-spec addon-source-map-to-url (s/or :ok ::sp/url, :error nil?)
+  "construct a URL given a `source`, `source-id` and toc data only.
+  caveats: 
+  * curseforge, can't go directly to an addon with just the source-id, so we use the slug and hope for the best.
+  * tukui, we also need the game track to know which url"
+  [addon :addon/toc, source-map :addon/source-map]
+  (case (:source source-map)
+    ;;"curseforge" (str "https://www.curseforge.com/wow/addons/search?search=" (-> addon :label java.net.URLEncoder/encode))
+    "curseforge" (str "https://www.curseforge.com/wow/addons/" (-> addon :name)) ;; still not great but about ~80% hit rate.
+    "wowinterface" (str "https://www.wowinterface.com/downloads/info" (-> source-map :source-id))
+    "tukui" (str "https://www.tukui.org/addons.php?search=" (-> addon :label url-encode))
+    "github" (str "https://github.com/" (-> source-map :source-id))
+    "gitlab" (str "https://gitlab.com/" (-> source-map :source-id))
+
+    nil))
+
 (defn-spec message-list string?
   "returns a multi-line string with the given `msg` on top and each message in `msg-list` bulleted beneath it"
   [msg string?, msg-list ::sp/list-of-strings]

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -580,11 +580,14 @@
 (deftest switch-source
   (testing "an addon can switch between sources"
     (let [new-source-map {:source "wowinterface" :source-id 321}
+          ;; attach extra source-map to the toc data so we can switch to it
           addon (merge helper/strongbox-installed-addon
                        {:source-map-list [new-source-map]})
-          nfo-data {:source-map-list [new-source-map]}
-          expected (merge helper/nfo-data new-source-map nfo-data)]
-      (helper/install-every-addon! nfo-data)
+          expected (merge helper/nfo-data
+                          new-source-map
+                          {:source-map-list [{:source "curseforge" :source-id 1} ;; original is preserved
+                                             new-source-map]})] ;; new one is present
+      (helper/install-every-addon!)
       (is (nil? (addon/switch-source! (helper/install-dir) addon new-source-map)))
       (is (= expected (nfo/read-nfo (helper/install-dir) (:dirname helper/toc-data)))))))
 

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -590,7 +590,9 @@
                     :source-id 123
 
                     ;; synthetic
-                    :url "https://example.org" ;; url won't be derived from source and id
+                    ;; 2021-12-30: changed, group-id is now ignored in favour of reconstructing the URL.
+                    ;;:url "https://example.org" ;; url won't be derived from source and id
+                    :url "https://www.wowinterface.com/downloads/info123"
                     :download-count 0,
                     :game-track-list [:classic], ;; classic is used
                     :tag-list [],
@@ -638,6 +640,24 @@
                                 {:source "curseforge"
                                  :source-id 123})]
       (is (nil? (catalogue/toc2summary curseforge-toc))))))
+
+(deftest toc2summary--github
+  (testing "toc data with a github source and id can be coerced to an addon summary without a `:url`"
+    (let [github-toc (merge helper/toc-data
+                            {:source "github"
+                             :source-id "everyman/everyaddon"})
+
+          expected {:source "github",
+                    :source-id "everyman/everyaddon",
+                    :name "everyaddon",
+                    :label "EveryAddon 1.2.3",
+
+                    ;; synthetic
+                    :tag-list [],
+                    :updated-date "2001-01-01T01:01:01Z",
+                    :url "https://github.com/everyman/everyaddon"
+                    :download-count 0}]
+      (is (= expected (catalogue/toc2summary github-toc))))))
 
 (deftest toc2summary--ignored
   (testing "any data that is ignored cannot be coerced to an addon summary, even if all the right data is there."

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -8,7 +8,7 @@
     [constants :as constants]
     [logging :as logging]
     [catalogue :as catalogue]
-    [test-helper :refer [fixture-path toc]]]
+    [test-helper :as helper :refer [fixture-path]]]
    [clj-http.fake :refer [with-fake-routes-in-isolation]]))
 
 (deftest de-dupe-wowinterface
@@ -573,16 +573,17 @@
 
 (deftest toc2summary--plain
   (testing "plain toc data with no extras can't be coerced into an addon summary"
-    (is (nil? (catalogue/toc2summary toc)))))
+    (is (nil? (catalogue/toc2summary helper/toc-data)))))
 
 (deftest toc2summary--toc+nfo
   (testing "toc with extra nfo data *can* be coerced into an addon summary with less guessing"
-    (let [toc+nfo (merge toc {:group-id "https://example.org"
-                              :source "wowinterface"
-                              :source-id 123
-                              :interface-version constants/default-interface-version-classic
-                              :toc/game-track :classic
-                              :supported-game-tracks [:classic]})
+    (let [toc+nfo (merge helper/toc-data
+                         {:group-id "https://example.org"
+                          :source "wowinterface"
+                          :source-id 123
+                          :interface-version constants/default-interface-version-classic
+                          :toc/game-track :classic
+                          :supported-game-tracks [:classic]})
           expected {:label "EveryAddon 1.2.3",
                     :name "everyaddon",
                     :source "wowinterface",
@@ -598,8 +599,9 @@
 
 (deftest toc2summary--wowinterface
   (testing "toc data with a wowinterface source and id *can* be coerced to addon summary without a `:url`"
-    (let [wowinterface-toc (merge toc {:source "wowinterface"
-                                       :source-id 123})
+    (let [wowinterface-toc (merge helper/toc-data
+                                  {:source "wowinterface"
+                                   :source-id 123})
           expected {:label "EveryAddon 1.2.3",
                     :name "everyaddon",
                     :source "wowinterface",
@@ -615,8 +617,9 @@
 
 (deftest toc2summary--tukui
   (testing "toc data with a tukui source and id can be coerced to an addon summary without a `:url`"
-    (let [tukui-toc (merge toc {:source "tukui"
-                                :source-id 123})
+    (let [tukui-toc (merge helper/toc-data
+                           {:source "tukui"
+                            :source-id 123})
           expected {:source "tukui",
                     :source-id 123,
                     :name "everyaddon",
@@ -631,16 +634,18 @@
 
 (deftest toc2summary--curseforge
   (testing "toc data with a curseforge source and id cannot be coerced to an addon summary without a `:url`"
-    (let [curseforge-toc (merge toc {:source "curseforge"
-                                     :source-id 123})]
+    (let [curseforge-toc (merge helper/toc-data
+                                {:source "curseforge"
+                                 :source-id 123})]
       (is (nil? (catalogue/toc2summary curseforge-toc))))))
 
 (deftest toc2summary--ignored
   (testing "any data that is ignored cannot be coerced to an addon summary, even if all the right data is there."
-    (let [toc (merge toc {:source "wowinterface"
-                          :source-id 123
-                          :ignore? true})]
-      (is (nil? (catalogue/toc2summary toc))))))
+    (let [wowi-toc (merge helper/toc-data
+                          {:source "wowinterface"
+                           :source-id 123
+                           :ignore? true})]
+      (is (nil? (catalogue/toc2summary wowi-toc))))))
 
 (deftest filter-catalogue
   (testing "a catalogue can have it's addon-summary-list filtered by a specific source"

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -373,7 +373,8 @@
                     :name "rotation-master",
                     :primary? true,
                     :source "wowinterface",
-                    :source-id 25079}
+                    :source-id 25079
+                    :source-map-list [{:source "wowinterface" :source-id 25079}]}
 
           expected-addon-dir (utils/join install-dir "EveryAddon")
           expected-user-catalogue [match]
@@ -442,7 +443,8 @@
                     :name "everyaddon",
                     :primary? true,
                     :source "curseforge",
-                    :source-id 1}
+                    :source-id 1
+                    :source-map-list [{:source "curseforge" :source-id 1}]}
 
           expected-addon-dir (utils/join install-dir "EveryAddon")
           expected-user-catalogue [match]
@@ -511,7 +513,8 @@
                     :name "-rp-tags",
                     :primary? true,
                     :source "tukui",
-                    :source-id 98}
+                    :source-id 98
+                    :source-map-list [{:source "tukui" :source-id 98}]}
 
           expected-addon-dir (utils/join install-dir "EveryAddon")
           expected-user-catalogue [match]

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -266,13 +266,14 @@
                            :installed-game-track :retail
                            :game-track :retail
                            :name "everyaddon",
-                           :source "curseforge",
                            :interface-version 80000,
                            :supported-game-tracks [:retail]
                            :download-url "https://edge.forgecdn.net/files/1/1/EveryAddon.zip",
                            :label "EveryAddon",
                            :download-count 3000000,
+                           :source "curseforge",
                            :source-id 1,
+                           :source-map-list [{:source "curseforge" :source-id 1}]
                            :url "https://www.curseforge.com/wow/addons/everyaddon",
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
@@ -294,13 +295,14 @@
                            :installed-game-track :retail
                            :game-track :retail
                            :name "everyotheraddon",
-                           :source "curseforge",
                            :interface-version 80200,
                            :supported-game-tracks [:retail]
                            :download-url "https://edge.forgecdn.net/files/2/2/EveryOtherAddon.zip",
                            :label "Every Other Addon",
                            :download-count 5400000,
+                           :source "curseforge",
                            :source-id 2,
+                           :source-map-list [{:source "curseforge" :source-id 2}]
                            :url "https://www.curseforge.com/wow/addons/everyotheraddon",
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
@@ -365,13 +367,14 @@
                            :installed-game-track :retail
                            :game-track :retail
                            :name "everyaddon",
-                           :source "curseforge",
                            :interface-version 80000,
                            :supported-game-tracks [:retail]
                            :download-url "https://edge.forgecdn.net/files/1/1/EveryAddon.zip",
                            :label "EveryAddon",
                            :download-count 3000000,
+                           :source "curseforge",
                            :source-id 1,
+                           :source-map-list [{:source "curseforge" :source-id 1}]
                            :url "https://www.curseforge.com/wow/addons/everyaddon",
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
@@ -396,6 +399,8 @@
                            :game-track :classic
                            :name "everyotheraddon",
                            :source "curseforge",
+                           :source-id 2,
+                           :source-map-list [{:source "curseforge" :source-id 2}]
                            :interface-version 11300, ;; changed
 
                            ;; why :retail? According to EveryOtherAddon.toc, it's actually a retail addon and not a classic addon.
@@ -406,7 +411,6 @@
                            :download-url "https://edge.forgecdn.net/files/2/2/EveryOtherAddon.zip",
                            :label "Every Other Addon",
                            :download-count 5400000,
-                           :source-id 2,
                            :url "https://www.curseforge.com/wow/addons/everyotheraddon",
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
@@ -632,7 +636,8 @@
                           :installed-game-track :retail,
                           :primary? false,
                           :source "curseforge",
-                          :source-id 1}]
+                          :source-id 1
+                          :source-map-list [{:source "curseforge" :source-id 1}]}]
         (is result) ;; success
         (is (= ["EveryAddon" "EveryAddon-BundledAddon" "everyaddon--0-1-2.zip"] directory-list))
         (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon-BundledAddon")))))))
@@ -872,21 +877,24 @@
                        :name "everyaddon"
                        :primary? false
                        :source "curseforge"
-                       :source-id 1}
+                       :source-id 1
+                       :source-map-list [{:source "curseforge" :source-id 1}]}
                       {:group-id "https://group.id/also/never/fetched",
                        :installed-game-track :retail,
                        :installed-version "5.6.7",
                        :name "everyotheraddon",
                        :primary? false,
                        :source "curseforge",
-                       :source-id 2}
+                       :source-id 2
+                       :source-map-list [{:source "curseforge" :source-id 2}]}
                       {:group-id "https://group.id/still/not/fetched",
                        :installed-game-track :retail,
                        :installed-version "a.b.c",
                        :name "bundledaddon",
                        :primary? true,
                        :source "curseforge",
-                       :source-id 3}]]
+                       :source-id 3
+                       :source-map-list [{:source "curseforge" :source-id 3}]}]]
 
         (core/install-addon-guard addon-1)
         (is (= ["EveryAddon" "EveryAddon-BundledAddon"] (helper/install-dir-contents)))
@@ -952,7 +960,8 @@
                         :name "everyaddon"
                         :primary? false
                         :source "curseforge"
-                        :source-id 1}]
+                        :source-id 1
+                        :source-map-list [{:source "curseforge" :source-id 1}]}]
 
           (core/install-addon-guard addon-1)
           (is (= ["EveryAddon" "EveryAddon-BundledAddon"] (helper/install-dir-contents)))
@@ -995,7 +1004,8 @@
                         :name "everyotheraddon"
                         :primary? false
                         :source "curseforge"
-                        :source-id 2}]
+                        :source-id 2
+                        :source-map-list [{:source "curseforge" :source-id 2}]}]
 
           (core/install-addon-guard addon-1)
           (is (= ["EveryAddon" "EveryAddon-BundledAddon"] (helper/install-dir-contents)))
@@ -1195,6 +1205,7 @@
                         :primary? true,
                         :source "curseforge",
                         :source-id 1,
+                        :source-map-list [{:source "curseforge" :source-id 1}]
                         :update? false}]
           (core/install-addon-guard addon)
           (is (= ["EveryAddon"] (helper/install-dir-contents)))
@@ -1234,6 +1245,7 @@
                         :primary? true,
                         :source "curseforge",
                         :source-id 1,
+                        :source-map-list [{:source "curseforge" :source-id 1}]
                         :update? false}]
           (core/install-addon-guard addon)
           (core/load-installed-addons)
@@ -1281,7 +1293,8 @@
                                         :name "everyotheraddon",
                                         :primary? false,
                                         :source "curseforge",
-                                        :source-id 2}
+                                        :source-id 2
+                                        :source-map-list [{:source "curseforge" :source-id 2}]}
 
                                        {:description "Does what every addon does, just better",
                                         :dirname "EveryOtherAddon",
@@ -1294,7 +1307,8 @@
                                         :name "everyotheraddon",
                                         :primary? false,
                                         :source "curseforge",
-                                        :source-id 2}],
+                                        :source-id 2
+                                        :source-map-list [{:source "curseforge" :source-id 2}]}],
                         :group-id "https://group.id/also/never/fetched",
                         :ignore? true,
                         :installed-game-track :retail,
@@ -1305,7 +1319,8 @@
                         :name "everyotheraddon",
                         :primary? false,
                         :source "curseforge",
-                        :source-id 2}
+                        :source-id 2
+                        :source-map-list [{:source "curseforge" :source-id 2}]}
 
               target-idx 0
               expected-2 (-> expected
@@ -1352,6 +1367,7 @@
                         :primary? true,
                         :source "curseforge",
                         :source-id 1,
+                        :source-map-list [{:source "curseforge" :source-id 1}]
                         :update? false}]
           (core/install-addon-guard addon)
           (fs/mkdir (utils/join install-dir "EveryAddon" ".git"))

--- a/test/strongbox/github_api_test.clj
+++ b/test/strongbox/github_api_test.clj
@@ -623,3 +623,13 @@
                      {:get (fn [req] {:status 200 :body fixture})}}]
     (with-fake-routes-in-isolation fake-routes
       (is (= expected (github-api/build-catalogue))))))
+
+(deftest make-url
+  (let [cases [[nil nil]
+               [{} nil]
+               [{:foo :bar} nil]
+               [{:source-id ""} "https://github.com/"]
+               [{:source-id "foo"} "https://github.com/foo"]
+               [{:source-id "foo/bar"} "https://github.com/foo/bar"]]]
+    (doseq [[given expected] cases]
+      (is (= expected (github-api/make-url given))))))

--- a/test/strongbox/gitlab_api_test.clj
+++ b/test/strongbox/gitlab_api_test.clj
@@ -370,3 +370,13 @@
                      {:get (fn [req] {:status 200 :body "{}"})}}]
     (with-fake-routes-in-isolation fake-routes
       (is (= expected (gitlab-api/guess-game-track-list source-id))))))
+
+(deftest make-url
+  (let [cases [[nil nil]
+               [{} nil]
+               [{:foo :bar} nil]
+               [{:source-id ""} "https://gitlab.com/"]
+               [{:source-id "foo"} "https://gitlab.com/foo"]
+               [{:source-id "foo/bar"} "https://gitlab.com/foo/bar"]]]
+    (doseq [[given expected] cases]
+      (is (= expected (gitlab-api/make-url given))))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -77,6 +77,7 @@
   (let [expected [{:fx/type :check-menu-item, :text "browse", :selected false}
                   {:fx/type :check-menu-item, :text "source", :selected true}
                   {:fx/type :check-menu-item, :text "ID", :selected true}
+                  {:fx/type :check-menu-item, :text "other sources", :selected false}
                   {:fx/type :check-menu-item, :text "name", :selected false}
                   {:fx/type :check-menu-item, :text "description", :selected false}
                   {:fx/type :check-menu-item, :text "tags", :selected false}

--- a/test/strongbox/nfo_test.clj
+++ b/test/strongbox/nfo_test.clj
@@ -79,8 +79,8 @@
           expected nil]
       (doseq [nfo-data invalid-nfo-data]
         (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
-        (is (= expected (nfo/read-nfo (install-dir) addon-dir)), (str "failed: " nfo-data))))))
-        ;;(is (not (fs/exists? (nfo/read-nfo (install-dir) addon-dir))))))))
+        (is (= expected (nfo/read-nfo (install-dir) addon-dir)), (str "failed: " nfo-data))
+        (is (not (fs/exists? (nfo/read-nfo (install-dir) addon-dir))))))))
 
 (deftest read-nfo--ignorable-subdir
   (testing "an addon with no nfo data but an ignorable sub-directory returns the 'ignore flag'"

--- a/test/strongbox/nfo_test.clj
+++ b/test/strongbox/nfo_test.clj
@@ -48,7 +48,8 @@
                     :group-id "https://foo.bar"
                     :primary? true
                     :source "curseforge"
-                    :source-id 321}]
+                    :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]}]
       (nfo/write-nfo (install-dir) addon-dir nfo-data)
       (is (fs/exists? (nfo/nfo-path (install-dir) addon-dir)))))
 
@@ -60,6 +61,7 @@
                     :primary? true
                     :source "curseforge"
                     :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]
 
                     :foo "bar!"}
           expected (dissoc nfo-data :foo)]
@@ -69,20 +71,23 @@
 (deftest read-nfo
   (testing "an addon with no nfo data returns nothing"
     (let [expected nil]
-      (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
+      (is (= expected (nfo/read-nfo (install-dir) addon-dir))))))
 
+(deftest read-nfo--invalid
   (testing "invalid nfo data returns `nil` and the nfo file is deleted"
     (let [invalid-nfo-data [{} [] 1 {:foo "bar"} "null"]
           expected nil]
       (doseq [nfo-data invalid-nfo-data]
         (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
-        (is (= expected (nfo/read-nfo (install-dir) addon-dir)))
-        (is (not (fs/exists? (nfo/read-nfo (install-dir) addon-dir)))))))
+        (is (= expected (nfo/read-nfo (install-dir) addon-dir)), (str "failed: " nfo-data))))))
+        ;;(is (not (fs/exists? (nfo/read-nfo (install-dir) addon-dir))))))))
 
+(deftest read-nfo--ignorable-subdir
   (testing "an addon with no nfo data but an ignorable sub-directory returns the 'ignore flag'"
     (let [expected {:ignore? true}]
-      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir)))))
+      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir))))))
 
+(deftest read-nfo--v1
   (testing "an addon with v1 nfo data is parsed correctly"
     (let [nfo-data {:installed-version "1.0"
                     :name "someaddon"
@@ -94,10 +99,15 @@
                     ;; may not have actually been installed from the retail track, we had to guess
                     ;; this will be updated as the addon is updated
                     :installed-game-track :retail}
-          expected nfo-data]
-      (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
-      (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
 
+          ;; 2021-12-20: new.
+          source-map-list {:source-map-list [{:source "wowinterface" :source-id 123}]}
+
+          expected (merge nfo-data source-map-list)]
+      (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
+      (is (= expected (nfo/read-nfo (install-dir) addon-dir))))))
+
+(deftest read-nfo--v1--ignorable-subdir
   (testing "an addon with v1 nfo data AND an ignorable sub-directory is parsed correctly"
     (let [nfo-data {:installed-version "1.0"
                     :name "someaddon"
@@ -109,10 +119,17 @@
                     ;; may not have actually been installed from the retail track, we had to guess
                     ;; this will be updated as the addon is updated
                     :installed-game-track :retail}
-          expected (assoc nfo-data :ignore? true)]
-      (spit (utils/join (ignorable-addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
-      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir)))))
 
+          ;; 2021-12-20: new.
+          source-map-list {:source-map-list [{:source "wowinterface" :source-id 123}]}
+
+          expected (merge nfo-data
+                          {:ignore? true}
+                          source-map-list)]
+      (spit (utils/join (ignorable-addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
+      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir))))))
+
+(deftest read-nfo--v2--ignorable-subdir--ignore-flag
   (testing "an addon with nfo v2 data, an ignorable sub-directory AND an ignore flag, is parsed correctly"
     (let [nfo-data {:installed-version "1.0"
                     :name "someaddon"
@@ -120,6 +137,7 @@
                     :primary? true
                     :source "wowinterface"
                     :source-id 123
+                    :source-map-list [{:source "wowinterface", :source-id 123}]
 
                     ;; user has manually marked this development addon for updates.
                     ;; this is only set by the user, not by the app (for now)
@@ -154,7 +172,8 @@
                   :group-id "https://foo.bar"
                   :primary? true
                   :source "curseforge"
-                  :source-id 321}]
+                  :source-id 321
+                  :source-map-list [{:source "curseforge" :source-id 321}]}]
 
     (testing "handles nil nfo data (for when nfo data doesn't exist)"
       (let [expected nil]
@@ -190,12 +209,16 @@
 
           updates {:source "wowinterface"}
 
-          expected (merge nfo-data updates)]
+          ;; 2021-12-20: new.
+          source-map-list {:source-map-list [{:source "curseforge" :source-id 321}]}
 
-      (nfo/write-nfo (install-dir) addon-dir nfo-data)
+          expected (merge nfo-data updates source-map-list)]
+
+      (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
       (nfo/update-nfo (install-dir) addon-dir updates)
-      (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
+      (is (= expected (nfo/read-nfo (install-dir) addon-dir))))))
 
+(deftest update-nfo-data--invalid-data
   (testing "invalid data is not updated"
     (let [nfo-data {:installed-version "1.2.1"
                     :installed-game-track :classic
@@ -207,10 +230,13 @@
 
           updates {:installed-game-track :foo}
 
-          expected nfo-data
+          ;; 2021-12-20: new.
+          source-map-list {:source-map-list [{:source "curseforge" :source-id 321}]}
+
+          expected (merge nfo-data source-map-list)
           expected-log ["new \".strongbox.json\" data is invalid and won't be written to file"]]
 
-      (nfo/write-nfo (install-dir) addon-dir nfo-data)
+      (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
       (is (= expected-log
              (logging/buffered-log :error
                                    (nfo/update-nfo (install-dir) addon-dir updates))))
@@ -249,7 +275,8 @@
                     :group-id "https://foo.bar"
                     :primary? true
                     :source "curseforge"
-                    :source-id 321}
+                    :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]}
           expected-raw nfo-data ;; no change in file
           expected (assoc nfo-data :ignore? true)] ;; back to being implicitly ignored
       (nfo/write-nfo (install-dir) ignorable-addon-dir nfo-data)
@@ -265,6 +292,7 @@
                     :primary? true
                     :source "curseforge"
                     :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]
                     :ignore? false} ;; explicit ignore flag
           expected-raw (dissoc nfo-data :ignore?)
           expected (assoc nfo-data :ignore? true)] ;; back to being implicitly ignored
@@ -281,7 +309,8 @@
                     :group-id "https://foo.bar"
                     :primary? true
                     :source "curseforge"
-                    :source-id 321}
+                    :source-id 321
+                    :source-map-list [{:source "curseforge", :source-id 123}]}
           expected (assoc nfo-data :pinned-version "a.b.c")]
       (nfo/write-nfo (install-dir) addon-dir nfo-data)
       (nfo/pin (install-dir) addon-dir "a.b.c")
@@ -296,6 +325,8 @@
                     :primary? true
                     :source "curseforge"
                     :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]
+
                     :pinned-version "1.2.1"}
           expected (dissoc nfo-data :pinned-version)]
       (nfo/write-nfo (install-dir) addon-dir nfo-data)
@@ -309,7 +340,8 @@
                     :group-id "https://foo.bar"
                     :primary? true
                     :source "curseforge"
-                    :source-id 321}
+                    :source-id 321
+                    :source-map-list [{:source "curseforge" :source-id 321}]}
           expected nfo-data]
       (nfo/write-nfo (install-dir) addon-dir nfo-data)
       (nfo/unpin (install-dir) addon-dir)

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -32,7 +32,8 @@
    :primary? true
    :installed-game-track :retail
    :source "curseforge"
-   :source-id 1})
+   :source-id 1
+   :source-map-list [{:source "curseforge" :source-id 1}]})
 
 (def strongbox-installed-addon
   (merge toc-data nfo-data))

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -89,9 +89,12 @@ SomeAddon.lua")
                      :-toc/game-track :retail
                      :supported-game-tracks [:retail]
                      :installed-version "1.6.1"
-                     ;; wowi is edged out in favour of curseforge unfortunately
+                     ;; wowi is edged out in favour of curseforge ...
                      :source "curseforge"
-                     :source-id 54321}]]
+                     :source-id 54321
+                     ;; ... both are captured here in `:source-map-list` however
+                     :source-map-list [{:source "wowinterface" :source-id 12345}
+                                       {:source "curseforge" :source-id 54321}]}]]
       (fs/mkdir addon-path)
       (spit toc-file-path toc-file-contents)
       (is (= expected (toc/parse-addon-toc-guard addon-path))))))
@@ -147,7 +150,7 @@ SomeAddon.lua")
         (is (= expected (toc/parse-addon-toc given addon-dir)))))))
 
 (deftest parse-addon-toc--x-source
-  (testing "addons whose toc files have a 'x-$host-id=val' will use those as `:source` and `:source-id`"
+  (testing "addons whose toc files have a 'x-<host>-id' value will use those as `:source` and `:source-id`"
     (let [addon-dir (utils/join (helper/install-dir) "dirname")
           defaults {:dirname "dirname"
                     :description nil
@@ -155,18 +158,45 @@ SomeAddon.lua")
                     :interface-version constants/default-interface-version
                     :supported-game-tracks [:retail]
                     :-toc/game-track :retail}
-          cases [[{:x-wowi-id "123"} {:label "dirname *" :name "dirname-*" :source "wowinterface" :source-id 123}]
-                 [{:x-wowi-id 123} {:label "dirname *" :name "dirname-*" :source "wowinterface" :source-id 123}]
+          cases [;; wowinterface
+                 [{:x-wowi-id "123"} {:label "dirname *" :name "dirname-*"
+                                      :source "wowinterface" :source-id 123
+                                      :source-map-list [{:source "wowinterface" :source-id 123}]}]
+                 [{:x-wowi-id 123} {:label "dirname *" :name "dirname-*"
+                                    :source "wowinterface" :source-id 123
+                                    :source-map-list [{:source "wowinterface" :source-id 123}]}]
                  [{:x-wowi-id "abc"} {:label "dirname *" :name "dirname-*"}] ;; bad case, non-numeric wowi ID
 
-                 [{:x-curse-project-id "123"} {:label "dirname *" :name "dirname-*" :source "curseforge" :source-id 123}]
-                 [{:x-curse-project-id 123} {:label "dirname *" :name "dirname-*" :source "curseforge" :source-id 123}]
+                 ;; curse
+                 [{:x-curse-project-id "123"} {:label "dirname *" :name "dirname-*"
+                                               :source "curseforge" :source-id 123
+                                               :source-map-list [{:source "curseforge" :source-id 123}]}]
+                 [{:x-curse-project-id 123} {:label "dirname *" :name "dirname-*"
+                                             :source "curseforge" :source-id 123
+                                             :source-map-list [{:source "curseforge" :source-id 123}]}]
                  [{:x-curse-project-id "abc"} {:label "dirname *" :name "dirname-*"}] ;; bad case, non-numeric curse ID
 
-                 [{:x-tukui-projectid "123"} {:label "dirname *" :name "dirname-*" :source "tukui" :source-id 123}]
-                 [{:x-tukui-projectid "-1"} {:label "dirname *" :name "dirname-*" :source "tukui" :source-id -1}]
-                 [{:x-tukui-projectid 123} {:label "dirname *" :name "dirname-*" :source "tukui" :source-id 123}]
-                 [{:x-tukui-projectid "abc"} {:label "dirname *" :name "dirname-*"}]]] ;; bad case
+                 ;; tukui
+                 [{:x-tukui-projectid "123"} {:label "dirname *" :name "dirname-*"
+                                              :source "tukui" :source-id 123
+                                              :source-map-list [{:source "tukui" :source-id 123}]}]
+                 [{:x-tukui-projectid "-1"} {:label "dirname *" :name "dirname-*"
+                                             :source "tukui" :source-id -1
+                                             :source-map-list [{:source "tukui" :source-id -1}]}]
+                 [{:x-tukui-projectid 123} {:label "dirname *" :name "dirname-*"
+                                            :source "tukui" :source-id 123
+                                            :source-map-list [{:source "tukui" :source-id 123}]}]
+                 [{:x-tukui-projectid "abc"} {:label "dirname *" :name "dirname-*"}] ;; bad case
+
+                 ;; mixed
+                 [{:x-wowi-id "123"
+                   :x-tukui-projectid "123"
+                   :x-curse-project-id "123"} {:label "dirname *" :name "dirname-*"
+                                               :source "tukui" :source-id 123 ;; todo: this precedence is interesting ...
+                                               :source-map-list [{:source "wowinterface" :source-id 123}
+                                                                 {:source "curseforge" :source-id 123}
+                                                                 {:source "tukui" :source-id 123}]}]]]
+
       (fs/mkdir addon-dir)
       (doseq [[given expected] cases
               :let [expected (merge expected defaults)]]

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -92,7 +92,7 @@ SomeAddon.lua")
                      ;; wowi is edged out in favour of curseforge ...
                      :source "curseforge"
                      :source-id 54321
-                     ;; ... both are captured here in `:source-map-list` however
+                     ;; ... however both are captured here in `:source-map-list`
                      :source-map-list [{:source "wowinterface" :source-id 12345}
                                        {:source "curseforge" :source-id 54321}]}]]
       (fs/mkdir addon-path)


### PR DESCRIPTION
- [x] multiple source locations are captured from the TOC file
  - can we rely on scraping this from other locations? I don't think so :(
- [x] an action exists that explicitly models the implicit process that happens when an addon is matched against a different catalogue item. 
  - we already support source switching but it's not directly under the user's control
- [x] ignored and pinned addons cannot be switched
- [x] a GUI action to search the catalogue for similarly named addons 
  - I've added a "Find similar" context menu option that does a catalogue search against the addon's `label`. 
  - It's the bare minimum but it kinda sorta *does* work - I've found curseforge addons with no alts in the wowi and github catalogues already.
- [x] GUI, add a 'source-list' column
- [ ] ~`group-id` is using the addon's `url` as a unique identifier and should be changed at the same time the source is switched~
  - should I just use a uuid? I think something in the import logic now depends on the group-id being a URL :(
    - looks like the mutual dependency checking relies on the group-id being predictable, so a unique uuid futzes with that
  - nope, this is complex enough to warrant it's own dedicated task. It's also fine for now
- [x] investigate 'synthetic' addon summaries that are built from the nfo data and the (now) incorrect group-id
  - how big of a deal is this?
    - not that big a deal. I've disabled the group-id from being used and instead recreate the URL if possible. curseforge addons now miss out on still being able to be checked if they can't be found in the catalogue, but curseforge is disappearing anyway.
- [x] case: a github addon has IDs for curseforge and wowinterface but nothing for github. switching to wowinterface would 'lose' github. 
  - nfo data should preserve a list of sources ever **used**, including the current one.
    - for example, a curseforge addon is installed, it is added to the list, but then switched to wowinterface because the addon supports it. The nfo data `source` and `source-id` are updated to wowinterface, and "wowinterface", present from the toc data, is added to the list of sources.
- [x] gui, list of releases are refreshed when an addon switches source
- [x] review
- [x] update CHANGELOG