### PR TITLE
gui, change default column set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * replaced 'View -> Columns -> Reset to defaults' with the 'default' column preset.
 * github catalogue tweaks to support latest version of https://github.com/layday/github-wow-addon-catalogue
+* column preferences in the config file are now upgraded to the new default column set.
+    - any customised column preferences are preserved.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,12 @@ see CHANGELOG.md for a more formal list of changes by release
 * github, update catalogue to handle layday's changed csv format
     - done
 
+* replace 'installed' and 'available' columns with the composite 'version' column
+    - done
+
+* remove the (pinned) and (ignored) labels from the 'available' column
+    - done
+
 ## todo (4.9.0 -> 5.0.0)
 
 * disable support for curseforge
@@ -43,10 +49,6 @@ see CHANGELOG.md for a more formal list of changes by release
         - I could switch between sources I suppose ...
             - ha! done.
 
-* replace 'installed' and 'available' columns with the composite 'version' column
-
-* remove the (pinned) and (installed) labels from from the 'available' column
-
 * strongbox-comrades
     - remove curseforge as a requirement for any category.
 
@@ -56,6 +58,9 @@ see CHANGELOG.md for a more formal list of changes by release
     - stretch goal
 
 ## todo bucket (no particular order)
+
+* search, add ability to browse catalogue page by page
+    - I have neglected the catalogue search *so much*. I need a whole release dedicated to improving it.
 
 * 'downloading strongbox data' shouldn't be blocking the gui from starting
 

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -110,6 +110,15 @@
     (assoc cfg :catalogue-location-list -default-catalogue-list--v2)
     cfg))
 
+(defn handle-column-preference
+  "handles upgrading of the default column list.
+  if the config is using the v1 defaults, upgrade to v2 defaults."
+  [cfg]
+  (if (= (-> cfg :preferences :ui-selected-columns set)
+         (set sp/default-column-list--v1))
+    (assoc-in cfg [:preferences :ui-selected-columns] sp/default-column-list--v2)
+    cfg))
+
 (defn remove-invalid-addon-dirs
   "removes any `addon-dir-map` items from the given configuration whose directories do not exist"
   [cfg]
@@ -150,6 +159,7 @@
                 handle-selected-addon-dir
                 remove-invalid-catalogue-location-entries
                 add-github-catalogue
+                handle-column-preference
                 strip-unspecced-keys)
         message (format "configuration from %s is invalid and will be ignored: %s"
                         msg (s/explain-str ::sp/user-config cfg))]

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -110,10 +110,10 @@
     (assoc cfg :catalogue-location-list -default-catalogue-list--v2)
     cfg))
 
