### PR TITLE
clickable tags in search and installed panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * 'star' column to the search tab. Starring an addon will add it to your user-catalogue.
 * 'addon host' multi-checkbox field to the search tab, allowing you to select which hosts to see addons from.
-    - (disabled when there is only one host to choose from)
+    - disabled when there is only one host to choose from.
+* clickable tags in the 'tags' column that filter search results.
+    - selected tags appear in the search area. clicking them will remove the tag from the search.
 
 ### Changed
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,18 +15,20 @@ see CHANGELOG.md for a more formal list of changes by release
 * search, filter by addon hosts
     - done
 
+* tags, make clickable in search results
+    - adds a filter that can be removed
+    - add clickable tags to addon detail page
+    - done
+
+* installed, clicking an addon's tags does a search
+    - done
+
 ## todo
 
 * search, bug, 'install selected' shouldn't do anything if nothing is selectedor
 
 * search, add ability to browse catalogue page by page
     - I have neglected the catalogue search *so much*. I need a whole release dedicated to improving it.
-
-* tags, make clickable in search results
-    - adds a filter that can be removed
-    - add clickable tags to addon detail page
-
-* installed, clicking an addon's tags does a search
 
 * addon detail, mutual dependencies pane
     - for example, I would like to see what is happening when:

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,9 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* catalogue, descriptions for wowinterface addons
+* catalogue, download counts for github addons
+
 * github, bug, multi-toc addons are getting a warning when `strict?` is true and the game track is changed
     - https://github.com/LenweSaralonde/MusicianList/releases
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -118,7 +118,8 @@
 
 (def -search-state-template
   {:term nil
-   :filter-by {}
+   :filter-by {:source nil
+               :tag #{}}
    :page 0
    :results []
    :selected-result-list []

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -416,4 +416,4 @@
 
 ;; search
 
-(s/def :search/filter-by #{:source})
+(s/def :search/filter-by #{:source :tag})

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -194,7 +194,9 @@
 (defn-spec search-add-filter nil?
   "adds a new filter to the search filter-by configuration."
   [filter-by :search/filter-by, val any?]
-  (swap! core/state assoc-in [:search :filter-by filter-by] (utils/nilable val))
+  (case filter-by
+    :source (swap! core/state assoc-in [:search :filter-by filter-by] (utils/nilable val))
+    :tag (swap! core/state update-in [:search :filter-by filter-by] conj val))
   nil)
 
 ;;

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -192,11 +192,17 @@
       (core/state-bind path listener))))
 
 (defn-spec search-add-filter nil?
-  "adds a new filter to the search filter-by configuration."
+  "adds a new filter to the search `filter-by` state."
   [filter-by :search/filter-by, val any?]
   (case filter-by
     :source (swap! core/state assoc-in [:search :filter-by filter-by] (utils/nilable val))
     :tag (swap! core/state update-in [:search :filter-by filter-by] conj val))
+  nil)
+
+(defn-spec search-rm-filter nil?
+  "removes a filter from the search `filter-by` state."
+  [filter-by :search/filter-by, val any?]
+  (swap! core/state update-in [:search :filter-by filter-by] clojure.set/difference #{val})
   nil)
 
 ;;

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1163,7 +1163,7 @@
 
          :name {:min-width 100 :pref-width 300}
          :description {:min-width 150 :pref-width 450}
-         :tag-list {:min-width 200 :pref-width 300 :cell-value-factory identity 
+         :tag-list {:min-width 200 :pref-width 300 :cell-value-factory identity
                     :cell-factory {:fx/cell-type :tree-table-cell
                                    :describe (fn [row]
                                                {:graphic {:fx/type :h-box
@@ -1811,14 +1811,13 @@
                       :cell-value-factory identity}
                      {:text "name" :min-width 150 :pref-width 250 :cell-value-factory (comp no-new-lines :label)}
                      {:text "description" :min-width 200 :pref-width 400 :cell-value-factory (comp no-new-lines :description)}
-                     {:text "tags" :min-width 200 :pref-width 250 :cell-value-factory identity 
+                     {:text "tags" :min-width 200 :pref-width 250 :cell-value-factory identity
                       :cell-factory {:fx/cell-type :table-cell
                                      :describe (fn [row]
                                                  {:graphic {:fx/type :h-box
                                                             :children (mapv (fn [tag]
                                                                               (button (name tag) (async-handler (partial cli/search-add-filter :tag tag))))
-                                                                            (:tag-list row))}})}
-                      }
+                                                                            (:tag-list row))}})}}
                      {:text "updated" :min-width 85 :max-width 85 :pref-width 85 :resizable false :cell-value-factory (comp #(utils/safe-subs % 10) :updated-date)}
                      {:text "downloads" :min-width 120 :pref-width 120 :max-width 120 :resizable false
                       :cell-value-factory :download-count

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1810,7 +1810,8 @@
                                      :describe (fn [row]
                                                  {:graphic {:fx/type :h-box
                                                             :children (mapv (fn [tag]
-                                                                              (button (name tag) donothing)) (:tag-list row))}})}
+                                                                              (button (name tag) (async-handler (partial cli/search-add-filter :tag tag))))
+                                                                            (:tag-list row))}})}
                       }
                      {:text "updated" :min-width 85 :max-width 85 :pref-width 85 :resizable false :cell-value-factory (comp #(utils/safe-subs % 10) :updated-date)}
                      {:text "downloads" :min-width 120 :pref-width 120 :max-width 120 :resizable false

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1805,7 +1805,13 @@
                       :cell-value-factory identity}
                      {:text "name" :min-width 150 :pref-width 250 :cell-value-factory (comp no-new-lines :label)}
                      {:text "description" :min-width 200 :pref-width 400 :cell-value-factory (comp no-new-lines :description)}
-                     {:text "tags" :min-width 200 :pref-width 250 :cell-value-factory (comp str :tag-list)}
+                     {:text "tags" :min-width 200 :pref-width 250 :cell-value-factory identity 
+                      :cell-factory {:fx/cell-type :table-cell
+                                     :describe (fn [row]
+                                                 {:graphic {:fx/type :h-box
+                                                            :children (mapv (fn [tag]
+                                                                              (button (name tag) donothing)) (:tag-list row))}})}
+                      }
                      {:text "updated" :min-width 85 :max-width 85 :pref-width 85 :resizable false :cell-value-factory (comp #(utils/safe-subs % 10) :updated-date)}
                      {:text "downloads" :min-width 120 :pref-width 120 :max-width 120 :resizable false
                       :cell-value-factory :download-count

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1168,7 +1168,9 @@
                                    :describe (fn [row]
                                                {:graphic {:fx/type :h-box
                                                           :children (mapv (fn [tag]
-                                                                            (button (name tag) (async-handler (partial cli/search-add-filter :tag tag))))
+                                                                            (button (name tag)
+                                                                                    (async-handler #(do (switch-tab SEARCH-TAB)
+                                                                                                        (cli/search-add-filter :tag tag)))))
                                                                           (:tag-list row))}})}}
          :created-date {:min-width 90 :pref-width 110 :max-width 120
                         :cell-value-factory :created-date

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -531,7 +531,6 @@
                 " .button" {:-fx-min-width 50
                             :-fx-font-size ".9em"
                             :-fx-padding "4px 5px"
-                            ;;:-fx-background-color (colour :row-updateable)
                             :-fx-background-color "none"
                             :-fx-opacity "1"
                             :-fx-border-width "0 1 0 0"
@@ -1899,7 +1898,7 @@
 
 (defn search-addons-search-field
   [{:keys [fx/context]}]
-  (let [search-state (fx/sub-val context utils/just-in [:app-state, :search [:term :filter-by :page :results-per-page]])
+  (let [search-state (fx/sub-val context get-in [:app-state, :search])
         ;;known-host-list (fx/sub-val context get-in [:app-state, :db-stats :known-host-list])
         known-host-list (core/get-state :db-stats :known-host-list)
         disable-host-selector? (= 1 (count known-host-list))

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1163,7 +1163,13 @@
 
          :name {:min-width 100 :pref-width 300}
          :description {:min-width 150 :pref-width 450}
-         :tag-list {:min-width 200 :pref-width 300}
+         :tag-list {:min-width 200 :pref-width 300 :cell-value-factory identity 
+                    :cell-factory {:fx/cell-type :tree-table-cell
+                                   :describe (fn [row]
+                                               {:graphic {:fx/type :h-box
+                                                          :children (mapv (fn [tag]
+                                                                            (button (name tag) (async-handler (partial cli/search-add-filter :tag tag))))
+                                                                          (:tag-list row))}})}}
          :created-date {:min-width 90 :pref-width 110 :max-width 120
                         :cell-value-factory :created-date
                         :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -515,15 +515,18 @@
                {:-fx-min-width "100px"
                 :-fx-text-fill (colour :table-font-colour)}
 
+               "#search-selected-tag-bar"
+               {:-fx-padding "0 0 10 10"
+                :-fx-spacing "10"
+                " > .button" {:-fx-padding "2.5 8"
+                              :-fx-background-radius "4"}}
+               
                ".table-view#search-addons .downloads-column"
                {:-fx-alignment "center-right"}
 
                ".table-view#search-addons .updated-column"
                {:-fx-alignment "center"}
 
-               ".tag-button-column-row"
-               {;;:-fx-spacing "3px"
-                :-fx-padding "0"}
 
                ".tag-button-column"
                {:-fx-padding "-1 0 0 0"
@@ -537,12 +540,6 @@
                             :-fx-border-color (colour :table-border)
                             :-fx-text-overrun "word-ellipsis"
                             ":hover" {:-fx-background-color (colour :row-updateable-selected)}}}
-
-               "#search-selected-tag-bar"
-               {:-fx-padding "0 0 10 10"
-                :-fx-spacing "10"
-                " > .button" {:-fx-padding "2.5 8"
-                              :-fx-background-radius "4"}}
 
 
                ;;
@@ -1820,7 +1817,7 @@
         empty-next-page (and (= 0 (count addon-list))
                              (> (-> search-state :page) 0))
 
-        tag-set (->> search-state :filter-by :tag)
+        tag-set (-> search-state :filter-by :tag)
         tag-selected (fn [tag]
                        (some #{tag} tag-set))
 
@@ -1847,7 +1844,6 @@
                       :cell-factory {:fx/cell-type :table-cell
                                      :describe (fn [row]
                                                  {:graphic {:fx/type :h-box
-                                                            :style-class ["h-box" "tag-button-column-row"]
                                                             :children (remove nil?
                                                                               (map (fn [tag]
                                                                                      (when-not (tag-selected tag)
@@ -1862,7 +1858,7 @@
                                      :describe (fn [n]
                                                  (when n
                                                    {:text (format-number n)}))}}
-                     {:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :resizable false
+                     {:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :max-width 120 :resizable false
                       :cell-factory {:fx/cell-type :table-cell
                                      :describe (fn [addon]
                                                  {:graphic (button "install" (async-handler #(search-results-install-handler [addon]))

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -186,7 +186,12 @@
           (Thread/sleep 10)
           (is (= 2 (count (core/get-state :search :results page-1))))
           (is (= "wowinterface" (->> (core/get-state :search :results page-1) first :source)))
-          (is (= "tukui" (-> (core/get-state :search :results page-1) second :source))))))))
+          (is (= "tukui" (-> (core/get-state :search :results page-1) second :source)))
+
+          ;; filters can be removed
+          (cli/search-rm-filter :tag :ui)
+          (is (= #{:vendors} (core/get-state :search :filter-by :tag)))
+          (is (= "wowinterface" (->> (core/get-state :search :results page-1) first :source))))))))          
 
 (deftest search-db--navigate
   (testing "a populated database can be searched forwards and backwards from the CLI"


### PR DESCRIPTION
- [x] tags are replaced with clickable buttons
- [x] clicking a tag button filters search results
- [x] tag button is disabled/marked if part of filters already
- [x] tags are added to the search bar on click. 
- [x] clicking tag in search bar removes them from search
- [x] clicking a tag in the installed pane switches to the search pane
- [x] tooltips on tags (because they're getting truncated when many)
- [x] bug: navigation buttons have stopped working
- [x] styling
- [x] review
- [x] update CHANGELOG