### PR TITLE
search across addon hosts

### DIFF
--- a/.joker
+++ b/.joker
@@ -1,5 +1,7 @@
 {
 :known-macros [orchestra.core/defn-spec strongbox.utils/if-let*]
-;; main.clj dynamically includes this ns
-:ignored-unused-namespaces [strongbox.ui.jfx]
+
+:ignored-unused-namespaces [strongbox.ui.jfx ;; main.clj dynamically includes this ns
+                            cljfx.api ;; Eastwood dies mid-lint without this: "Toolkit not initialized"
+                            ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * 'star' column to the search tab. Starring an addon will add it to your user-catalogue.
+* 'addon host' multi-checkbox field to the search tab, allowing you to select which hosts to see addons from.
+    - (disabled when there is only one host to choose from)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -195,17 +195,18 @@ Click `Catalogue` from the top menu and choose your preferred catalogue.
 
 The default catalogue is the 'short' catalogue. It contains all addons from all supported hosts that have been *updated* 
 since *the beginning of the previous expansion*. This is currently Battle For Azeroth, released 2018-08-14 and the 
-catalogue has approximately 7.5k addons.
+catalogue has approximately 2.8k addons.
 
-The 'full' catalogue contains all addons from all supported hosts, ever, and is approximately 15.3k addons large. It 
-contains many addons that haven't been updated in years.
+The 'full' catalogue contains all addons from all supported hosts, ever, and is approximately 7.2k addons large. It 
+contains many unmaintained addons.
 
 There are also per-host catalogues, like a 'wowinterface' catalogue, and strongbox supports selecting between all of them.
 
 Catalogues are updated weekly. New addons released during the week will not be present until the next week. Addons can 
 be installed using its URL in these cases.
 
-The 'user' catalogue is a little different. It's initially empty but grows as addons are imported from hosts like Github. 
+The 'user' catalogue is a little different. It's initially empty but grows as addons are starred while searching or 
+imported from addon hosts, like Github. 
 These addons also appear in search results. Individual addons from the user catalogue are checked for new releases 
 normally, but the catalogue itself can only be updated manually.
 

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,12 @@ see CHANGELOG.md for a more formal list of changes by release
     - add a column to the search results
     - done
 
+* search, filter by addon hosts
+    - done
+
 ## todo
+
+* search, bug, 'install selected' shouldn't do anything if nothing is selectedor
 
 * search, add ability to browse catalogue page by page
     - I have neglected the catalogue search *so much*. I need a whole release dedicated to improving it.
@@ -20,8 +25,6 @@ see CHANGELOG.md for a more formal list of changes by release
 * tags, make clickable in search results
     - adds a filter that can be removed
     - add clickable tags to addon detail page
-
-* search, filter by addon hosts
 
 * installed, clicking an addon's tags does a search
 

--- a/project.clj
+++ b/project.clj
@@ -57,6 +57,8 @@
 
                  ;;[org.clojure/core.cache "1.0.207"] ;; jfx context caching
 
+                 [org.controlsfx/controlsfx "11.1.1"] ;; BSD-3
+                 
                  ]
 
   :managed-dependencies [;; fixes the annoying:

--- a/project.clj
+++ b/project.clj
@@ -51,13 +51,12 @@
                  ;; these don't need an exception in LICENCE.txt
                  [org.apache.commons/commons-compress "1.21"] ;; Apache 2.0 licenced, bz2 compression/decompression of static catalogue
                  [org.ocpsoft.prettytime/prettytime "5.0.2.Final"] ;; Apache 2.0 licenced, pretty date formatting
-
+                 [org.controlsfx/controlsfx "11.1.1"] ;; BSD-3
+                 
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
                  ;;[org.clojure/core.cache "1.0.207"] ;; jfx context caching
-
-                 [org.controlsfx/controlsfx "11.1.1"] ;; BSD-3
                  
                  ]
 

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -215,10 +215,11 @@
 (defn-spec write-catalogue (s/or :ok ::sp/extant-file, :error nil?)
   "write catalogue to given `output-file` as JSON. returns path to output file"
   [catalogue-data :catalogue/catalogue, output-file ::sp/file]
-  (if (some->> catalogue-data validate (utils/dump-json-file output-file))
-    (do (info "wrote:" output-file)
-        output-file)
-    (error "catalogue data is invalid, refusing to write:" output-file)))
+  (locking output-file
+    (if (some->> catalogue-data validate (utils/dump-json-file output-file))
+      (do (info "wrote:" output-file)
+          output-file)
+      (error "catalogue data is invalid, refusing to write:" output-file))))
 
 (defn-spec new-catalogue :catalogue/catalogue
   "convenience. returns a new catalogue with datestamp of 'now' given a list of addon summaries"

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -118,6 +118,7 @@
 
 (def -search-state-template
   {:term nil
+   :filter-by []
    :page 0
    :results []
    :selected-result-list []

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -153,6 +153,9 @@
    ;; the list of addons from the catalogue
    :db nil
 
+   ;; some generated stats about the db that are updated just once at load time.
+   :db-stats {:known-host-list []}
+
    ;; the list of addons from the user-catalogue
    :user-catalogue nil
 
@@ -864,8 +867,14 @@
                              (load-current-catalogue))]
       (when-not (empty? final-catalogue)
         (p :p2/db:load
-           (swap! state assoc :db
-                  (db/put-many [] (:addon-summary-list final-catalogue))))))
+           (swap! state merge {:db (:addon-summary-list final-catalogue)
+                               :db-stats {:num-addons (count (:addon-summary-list final-catalogue))
+                                          :known-host-list (->> final-catalogue
+                                                                :addon-summary-list
+                                                                (map :source)
+                                                                distinct
+                                                                sort
+                                                                vec)}}))))
     (debug "skipping db load. already loaded or no catalogue selected."))
   nil)
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -118,7 +118,7 @@
 
 (def -search-state-template
   {:term nil
-   :filter-by []
+   :filter-by {}
    :page 0
    :results []
    :selected-result-list []
@@ -803,8 +803,8 @@
 (defn db-search
   "searches database for addons whose name or description contains given user input.
   if no user input, returns a list of randomly ordered results"
-  [search-term]
-  (let [args [(utils/nilable search-term) (get-state :search :results-per-page)]]
+  [search-term cap filter-by]
+  (let [args [(utils/nilable search-term) cap filter-by]]
     (query-db :search args)))
 
 (defn-spec empty-search-results nil?

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -217,7 +217,8 @@
 (s/def :addon/category string?)
 (s/def :addon/category-list (s/coll-of :addon/category))
 
-(s/def :addon/source (s/or :known #{"curseforge" "wowinterface" "github" "gitlab" "tukui" "tukui-classic" "tukui-classic-tbc"}
+(def known-hosts ["wowinterface" "github" "gitlab" "tukui" "tukui-classic" "tukui-classic-tbc"])
+(s/def :addon/source (s/or :known (set (conj known-hosts "curseforge"))
                            :unknown string?))
 (s/def :addon/source-id (s/or ::integer-id? int? ;; tukui has negative ids
                               ::string-id? string?))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -415,4 +415,6 @@
 (s/def :joblib/job-info (s/keys :req-un [:joblib/job :joblib/job-id :joblib/progress]))
 (s/def :joblib/queue (s/or :keyvals map? :pairs ::list-of-lists))
 
-;;
+;; search
+
+(s/def :search/filter-by #{:source})

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -217,8 +217,7 @@
 (s/def :addon/category string?)
 (s/def :addon/category-list (s/coll-of :addon/category))
 
-(def known-hosts ["wowinterface" "github" "gitlab" "tukui" "tukui-classic" "tukui-classic-tbc"])
-(s/def :addon/source (s/or :known (set (conj known-hosts "curseforge"))
+(s/def :addon/source (s/or :known #{"curseforge" "wowinterface" "github" "gitlab" "tukui" "tukui-classic" "tukui-classic-tbc"}
                            :unknown string?))
 (s/def :addon/source-id (s/or ::integer-id? int? ;; tukui has negative ids
                               ::string-id? string?))

--- a/src/strongbox/ui/check_combo_box.clj
+++ b/src/strongbox/ui/check_combo_box.clj
@@ -6,7 +6,6 @@
    [cljfx.lifecycle :as lifecycle]
    [cljfx.fx.control]
    [cljfx.mutator :as mutator]
-   [cljfx.prop :as prop]
    [cljfx.coerce :as coerce])
   (:import
    [org.controlsfx.control IndexedCheckModel CheckComboBox]

--- a/src/strongbox/ui/check_combo_box.clj
+++ b/src/strongbox/ui/check_combo_box.clj
@@ -1,0 +1,36 @@
+(ns strongbox.ui.check-combo-box
+  (:require
+   [cljfx.api] ;; Eastwood dies mid-lint without this: "Toolkit not initialized"
+
+   [cljfx.composite :as composite]
+   [cljfx.lifecycle :as lifecycle]
+   [cljfx.fx.control]
+   [cljfx.mutator :as mutator]
+   [cljfx.prop :as prop]
+   [cljfx.coerce :as coerce])
+  (:import
+   [org.controlsfx.control IndexedCheckModel CheckComboBox]
+   [javafx.collections ObservableList FXCollections]
+   [java.util Collection]))
+
+;; checkModelProperty https://controlsfx.github.io/javadoc/11.1.1/org.controlsfx.controls/org/controlsfx/control/CheckListView.html#checkModelProperty()
+;; seeing a bug here: https://github.com/controlsfx/controlsfx/issues/1030
+;; this fn gets called twice if you click the label vs the checkbox
+(def props
+  (merge
+   cljfx.fx.control/props
+   (composite/props CheckComboBox
+                    :items [:list lifecycle/scalar]
+                    :converter [:setter lifecycle/scalar :coerce coerce/string-converter]
+                    :show-checked-count [:setter lifecycle/scalar :default false]
+                    :title [:setter lifecycle/scalar]
+                    :check-model [:setter lifecycle/scalar]
+
+                    :on-checked-items-changed [(mutator/list-change-listener
+                                                #(.getCheckedItems ^IndexedCheckModel (.getCheckModel ^CheckComboBox %)))
+                                               lifecycle/list-change-listener])))
+
+(def lifecycle
+  (composite/describe CheckComboBox
+                      :ctor []
+                      :props props))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -181,15 +181,19 @@
   results are updated at [:search :results]"
   []
   ;; todo: cancel any other searching going on?
-  (core/state-bind
-   [:search :term]
-   (fn [new-state]
-     (future
-       (let [results (core/db-search (-> new-state :search :term))]
-         (swap! core/state assoc-in [:search :results] results))))))
+  (let [path-list [[:search :term]
+                   [:search :filter-by]]
+        listener (fn [new-state]
+                   (future
+                     (let [{:keys [term results-per-page filter-by]} (:search new-state)
+                           results (core/db-search term results-per-page filter-by)]
+                       (swap! core/state assoc-in [:search :results] results))))]
+    (doseq [path path-list]
+      (core/state-bind path listener))))
 
 (defn-spec search-results-filter-by nil?
-  [filter-by keyword?, val any?]
+  [filter-by :search/filter-by, val any?]
+  (swap! core/state assoc-in [:search :filter-by filter-by] (utils/nilable val))
   nil)
 
 ;;

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -191,7 +191,8 @@
     (doseq [path path-list]
       (core/state-bind path listener))))
 
-(defn-spec search-results-filter-by nil?
+(defn-spec search-add-filter nil?
+  "adds a new filter to the search filter-by configuration."
   [filter-by :search/filter-by, val any?]
   (swap! core/state assoc-in [:search :filter-by filter-by] (utils/nilable val))
   nil)

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -188,6 +188,10 @@
        (let [results (core/db-search (-> new-state :search :term))]
          (swap! core/state assoc-in [:search :results] results))))))
 
+(defn-spec search-results-filter-by nil?
+  [filter-by keyword?, val any?]
+  nil)
+
 ;;
 
 (defn-spec change-catalogue nil?

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1795,7 +1795,7 @@
                                                  (let [starred (starred? addon-summary)
                                                        f (if starred cli/remove-summary-from-user-catalogue cli/add-summary-to-user-catalogue)]
                                                    {:graphic (button "\u2605"
-                                                                     (handler (partial f addon-summary))
+                                                                     (async-handler (partial f addon-summary))
                                                                      {:style-class (if starred "starred" "unstarred")})}))}}
 
                      {:text "source" :min-width 125 :pref-width 125 :max-width 125 :resizable false
@@ -1849,9 +1849,9 @@
 
 (defn search-addons-search-field
   [{:keys [fx/context]}]
-  (let [just-x (fn [state]
-                 (select-keys (get-in state [:app-state :search]) [:term :filter-by :page :results-per-page]))
-        search-state (fx/sub-val context just-x)]
+  (let [search-state (fx/sub-val context utils/just-in [:app-state :search [:term :filter-by :page :results-per-page]])
+        known-host-list (core/get-state :db-stats :known-host-list)
+        disable-host-selector? (= 1 (count known-host-list))]
     {:fx/type :h-box
      :padding 10
      :spacing 10
@@ -1870,10 +1870,11 @@
 
       {:fx/type controlsfx.check-combo-box/lifecycle
        :title "addon host"
-       :items sp/known-hosts
+       :items known-host-list
        :show-checked-count true
        :on-checked-items-changed (fn [val]
-                                   (cli/search-results-filter-by :source val))}
+                                   (cli/search-add-filter :source val))
+       :disable disable-host-selector?}
 
       ;;{:fx/type :button
       ;; :id "search-random-button"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1849,7 +1849,9 @@
 
 (defn search-addons-search-field
   [{:keys [fx/context]}]
-  (let [search-state (fx/sub-val context get-in [:app-state :search])]
+  (let [just-x (fn [state]
+                 (select-keys (get-in state [:app-state :search]) [:term :filter-by :page :results-per-page]))
+        search-state (fx/sub-val context just-x)]
     {:fx/type :h-box
      :padding 10
      :spacing 10
@@ -1870,8 +1872,8 @@
        :title "addon host"
        :items sp/known-hosts
        :show-checked-count true
-       :on-checked-items-changed (async-handler (partial cli/search-results-filter-by :host))
-       }
+       :on-checked-items-changed (fn [val]
+                                   (cli/search-results-filter-by :source val))}
 
       ;;{:fx/type :button
       ;; :id "search-random-button"

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -17,6 +17,7 @@
    [clojure.spec.alpha :as s]
    [orchestra.core :refer [defn-spec]]
    [strongbox.ui.cli :as cli]
+   [strongbox.ui.check-combo-box :as controlsfx.check-combo-box]
    [strongbox
     [constants :as constants]
     [joblib :as joblib]
@@ -1853,22 +1854,29 @@
      :padding 10
      :spacing 10
      :children
-     [{:fx/type :text-field
+     [{:fx/type :button
+       :id "search-install-button"
+       :text "install selected"
+       :on-action (async-handler #(search-results-install-handler (core/get-state :search :selected-result-list)))}
+
+      {:fx/type :text-field
        :id "search-text-field"
        :prompt-text "search"
        ;;:text (:term search-state) ;; don't do this, it can go spastic
        :text (core/get-state :search :term) ;; this seems ok, probably has it's own drawbacks
        :on-text-changed cli/search}
 
-      {:fx/type :button
-       :id "search-install-button"
-       :text "install selected"
-       :on-action (async-handler #(search-results-install-handler (core/get-state :search :selected-result-list)))}
+      {:fx/type controlsfx.check-combo-box/lifecycle
+       :title "addon host"
+       :items sp/known-hosts
+       :show-checked-count true
+       :on-checked-items-changed (async-handler (partial cli/search-results-filter-by :host))
+       }
 
-      {:fx/type :button
-       :id "search-random-button"
-       :text "random"
-       :on-action (handler cli/random-search)}
+      ;;{:fx/type :button
+      ;; :id "search-random-button"
+      ;; :text "random"
+      ;; :on-action (handler cli/random-search)}
 
       {:fx/type :h-box
        :id "spacer"

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -762,3 +762,14 @@
   "extracts the addon ID from the given `url`."
   [url ::sp/url]
   (->> url java.net.URL. .getPath (re-matches #"^/([^/]+/[^/]+)[/]?.*") rest first))
+
+(defn-spec just-in any?
+  "like `get-in` but the last path element is used with `select-keys`.
+  returns nil if the second-to-last path element doesn't yield a map."
+  [m (s/nilable map?), ks vector?]
+  (let [path (butlast ks)
+        these-keys (last ks)]
+    (when m
+      (let [v (get-in m path)]
+        (when (and (map? v) (vector? these-keys))
+          (select-keys v these-keys))))))

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -707,6 +707,7 @@
 
 ;;
 
+
 ;; test doesn't seem to live comfortably in `core_test.clj`
 (deftest install-update-these-in-parallel--bad-download
   (testing "bad downloads are not passed to `core/install-addon`."

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -119,6 +119,46 @@
           (Thread/sleep 10)
           (is (= nil (core/get-state :search :term))))))))
 
+(deftest search-db--filter-by--host
+  (testing "a populated database can be filtered by host from the CLI"
+    (let [catalogue (slurp (fixture-path "catalogue--v2.json"))
+          fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+                       {:get (fn [req] {:status 200 :body catalogue})}}
+          expected-num-addons 4
+          page-1 0]
+      (with-global-fake-routes-in-isolation fake-routes
+        (with-running-app
+          ;; any catalogue with less than 60 (a magic number) items has >100% probability of being included.
+          (cli/search nil)
+          (Thread/sleep 10)
+          ;; sanity check, we have all four addons
+          (is (= expected-num-addons (count (core/get-state :search :results page-1))))
+
+          ;; limit results to just wowinterface
+          (cli/search-add-filter :source ["wowinterface"])
+          (Thread/sleep 10)
+          (is (= "wowinterface" (-> (core/get-state :search :results page-1)
+                                    first ;; `get-in` doesn't realize lazy sequences so we'll get nils if we try accessing this with `0`
+                                    :source))) ;; we have one addon from each of the hosts
+
+          ;; limit results to just github
+          (cli/search-add-filter :source ["github"])
+          (Thread/sleep 10)
+          (is (= "github" (-> (core/get-state :search :results page-1)
+                              first
+                              :source)))
+
+          ;; limit results to just wowinterface+github, results are OR'd, order from catalogue is preserved (wowi, curse, tukui, github)
+          (cli/search-add-filter :source ["github" "wowinterface"])
+          (Thread/sleep 10)
+          (is (= "wowinterface" (-> (core/get-state :search :results page-1)
+                                    first ;; `get-in` doesn't realize lazy sequences so we'll get nils if we try accessing this with `0`
+                                    :source))) ;; we have one addon from each of the hosts
+          (is (= "github" (-> (core/get-state :search :results page-1)
+                              second ;; `get-in` doesn't realize lazy sequences so we'll get nils if we try accessing this with `0`
+                              :source))) ;; we have one addon from each of the hosts
+          )))))
+
 (deftest search-db--navigate
   (testing "a populated database can be searched forwards and backwards from the CLI"
     (let [catalogue (slurp (fixture-path "catalogue--v2.json"))
@@ -709,6 +749,8 @@
 
 
 ;; test doesn't seem to live comfortably in `core_test.clj`
+
+
 (deftest install-update-these-in-parallel--bad-download
   (testing "bad downloads are not passed to `core/install-addon`."
     (with-running-app

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1592,7 +1592,11 @@
           fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
                        {:get (fn [req] {:status 200 :body dummy-catalogue})}}
           expected-messages ["addon 'A New Simple Percent' is from an unsupported source 'gitplex'."
-                             "refresh"]]
+                             "refresh"]
+
+          search-term "new"
+          search-cap 10
+          search-filter-by {}]
 
       (with-global-fake-routes-in-isolation fake-routes
         (with-running-app+opts {:spec? false}
@@ -1602,7 +1606,7 @@
           (is (= expected-messages
                  (logging/buffered-log
                   :error
-                  (-> (core/db-search "new")
+                  (-> (core/db-search search-term search-cap search-filter-by)
                       first ;; first page of results
                       first ;; first result
                       cli/install-addon))))
@@ -1633,7 +1637,10 @@
                      "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
                      {:get (fn [req] {:status 200 :body dummy-catalogue})}}
         expected-messages ["unsupported game track ':classic-bfa'."
-                           "refresh"]]
+                           "refresh"]
+        search-term "chin"
+        search-cap 10
+        search-filter-by {}]
 
     (testing "strongbox can attempt to install an addon from an unknown source and not crash"
       (with-global-fake-routes-in-isolation fake-routes
@@ -1648,7 +1655,7 @@
           (is (= expected-messages
                  (logging/buffered-log
                   :error
-                  (-> (core/db-search "chin")
+                  (-> (core/db-search search-term search-cap search-filter-by)
                       first ;; first page of results
                       first ;; first result
                       cli/install-addon))))

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -442,3 +442,19 @@
                ["2019-08-26T00:00:01Z" false]]]
     (doseq [[given expected] cases]
       (is (= expected (utils/published-before-classic? given))))))
+
+(deftest just-in
+  (let [cases [[nil [] nil]
+               [nil [:foo :bar [:baz]] nil]
+               [{} [] nil]
+               [{:foo :bar} [:foo] nil]
+               [{:foo :bar} [:foo [:foo]] nil]
+               [{:foo :bar, :baz :bup} [:foo [:foo :baz]] nil]
+               [{:foo {:bar :baz}} [:foo [:bar]] {:bar :baz}]
+               [{:foo {:bar :baz, :bup :boo}} [:foo [:bar :bup :boop]] {:bar :baz, :bup :boo}]
+
+               [{:foo []} [:foo [:bar]] nil]
+               [{:foo ""} [:foo [:bar]] nil]]]
+    (doseq [[m ks expected] cases]
+      (is (= expected (utils/just-in m ks)), (str "failed case: " m ks)))))
+


### PR DESCRIPTION
- [x] one or many addon hosts can be selected to be filtered by
- [x] results are OR'd together (wowi OR github), excluding unselected (NOT tukui)
- [ ] ~tukui has three addon hosts because of the way it was implemented (tukui, tukui-classic, tukui-classic-tbc), aggregate them into one 'tukui' that search over all three.~
  - I kinda like having more options rather than less. keeping for now.
- [x] results are further filtered by a search term, if any
- [x] review
- [x] update CHANGELOG