### PR TITLE
add 'x-github' support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * column presets 'default', 'skinny' and 'fat'.
+* support for `X-Github` fields in the `.toc` file.
+    - these are a form `x-<source>-id` like `x-curse-project-id` and `x-wowi-id` and the value should be a Github URL.
 
 ### Changed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,21 +2,22 @@
 
 I'm grateful you are interested in contributing.
 
+## feedback, feature requests
+
+If you ever want to get in touch, please just [open an issue](https://github.com/ogri-la/strongbox/issues).
+
+I love *all* feedback including criticism, compliments, feature requests and especially bug reports.
+
 ## bugs
 
-To get a bug looked at I must be able to recreate it.
+To get your bug fixed I must be able to recreate it.
 
 1. create an [issue](https://github.com/ogri-la/strongbox/issues) to describe the bug
 
 2. run the application with the `--debug` flag. For example, `strongbox --debug` or `java -jar strongbox.jar --debug`.
 
 3. When the application exits, the version of strongbox and the path to the log file will be printed to the console. 
-Include the version in the bug report and attach the log to the ticket. The log file will include your hostname and list 
-of installed addons so make sure you're OK with that.
-
-## feedback, feature requests
-
-If you are a user of strongbox and you ever want to get in touch, please just [open an issue](https://github.com/ogri-la/strongbox/issues).
+Attach the log to your bug report. The log file will include your list of installed addons so make sure you're OK with that.
 
 ## code
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `strongbox` is an **open source**, **[advertisement free](#recognition)** and **[privacy respecting](#privacy)** addon manager for World of Warcraft.
 
-It supports Linux and macOS.
+It runs on Linux and macOS.
 
 It supports addons hosted by Curseforge, wowinterface, Tukui, Github and Gitlab.
 
@@ -350,16 +350,13 @@ the game tracks for a release can't be otherwise guessed.
 An installed addon comes from a specific addon host or *source*. An addon in it's `.toc` file may include the details of
 other sources where it can be found.
 
-For example, WeakAuras can be found on github, wowinterface and curseforge.
+For example, WeakAuras can be found on Github, wowinterface and Curseforge.
 
 To see addons with other sources, go to `View -> Columns` and click `other sources`.
 
 To switch an addon between sources, right-click an addon with other sources and select `Source`.
 
 ## Misc
-
-Prior to `1.0.0`, `strongbox` was known as `wowman`. The [AUR package](https://aur.archlinux.org/packages/wowman) for 
-`wowman` is obsolete.
 
 User configuration is stored in `~/.config/strongbox` unless run with the envvar `$XDG_CONFIG_HOME` set.
 
@@ -382,9 +379,10 @@ Changes are recorded in the [CHANGELOG.md](CHANGELOG.md) file.
 
 All bugs/questions/requests/feedback should go in [Github Issues](https://github.com/ogri-la/strongbox/issues).
 
-I prefer to **not** receive *code* contributions.
+I prefer to **not** receive *code* contributions. See [CONTRIBUTING](CONTRIBUTING.md) for more detail.
 
-See [CONTRIBUTING](CONTRIBUTING.md) for more detail.
+Prior to `1.0.0`, `strongbox` was known as `wowman`. The [AUR package](https://aur.archlinux.org/packages/wowman) for 
+`wowman` is obsolete.
 
 ## Other addon managers
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,16 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * remove the (pinned) and (ignored) labels from the 'available' column
     - done
+    
+* toc, add support for x-github key
+    - X-Github: https://github.com/teelolws/Altoholic-Retail 
+        - repo no longer exists
+        - github search:
+            - https://github.com/search?q=%22X-Github%22++extension%3Atoc&type=Code&ref=advsearch&l=&l=
+    - and what would it do?
+        - I could switch between sources I suppose ...
+            - ha! done.
+    - done
 
 ## todo (4.9.0 -> 5.0.0)
 
@@ -39,15 +49,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - curseforge catalogue should not be present
     - curseforge addons should be present in full and short catalogues
     - curseforge results should not be in search results
-
-* toc, add support for x-github key
-    - X-Github: https://github.com/teelolws/Altoholic-Retail 
-        - repo no longer exists
-        - github search:
-            - https://github.com/search?q=%22X-Github%22++extension%3Atoc&type=Code&ref=advsearch&l=&l=
-    - and what would it do?
-        - I could switch between sources I suppose ...
-            - ha! done.
 
 * strongbox-comrades
     - remove curseforge as a requirement for any category.

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -247,10 +247,7 @@
              vec
              utils/nilable)))
 
-(defn-spec parse-user-string (s/or :ok :addon/source-id :error nil?)
-  "extracts the addon ID from the given `url`."
-  [url ::sp/url]
-  (->> url java.net.URL. .getPath (re-matches #"^/([^/]+/[^/]+)[/]?.*") rest first))
+(def parse-user-string utils/github-url-to-source-id) ;; moved to utils to avoid coupling with `toc.clj`
 
 (defn-spec find-latest-release (s/or :release map?, :no-viable-release nil?)
   "the literal latest release we can find may not be the best choice and should only be "

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -161,7 +161,11 @@
                         {:source "tukui"
                          :source-id x-tukui-id})
 
-         source-map-list (when-let [items (->> [wowi-source curse-source tukui-source]
+         github-source (when-let [x-github (-> keyvals :x-github)]
+                         {:source "github"
+                          :source-id (utils/github-url-to-source-id x-github)})
+
+         source-map-list (when-let [items (->> [wowi-source curse-source tukui-source github-source]
                                                utils/items
                                                utils/nilable)]
                            {:source-map-list items})

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -753,3 +753,8 @@
        (map f)
        (remove nil?)
        first))
+
+(defn-spec github-url-to-source-id (s/or :ok :addon/source-id :error nil?)
+  "extracts the addon ID from the given `url`."
+  [url ::sp/url]
+  (->> url java.net.URL. .getPath (re-matches #"^/([^/]+/[^/]+)[/]?.*") rest first))


### PR DESCRIPTION
https://github.com/search?q=%22X-Github%22++extension%3Atoc&type=Code&ref=advsearch&l=&l=

- [x] toc, `x-github` is detected in toc files and added to the source-map-list
- [x] gui, `x-github` data is available from the 'other sources' column and 'source' context menu
- [x] review
- [x] update CHANGELOG