-(defn handle-column-preference
+(defn-spec handle-column-preferences map?
   "handles upgrading of the default column list.
   if the config is using the v1 defaults, upgrade to v2 defaults."
-  [cfg]
+  [cfg map?]
   (if (= (-> cfg :preferences :ui-selected-columns set)
          (set sp/default-column-list--v1))
     (assoc-in cfg [:preferences :ui-selected-columns] sp/default-column-list--v2)
@@ -159,7 +159,7 @@
                 handle-selected-addon-dir
                 remove-invalid-catalogue-location-entries
                 add-github-catalogue
-                handle-column-preference
+                handle-column-preferences
                 strip-unspecced-keys)
         message (format "configuration from %s is invalid and will be ignored: %s"
                         msg (s/explain-str ::sp/user-config cfg))]

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -139,7 +139,10 @@
 (def known-column-list [:browse-local :source :source-id :source-map-list :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
 
 ;; default set of columns
-(def default-column-list [:source :name :description :installed-version :available-version :game-version :uber-button])
+(def default-column-list--v1 [:source :name :description :installed-version :available-version :game-version :uber-button])
+(def default-column-list--v2 [:source :name :description :combined-version :game-version :uber-button])
+(def default-column-list default-column-list--v2)
+
 (def skinny-column-list [:name :version :combined-version :game-version :uber-button])
 (def fat-column-list [:browse-local :source :source-id :name :description :tag-list :created-date :updated-date :combined-version :game-version :uber-button])
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -623,8 +623,8 @@
   pinned and ignored addons get a helpful prefix."
   [row map?]
   (cond
-    (:ignore? row) "(ignored)"
-    (:pinned-version row) (str "(pinned) " (:pinned-version row))
+    (:ignore? row) ""
+    (:pinned-version row) (:pinned-version row)
     :else
     (:version row)))
 

--- a/test/fixtures/user-config-5.0.json
+++ b/test/fixtures/user-config-5.0.json
@@ -1,0 +1,56 @@
+{
+  "gui-theme": "dark-green",
+  "addon-dir-list": [
+    {
+      "addon-dir": "/tmp/.strongbox-bar",
+      "game-track": "classic-tbc",
+      "strict?": true
+    },
+    {
+      "addon-dir": "/tmp/.strongbox-foo",
+      "game-track": "retail",
+      "strict?": false
+    }
+  ],
+  "selected-addon-dir": "/tmp/.strongbox-foo",
+  "catalogue-location-list": [
+    {
+      "name": "short",
+      "label": "Short (default)",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+    },
+    {
+      "name": "full",
+      "label": "Full",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
+    },
+    {
+      "name": "tukui",
+      "label": "Tukui",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"
+    },
+    {
+      "name": "curseforge",
+      "label": "Curseforge",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"
+    },
+    {
+      "name": "wowinterface",
+      "label": "WoWInterface",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"
+    },
+    {
+      "name": "github",
+      "label": "GitHub",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"
+    }
+  ],
+  "selected-catalogue": "full",
+  "preferences":
+  {
+      "addon-zips-to-keep": 3,
+      "ui-selected-columns": [
+        "source", "name", "description", "installed-version", "available-version", "game-version", "uber-button"
+      ]
+  }
+}

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -589,4 +589,55 @@
                     :etag-db {}}]
       (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
-;; todo: settings for 5.0.0
+(deftest load-settings-5.0
+  (testing "a standard config file circa 5.0 is loaded and parsed as expected"
+    (let [cli-opts {}
+          cfg-file (fixture-path "user-config-5.0.json")
+          etag-db-file (fixture-path "empty-map.json")
+
+          expected {:cfg {:gui-theme :dark-green ;; new in 0.11, `:dark-green` new in 3.2.0
+                          :selected-catalogue :full ;; new in 0.10
+                          ;;:debug? true ;; removed in 0.12
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc :strict? true} ;; `:classic-tbc` and `:strict?` added in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :retail :strict? false}]
+
+                          ;; new in 1.0
+                          ;; new in 4.9, the set of available catalogues now includes a github catalogue
+                          :catalogue-location-list (:catalogue-location-list config/default-cfg)
+
+                          ;; new in 0.12
+                          ;; moved to :cfg in 1.0
+                          :selected-addon-dir "/tmp/.strongbox-foo"
+
+                          ;; new in 3.1.0
+                          :preferences {:addon-zips-to-keep 3
+
+                                        :ui-selected-columns [:source :name :description
+                                                              :combined-version ;; new default in 5.0.0
+                                                              :game-version :uber-button]}}
+
+                    :cli-opts {}
+                    :file-opts {:gui-theme :dark-green
+                                :selected-catalogue :full
+                                :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc, :strict? true}
+                                                 {:addon-dir "/tmp/.strongbox-foo", :game-track :retail, :strict? false}]
+                                :selected-addon-dir "/tmp/.strongbox-foo"
+
+                                ;; new in 1.0
+                                :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
+                                                          {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
+                                                          {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
+                                                          {:name :wowinterface :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"}
+                                                          ;; new in 4.9
+                                                          ;; the set of available catalogues now includes a github catalogue
+                                                          {:name :github :label "GitHub" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"}]
+
+                                :preferences {:addon-zips-to-keep 3
+                                              :ui-selected-columns [:source :name :description
+                                                                    :installed-version :available-version ;; replaced in 5.0.0
+                                                                    :game-version :uber-button]}}
+
+                    :etag-db {}}]
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
+

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -194,7 +194,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep nil
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:debug? true
@@ -225,7 +228,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep nil
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:selected-catalogue :full
@@ -257,7 +263,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep nil
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -290,7 +299,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep nil
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -322,7 +334,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep nil
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -365,7 +380,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep 3
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -409,7 +427,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep 3
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark-green
@@ -452,7 +473,10 @@
                           ;; new in 3.1.0
                           :preferences {:addon-zips-to-keep 3
                                         ;; new in 4.7.0
-                                        :ui-selected-columns [:source :name :description :installed-version :available-version :game-version :uber-button]}}
+                                        :ui-selected-columns [:source :name :description
+                                                              ;;:installed-version :available-version ;; replaced in 5.0.0
+                                                              :combined-version
+                                                              :game-version :uber-button]}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark-green
@@ -564,3 +588,5 @@
 
                     :etag-db {}}]
       (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
+
+;; todo: settings for 5.0.0


### PR DESCRIPTION
- [x] default columns are upgraded to use the 'combined' version column instead of 'installed' and 'available' columns
- [x] remove annotations on 'available' column
- [x] review
- [x] update CHANGELOG