### PR TITLE
gui, addon-detail, add mutual dependencies pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * clickable tags in the 'tags' column that filter search results.
     - selected tags appear in the search area. clicking them will remove the tag from the search.
 * gui, search, count of addons selected to the 'install selected' button.
+* gui, addon-details, a 'mutual dependencies' pane to show which addons the current addon is overwriting.
 
 ### Changed
 
 * core, the user-catalogue is now part of application state rather than read from file as needed.
 * gui, search, 'install selected' button moved to the left of the search field and disabled if no addons selected.
+* gui, addon-details, switched from a three-pane layout to a two-pane layout with navigation.
+    - default panes displayed are 'releases' and 'grouped addons'
+    - 'raw-data' shifted to it's own pane, it's always been a bit of a debug option.
+* gui, styling, some of the early, complex, styling has been minimised and contained to just the install and search tabs.
+    - the appearance shouldn't have altered, it's just less wooly behind the scenes.
+* gui, addon-details, very minor, "Stop ignoring" label changed to "Unignore" to conserve horizontal space.
 
 ### Fixed
+
+* gui, addon-details, very minor bug that would sometimes result in two seemingly identical addon tabs being open.
+    - new tab and their default state were being compared to all other tabs open and, if not found, a new one would be opened.
+        - for example, if you changed the log level in an addon's detail pane then opened the addon again, you'd get a duplicate tab.
 
 ### Removed
 
 * the 'random' button. room was needed for the new filters.
     - it's affect can still be simulated by pressing spacebar in the search field.
 * the 'wrote: /path/to/user-catalogue.json' message when the user catalogue is updated.
-    - it's just noise when the operation becomes common
+    - it's just noise now that the operation has become common.
 
 ## 5.0.0 - 2022-01-31
 

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,15 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* addon detail, 'releases' widget
+    - installed release should be highlighted
+
+* 'update all' should be a no-op if nothing has updates available
+    - don't disable the button, just don't do anything
+
+* change split button 'outdent' to 'indent'
+    - and if split, keep it 'pressed in'
+
 * search, add ability to browse catalogue page by page
     - I have neglected the catalogue search *so much*. I need a whole release dedicated to improving it.
 
@@ -41,10 +50,37 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
-* github, preference to sync stars with github repo, if authenticated
+### catalogue v3 / capture more addon data
 
+* 'website'
+    - 'x-website'/'x-url' in toc
+    - add 'website' to addon-detail pane next to 'browse local files' and addon host
+        - depends on capturing x-website
+    - add a 'website' column to installed-addons
+* 'author'
+    - add an 'author' column to installed-addons
+    - add to addon-detail
+    - search other addons by author
+* 'releases'
+    - capture full set of releases, including hashes if they exist
+
+###
+
+* wowinterface, multiple game tracks
+    - investigate just what is being downloaded when a classic version of a wowi addon is downloaded
+    - see 'LagBar'
+* investigate better popularity metric than 'downloads'
+    - if we make an effort to scrape everyday, we can generate this popularity graph ourselves
+* wowinterface, revisit the pages that are being scraped, make sure we're not missing any
+* github, questie is kinda fubar
 * catalogue, descriptions for wowinterface addons
 * catalogue, download counts for github addons
+
+* github, preference to sync stars with github repo, if authenticated
+
+* user catalogue, refresh happens in parallel
+    - write the user-catalogue once, not each time or else we'll get Weirdness
+        - a lock is now acquired when writing the user catalogue
 
 * github, bug, multi-toc addons are getting a warning when `strict?` is true and the game track is changed
     - https://github.com/LenweSaralonde/MusicianList/releases
@@ -83,9 +119,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * http, add with-backoff support to download-file
     - just had a wowinterface addon download timeout
-
-* user catalogue, refresh happens in parallel
-    - write the user-catalogue once, not each time or else we'll get Weirdness
 
 * a more permanent store than just cached files
     - I want to store release data permanently
@@ -176,7 +209,6 @@ see CHANGELOG.md for a more formal list of changes by release
         - clicking 'more' (or whatever) takes to addon detail page
     - perhaps coincide with catalogue v3 with more addon details
 
-* wowinterface, revisit the pages that are being scraped, make sure we're not missing any
 
 * import/export, bring up the split logging pane during operation so any problems can be seen
     - or update the tab title to reflect the number of warnings/errors
@@ -196,11 +228,9 @@ see CHANGELOG.md for a more formal list of changes by release
     - ensure the user catalogue doesn't get too stale and perform an update in the background if it looks like it's very old
         - update README
 
-* 'update all' should be a no-op if nothing has updates available
-    - don't disable the button, just don't do anything
-
 * http, clear non-catalogue cache after session
     - it seems reasonable that stopping and starting the app will have it re-fetch addon summaries.
+    - maybe add as a preference
 
 * install addon from local zipfile
     - *not* the 'reinstallation' feature, but literally selecting a zipfile from somewhere and installing it
@@ -222,11 +252,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - N connections serving M threads
     - pretty fast just by making requests in parallel
         - moving this back to the bucket until I start really looking for optimisations
-
-
-
-* change split button 'outdent' to 'indent'
-    - and if split, keep it 'pressed in'
 
 * preferences, "update all addons automatically"
     - update README features
@@ -285,19 +310,12 @@ see CHANGELOG.md for a more formal list of changes by release
 * reconciliation, add dirname support
     - not sure which hosts support these
 
-* wowinterface, multiple game tracks
-    - investigate just what is being downloaded when a classic version of a wowi addon is downloaded
-    - see 'LagBar'
-
 * reconciliation, rename 'reinstall all' to 'reconcile'
     - steal from the best
     - make the reconcile automatic
         - if a nfo file isn't found
     - remove the 'first time instructions' from the readme
         - it should just fucking do it
-
-* investigate better popularity metric than 'downloads'
-    - if we make an effort to scrape everyday, we can generate this popularity graph ourselves
 
 * add a 'tabula rasa' option that wipes *everything* 
     - cache, catalog, config, downloaded zip files
@@ -309,18 +327,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * rename 'retail' to 'mainline'
     - pretty big change ;) but probably for the best.
-
-## catalogue v3 / capture more addon data
-
-* 'website'
-    - 'x-website'/'x-url' in toc
-    - add 'website' to addon-detail pane next to 'browse local files' and addon host
-        - depends on capturing x-website
-    - add a 'website' column to installed-addons
-* 'author'
-    - add an 'author' column to installed-addons
-    - add to addon-detail
-    - search other addons by author
 
 ## 
 
@@ -341,9 +347,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - eh. tie it in with downloading more release information
     - defer until after job queue
         - very large downloads are possible. just see curseforge dbm
-
-* addon detail, 'releases' widget
-    - installed release should be highlighted
 
 * import and export addons using addon urls
 
@@ -445,10 +448,6 @@ this is still an interesting idea
     - I'm moving this to 'wontfix'
         - it's possible for wowi and tukui, not curse
         - the error message is clear (can't find in catalogue)
-* github, add a github catalogue
-    - just a simple list of wow addons on github that can be installed with strongbox
-    - yeah, nah
-        - I don't want that responsibility
 * logs, persistent addon events
     - installed, updated, pin, ignore events
     - like ... stored in addon history?
@@ -473,7 +472,6 @@ this is still an interesting idea
     - the vast majority of addons use .zip
     - no native support in java/clojure for it
         - library here: https://github.com/junrar/junrar
-            - just found it while going through minion source
 
 * cli, interactive interface when no specific action specified 
     - you have N addons installed. what do you want to do? (list, update, update-all, delete) etc

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * addon detail, mutual dependencies pane
     - for example, I would like to see what is happening when:
-        adibags anima & conduits is overwritten by adibags anima filter
+        - adibags anima & conduits is overwritten by adibags anima filter
+        - adibags-shadowlands (github+wowinterface) 
 
 ## todo bucket (no particular order)
 

--- a/TODO.md
+++ b/TODO.md
@@ -46,7 +46,7 @@ see CHANGELOG.md for a more formal list of changes by release
 * addon detail, mutual dependencies pane
     - for example, I would like to see what is happening when:
         - adibags anima & conduits is overwritten by adibags anima filter
-        - adibags-shadowlands (github+wowinterface) 
+        - adibags-shadowlands (github+wowinterface)
 
 ## todo bucket (no particular order)
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,6 +29,12 @@ see CHANGELOG.md for a more formal list of changes by release
 * add a 'starred' filter to limit the search results to just those that are starred
     - done
 
+* addon detail, mutual dependencies pane
+    - for example, I would like to see what is happening when:
+        - adibags anima & conduits is overwritten by adibags anima filter
+        - adibags-shadowlands (github+wowinterface)
+    - done 
+
 ## todo
 
 * addon detail, 'releases' widget
@@ -42,11 +48,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * search, add ability to browse catalogue page by page
     - I have neglected the catalogue search *so much*. I need a whole release dedicated to improving it.
-
-* addon detail, mutual dependencies pane
-    - for example, I would like to see what is happening when:
-        - adibags anima & conduits is overwritten by adibags anima filter
-        - adibags-shadowlands (github+wowinterface)
 
 ## todo bucket (no particular order)
 

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -121,6 +121,14 @@
       nfo-data
       (invalid-data))))
 
+(defn-spec mutual-dependencies (s/coll-of :addon/nfo)
+  "returns a list of `addon/nfo` data for addons using the given `addon-dirname` (including itself)."
+  [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname]
+  (let [contents (read-nfo-file install-dir addon-dirname)]
+    (if (vector? contents)
+      contents
+      [contents])))
+
 (defn-spec mutual-dependency? boolean?
   "returns `true` if multiple sets of nfo data exist in file"
   ([nfo-data (s/nilable ::sp/map-or-list-of-maps)]

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -127,7 +127,9 @@
 
 (s/def :addon/id (s/or :regular (s/keys :req-un [:addon/source :addon/source-id]) ;; installed addons and catalogue addons
                        :edge (s/keys :req-in [::dirname]))) ;; unmatched and ignored addons
-(s/def :ui/addon-detail-nav-key #{:releases+grouped-addons :mutual-dependencies :raw-data})
+
+(def addon-detail-nav-key-set #{:releases+grouped-addons :mutual-dependencies :raw-data})
+(s/def :ui/addon-detail-nav-key addon-detail-nav-key-set)
 (s/def :ui/tab-data :addon/id) ;; for now
 (s/def :ui/tab-id string?)
 (s/def :ui/tab (s/keys :req-un [:ui/tab-id ::label ::closable? :ui/tab-data ::log-level :ui/addon-detail-nav-key]))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -127,9 +127,10 @@
 
 (s/def :addon/id (s/or :regular (s/keys :req-un [:addon/source :addon/source-id]) ;; installed addons and catalogue addons
                        :edge (s/keys :req-in [::dirname]))) ;; unmatched and ignored addons
+(s/def :ui/addon-detail-nav-key #{:releases+grouped-addons :mutual-dependencies :raw-data})
 (s/def :ui/tab-data :addon/id) ;; for now
 (s/def :ui/tab-id string?)
-(s/def :ui/tab (s/keys :req-un [:ui/tab-id ::label ::closable? :ui/tab-data ::log-level]))
+(s/def :ui/tab (s/keys :req-un [:ui/tab-id ::label ::closable? :ui/tab-data ::log-level :ui/addon-detail-nav-key]))
 (s/def :ui/tab-list (s/coll-of :ui/tab))
 
 ;; column lists

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -458,8 +458,8 @@
                  :tab-data tab-data
                  :addon-detail-nav-key :releases+grouped-addons}
         tab-list (remove (fn [tab]
-                           (= (dissoc tab :tab-id)
-                              (dissoc new-tab :tab-id)))
+                           (= (select-keys tab [:label :tab-data])
+                              (select-keys new-tab [:label :tab-data])))
                          (core/get-state :tab-list))
         tab-list (vec (concat tab-list [new-tab]))]
     (swap! core/state assoc :tab-list tab-list))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -418,6 +418,11 @@
 
 ;; tabs
 
+(defn-spec change-addon-detail-nav nil?
+  [nav-key :ui/addon-detail-nav-key, tab-idx int?]
+  (swap! core/state assoc-in [:tab-list tab-idx :addon-detail-nav-key] nav-key)
+  nil)
+
 (defn-spec change-notice-logger-level nil?
   "changes the log level on the UI notice-logger widget.
   changes the log level for a tab in `:tab-list` when `tab-idx` is also given."
@@ -450,7 +455,8 @@
                  :label tab-label
                  :closable? closable?
                  :log-level :info
-                 :tab-data tab-data}
+                 :tab-data tab-data
+                 :addon-detail-nav-key :releases+grouped-addons}
         tab-list (remove (fn [tab]
                            (= (dissoc tab :tab-id)
                               (dissoc new-tab :tab-id)))

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -419,9 +419,11 @@
 ;; tabs
 
 (defn-spec change-addon-detail-nav nil?
+  "changes the selected mode of the addon detail pane between releases+grouped-addons, mutual dependencies and key+vals"
   [nav-key :ui/addon-detail-nav-key, tab-idx int?]
-  (swap! core/state assoc-in [:tab-list tab-idx :addon-detail-nav-key] nav-key)
-  nil)
+  (when (some #{nav-key} sp/addon-detail-nav-key-set)
+    (swap! core/state assoc-in [:tab-list tab-idx :addon-detail-nav-key] nav-key)
+    nil))
 
 (defn-spec change-notice-logger-level nil?
   "changes the log level on the UI notice-logger widget.

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -236,7 +236,23 @@
 
 
                ;;
-               ;; common tables
+               ;; tabber
+               ;;
+
+
+               ".tab-pane > .tab-header-area "
+               {:-fx-padding ".7em 0 0 .6em"
+
+                "> .headers-region > .tab"
+                {:-fx-background-radius "0"
+                 :-fx-padding ".25em 1em"
+                 :-fx-focus-color "transparent" ;; disables the 'blue box' of selected widgets
+                 :-fx-faint-focus-color "transparent" ;; literally, a very faint box remains
+                 }}
+
+
+               ;;
+               ;; common styling for all tables
                ;;
 
 
@@ -248,162 +264,52 @@
 
                 ".table-placeholder-text" {:-fx-font-size "3em"}
 
-                ".column-header" {;;:-fx-background-color "#ddd" ;; flat colour vs gradient
-                                  :-fx-font-size "1em"}
+                ".column-header" {:-fx-font-size "1em"}
 
                 [".table-row-cell" ".tree-table-row-cell"]
                 {:-fx-border-insets "-1 -1 0 -1"
-                 :-fx-border-color (colour :table-border)
-                 :-fx-background-color (colour :row) ;; even
+                 :-fx-border-color (colour :table-border)}
 
-                 " .table-cell" {:-fx-text-fill (colour :table-font-colour)}
-                 ":hover" {:-fx-background-color (colour :row-hover)}
-                 ":selected" {:-fx-background-color (colour :row-selected)
-                              :-fx-table-cell-border-color (colour :table-border)
-                              " .table-cell" {:-fx-text-fill "-fx-focused-text-base-color"}}
-                 ":selected:hover" {:-fx-background-color (colour :row-hover)}
 
-                 ":odd" {:-fx-background-color (colour :row)
-                         ":hover" {:-fx-background-color (colour :row-hover)}
-                         ":selected" {:-fx-background-color (colour :row-selected)}
-                         ":selected:hover" {:-fx-background-color (colour :row-hover)}}
+                ;;
+                ;; common column styling
+                ;;
 
-                 ".unsteady" {;; '!important' so that it takes precedence over .updateable addons
-                              ;;:-fx-background-color (str (colour :unsteady) " !important")
-                              }}
+                ;; 'wide' buttons, like "[  install  ]" buttons
 
+
+                ".wide-button-column.table-cell"
+                {:-fx-padding "0px"
+                 :-fx-alignment "center"}
+
+                ".wide-button-column .button"
+                {:-fx-pref-width 100
+                 :-fx-padding "2px 0"
+                 :-fx-background-radius "4"}
+
+                ;; columns with buttons that don't look like buttons (star, uber-button, etc)
+                ".invisible-button-column"
+                {:-fx-padding 0
+                 :-fx-alignment "top-center"}
+
+                ".invisible-button-column > .button"
+                {:-fx-padding 0
+                 :-fx-background-color nil
+                 ;; invisible button should fill width of column
+                 :-fx-max-width "10em"}
+
+                ;; cells in ignored rows are semi-transparent
                 ".ignored .table-cell" {:-fx-opacity "0.5"
                                         :-fx-font-style "italic"}
 
-                ;; ignored 'install' button gets slightly different styling
-                ".ignored .install-button-column.table-cell"
-                {:-fx-opacity "1" ;; a disabled button already has some greying effect applied
-                 :-fx-font-style "normal"}}
-
-               ;;
-               ;; tables with alternating row colours (just add the '.odd-rows' class)
-               ;; 
-
-               ".table-view.odd-rows .table-row-cell:odd"
-               {:-fx-background-color (colour :row-alt)
-                ":hover"
-                {:-fx-background-color (colour :row-hover)}}
-
-               ;; 'the above overwrites the pseudo class as well apparently.
-               ;; this 'resets' it so we don't get selected rows with alternating blanks
-               ".table-view.odd-rows .table-row-cell:odd:selected"
-               {:-fx-background-color (colour :row-selected)
-                ":hover"
-                {:-fx-background-color (colour :row-hover)}}
-
-               ".table-view .install-button-column.table-cell"
-               {:-fx-padding "0px"
-                :-fx-alignment "center"}
-
-               ".table-view .install-button-column .button"
-               {:-fx-pref-width 100
-                :-fx-padding "2px 0"
-                :-fx-background-radius "4"}
-
-               ;; columns with invisible buttons in them
-               ".button-column"
-               {:-fx-padding 0
-                :-fx-alignment "top-center"}
-
-               ".button-column > .button"
-               {:-fx-padding 0
-                :-fx-background-color nil
-                :-fx-max-width "10em"} ;; "fill column width" 
-
-               ".star-column:hover > .button"
-               {:-fx-text-fill (colour :star-hover)}
-
-               ".star-column > .button"
-               {:-fx-padding "-0.25em"
-                :-fx-font-size "1.9em"
-                :-fx-text-fill (colour :star-unstarred)
-
-                ".starred"
-                {:-fx-text-fill (colour :star-starred)}}
-
-               ".button-column > .uber"
-               {:-fx-font-size "1.5em"
-                :-fx-text-fill (colour :uber-button-tick) ;; green tick
-                :-fx-font-weight "bold"}
-
-
-               ;;
-               ;; treetableview
-               ;;
-
-
-               ".tree-table-row-cell > .tree-disclosure-node"
-               {;; default is "4 6 4 8" but this makes the hitbox a tiny bit easier to hit
-                :-fx-padding "9"
-                " > .arrow" {:-fx-background-color (colour :table-font-colour)}}
-
-               ".table-view .child-row .table-cell"
-               {:-fx-opacity 0.6}
-
-               ;;
-               ;; tabber
-               ;;
-
-
-               ".tab-pane > .tab-header-area"
-               {:-fx-padding ".7em 0 0 .6em"}
-
-               ;; tabs
-               ".tab-pane > .tab-header-area > .headers-region > .tab"
-               {:-fx-background-radius "0"
-                :-fx-padding ".25em 1em"
-                :-fx-focus-color "transparent" ;; disables the 'blue box' of selected widgets
-                :-fx-faint-focus-color "transparent" ;; literally, a very faint box remains
-                }
-
-
-               ;;
-               ;; installed-addons tab
-               ;;
-
-
-               ".table-view #placeholder "
-               {:-fx-alignment "center"
-
-                ".big-welcome-text"
-                {:-fx-font-size "5em"
-                 :-fx-font-weight "bold"
-                 :-fx-padding ".3em 1em"
-                 :-fx-spacing "1em"}
-
-                ".big-welcome-subtext"
-                {:-fx-font-size "1.8em"
-                 :-fx-font-family "monospace"
-                 :-fx-padding ".8em 0 1em 0"}}
-
-               "#update-all-button"
-               {:-fx-min-width "110px"}
-
-               "#game-track-container "
-               {:-fx-alignment "center"
-
-                "#game-track-check-box"
-                {:-fx-padding "0 0 0 .65em"
-                 :-fx-min-width "70px"}}
-
-               ".table-view#installed-addons "
-               {".wow-column"
-                {:-fx-alignment "center"}
-
-                ".table-row-cell.warnings .button-column > .button"
-                {;; orange bar
-                 :-fx-text-fill (colour :uber-button-warn)}
-
-                ".table-row-cell.errors .button-column > .button"
-                {;; red cross
-                 :-fx-text-fill (colour :uber-button-error)}
+                ;; wide buttons in ignored cells get slightly different styling
+                ".ignored .wide-button-column.table-cell"
+                {:-fx-opacity "1" ;; a disabled button already has a greying effect applied
+                 :-fx-font-style "normal"}
 
                 ;; .installed-column, .available-column, .version-column
+
+
                 ".version-column"
                 {:-fx-alignment "center-right"
                  :-fx-text-overrun "leading-ellipsis"}
@@ -418,68 +324,150 @@
                 ".updated-column"
                 {:-fx-alignment "center"}}
 
-               ;; installed, updateable
+               ;;
+               ;; common styling for tree-tables
+               ;;
 
-               ".table-view#installed-addons .updateable"
-               {:-fx-background-color (colour :row-updateable)
 
-                " .table-cell"
-                {:-fx-text-fill (colour :row-updateable-text)}
+               ".tree-table-row-cell > .tree-disclosure-node"
+               {;; default is "4 6 4 8" but this makes the hitbox a tiny bit easier to hit
+                :-fx-padding "9"
+                " > .arrow" {:-fx-background-color (colour :table-font-colour)}}
 
-                " .hyperlink"
-                {:-fx-text-fill (colour :hyperlink-updateable)}
 
-                ;; selected+updateable addons look *slightly* different
-                ":selected"
-                {;; !important so that hovering over a selected+updateable row doesn't change it's colour
-                 :-fx-background-color (str (colour :row-updateable-selected) " !important")}}
+               ;;
+               ;; common styling for install + search tables
+               ;;
 
-               ;; installed, ignored
 
-               ".table-view#installed-addons .ignored"
-               {" .button-column > .button"
-                ;; !important because an orange warning colour is being inherited from somewhere
-                {:-fx-text-fill "gray !important"}}
+               ["#installed-addons .table-view " "#search-addons .table-view "]
+               {[".table-row-cell" ".tree-table-row-cell"]
+                {:-fx-background-color (colour :row) ;; even rows
+
+                 " .table-cell" {:-fx-text-fill (colour :table-font-colour)}
+                 ":hover" {:-fx-background-color (colour :row-hover)}
+                 ":selected" {:-fx-background-color (colour :row-selected)
+                              :-fx-table-cell-border-color (colour :table-border)
+                              " .table-cell" {:-fx-text-fill "-fx-focused-text-base-color"}}
+                 ":selected:hover" {:-fx-background-color (colour :row-hover)}
+
+                 ":odd" {;;:-fx-background-color (colour :row)
+                         ":hover" {:-fx-background-color (colour :row-hover)}
+                         ":selected" {:-fx-background-color (colour :row-selected)}
+                         ":selected:hover" {:-fx-background-color (colour :row-hover)}}}}
+
+
+
+
+               ;;
+               ;; installed-addons tab
+               ;;
+
+
+               "#installed-addons"
+               {".table-view #placeholder "
+                {:-fx-alignment "center"
+
+                 ".big-welcome-text"
+                 {:-fx-font-size "5em"
+                  :-fx-font-weight "bold"
+                  :-fx-padding ".3em 1em"
+                  :-fx-spacing "1em"}
+
+                 ".big-welcome-subtext"
+                 {:-fx-font-size "1.8em"
+                  :-fx-font-family "monospace"
+                  :-fx-padding ".8em 0 1em 0"}}
+
+                "#update-all-button"
+                {:-fx-min-width "110px"}
+
+                "#game-track-container "
+                {:-fx-alignment "center"
+
+                 "#game-track-check-box"
+                 {:-fx-padding "0 0 0 .65em"
+                  :-fx-min-width "70px"}}
+
+                ".table-view#installed-addons-table "
+                {".wow-column"
+                 {:-fx-alignment "center"}
+
+                 ".uber-button"
+                 {:-fx-font-size "1.5em"
+                  :-fx-text-fill (colour :uber-button-tick) ;; green tick
+                  :-fx-font-weight "bold"}
+
+                 ".table-row-cell.warnings .invisible-button-column > .uber-button"
+                 {;; orange bar
+                  :-fx-text-fill (colour :uber-button-warn)}
+
+                 ".table-row-cell.errors .invisible-button-column > .uber-button"
+                 {;; red cross
+                  :-fx-text-fill (colour :uber-button-error)}
+
+                 ".child-row .table-cell"
+                 {:-fx-opacity 0.6}
+
+                 ".updateable"
+                 {:-fx-background-color (str (colour :row-updateable) " !important")
+
+                  " .table-cell"
+                  {:-fx-text-fill (colour :row-updateable-text)}
+
+                  " .hyperlink"
+                  {:-fx-text-fill (colour :hyperlink-updateable)}
+
+                  ;; selected+updateable addons look *slightly* different
+                  ":selected"
+                  {;; !important so that hovering over a selected+updateable row doesn't change it's colour
+                   :-fx-background-color (str (colour :row-updateable-selected) " !important")}}
+
+                 ".ignored"
+                 {" .invisible-button-column > .button"
+                  ;; !important because an orange warning colour is being inherited from somewhere
+                  {:-fx-text-fill "gray !important"}}}}
 
                ;;
                ;; notice-logger
                ;;
 
 
-               ".table-view#notice-logger "
-               {:-fx-font-family "monospace"
+               "#notice-logger "
+               {".table-view "
+                {:-fx-font-family "monospace"
 
-                ".warn .table-cell"
-                {:-fx-text-fill (colour :row-warning-text)
-                 :-fx-background-color (colour :row-warning)}
+                 ".warn .table-cell"
+                 {:-fx-text-fill (colour :row-warning-text)
+                  :-fx-background-color (colour :row-warning)}
 
-                ".warn:selected"
-                {:-fx-background-color "-fx-selection-bar"}
+                 ".warn:selected"
+                 {:-fx-background-color "-fx-selection-bar"}
 
-                ".error .table-cell"
-                {:-fx-text-fill (colour :row-error-text)
-                 :-fx-background-color (colour :row-error)}
+                 ".error .table-cell"
+                 {:-fx-text-fill (colour :row-error-text)
+                  :-fx-background-color (colour :row-error)}
 
-                ".error:selected"
-                {:-fx-background-color "-fx-selection-bar"}
+                 ".error:selected"
+                 {:-fx-background-color "-fx-selection-bar"}
 
-                ".report .table-cell"
-                {:-fx-text-fill (colour :row-report-text)}
+                 ".report .table-cell"
+                 {:-fx-text-fill (colour :row-report-text)}
 
-                ".report #message"
-                {:-fx-font-style "italic"}
+                 ".report #message"
+                 {:-fx-font-style "italic"}
 
-                "#level"
-                {:-fx-alignment "center"}
+                 "#level"
+                 {:-fx-alignment "center"}
 
-                "#source"
-                {:-fx-alignment "center"}
+                 "#source"
+                 {:-fx-alignment "center"}
 
-                "#time"
-                {:-fx-alignment "center"}
+                 "#time"
+                 {:-fx-alignment "center"}
 
-                "#message.column-header .label"
-                {:-fx-alignment "center-left"}}
+                 "#message.column-header .label"
+                 {:-fx-alignment "center-left"}}
 
 
                ;;
@@ -487,124 +475,128 @@
                ;;
 
 
-               "#notice-logger-nav"
-               {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
-                :-fx-font-size ".9em"
+                "#notice-logger-nav"
+                {:-fx-padding "1.1em .75em" ;; 1.1em so installed, search and log pane tables all start at the same height
+                 :-fx-font-size ".9em"
 
-                " .radio-button"
-                {:-fx-padding "0 .5em"}}
-
+                 " .radio-button"
+                 {:-fx-padding "0 .5em"}}}
 
                ;;
                ;; search
                ;;
 
 
-               "#search-install-button"
-               {:-fx-min-width "90px"}
+               "#search-addons "
+               {".star-column:hover > .button"
+                {:-fx-text-fill (colour :star-hover)}
 
-               "#search-random-button"
-               {:-fx-min-width "80px"}
+                ".star-column > .button"
+                {:-fx-padding "-0.25em !important"
+                 :-fx-font-size "1.9em"
+                 :-fx-text-fill (colour :star-unstarred)
 
-               "#search-user-catalogue-button"
-               {:-fx-font-weight "bold"
-                :-fx-font-size "1.4em"
-                :-fx-padding "1 7"
+                 ".starred"
+                 {:-fx-text-fill (colour :star-starred)}}
 
-                ".starred" {:-fx-text-fill (colour :star-starred)
-                            ;; the yellow of the star doesn't stand out from the gray gradient behind it.
-                            ;; this gives the text a border (stroke) and a very faint glow.
-                            " .text" {:-fx-stroke (colour :table-font-colour)
-                                      :-fx-stroke-width ".2"
-                                      :-fx-effect (str "dropshadow( gaussian , " (colour :star-starred) " , 10, 0.0 , 0 , 0 )")}}}
+                "#search-install-button"
+                {:-fx-min-width "90px"}
 
-               "#search-prev-button"
-               {:-fx-min-width "80px"}
+                "#search-random-button"
+                {:-fx-min-width "80px"}
 
-               "#search-next-button"
-               {:-fx-min-width "70px"}
+                "#search-user-catalogue-button"
+                {:-fx-font-weight "bold"
+                 :-fx-font-size "1.4em"
+                 :-fx-padding "1 7"
 
-               "#search-text-field "
-               {:-fx-min-width "100px"
-                :-fx-text-fill (colour :table-font-colour)}
+                 ".starred" {:-fx-text-fill (colour :star-starred)
+                             ;; the yellow of the star doesn't stand out from the gray gradient behind it.
+                             ;; this gives the text a border (stroke) and a very faint glow.
+                             " .text" {:-fx-stroke (colour :table-font-colour)
+                                       :-fx-stroke-width ".2"
+                                       :-fx-effect (str "dropshadow( gaussian , " (colour :star-starred) " , 10, 0.0 , 0 , 0 )")}}}
 
-               "#search-selected-tag-bar"
-               {:-fx-padding "0 0 10 10"
-                :-fx-spacing "10"
-                " > .button" {:-fx-padding "2.5 8"
-                              :-fx-background-radius "4"}}
+                "#search-prev-button"
+                {:-fx-min-width "80px"}
 
-               ".table-view#search-addons .downloads-column"
-               {:-fx-alignment "center-right"}
+                "#search-next-button"
+                {:-fx-min-width "70px"}
 
-               ".table-view#search-addons .updated-column"
-               {:-fx-alignment "center"}
+                "#search-text-field "
+                {:-fx-min-width "100px"
+                 :-fx-text-fill (colour :table-font-colour)}
 
-               ".tag-button-column"
-               {:-fx-padding "-1 0 0 0"
+                "#search-selected-tag-bar"
+                {:-fx-padding "0 0 10 10"
+                 :-fx-spacing "10"
+                 " > .button" {:-fx-padding "2.5 8"
+                               :-fx-background-radius "4"}}
 
-                " .button" {:-fx-min-width 50
-                            :-fx-font-size ".9em"
-                            :-fx-padding "4px 5px"
-                            :-fx-background-color "none"
-                            :-fx-opacity "1"
-                            :-fx-border-width "0 1 0 0"
-                            :-fx-border-color (colour :table-border)
-                            :-fx-text-overrun "word-ellipsis"
-                            ":hover" {:-fx-background-color (colour :row-updateable-selected)}}}
+                ".table-view "
+                {".downloads-column" {:-fx-alignment "center-right"}
+                 ".updated-column" {:-fx-alignment "center"}
 
+                 ".tag-button-column"
+                 {:-fx-padding "-1 0 0 0"
+                  " .button" {:-fx-min-width 50
+                              :-fx-font-size ".9em"
+                              :-fx-padding "4px 5px"
+                              :-fx-background-color "none"
+                              :-fx-opacity "1"
+                              :-fx-border-width "0 1 0 0"
+                              :-fx-border-color (colour :table-border)
+                              :-fx-text-overrun "word-ellipsis"
+                              ":hover" {:-fx-background-color (colour :row-updateable-selected)}}}}}
 
                ;;
                ;; status bar (bottom of app)
                ;; 
 
 
-               "#status-bar"
+               "#status-bar "
                {:-fx-font-size ".9em"
                 :-fx-padding "0"
-                :-fx-alignment "center-left"}
-
-               "#status-bar-left"
-               {:-fx-padding "0 10"
                 :-fx-alignment "center-left"
-                :-fx-pref-width 9999.0
 
-                " > .text"
-                {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
-                 :-fx-fill (colour :table-font-colour)}}
+                "#status-bar-left"
+                {:-fx-padding "0 10"
+                 :-fx-alignment "center-left"
+                 :-fx-pref-width 9999.0
+                 " > .text" {;; omg, wtf does 'fx-fill' work and not 'fx-text-fill' ???
+                             :-fx-fill (colour :table-font-colour)}}
 
-               "#status-bar-right"
-               {:-fx-min-width "130px" ;; long enough to render "warnings (999)"
+                "#status-bar-right"
+                {:-fx-min-width "130px" ;; long enough to render "warnings (999)"
+                 :-fx-padding "5px 12px 5px 0"
+                 :-fx-alignment "center-right"}
 
-                :-fx-padding "5px 12px 5px 0"
-                :-fx-alignment "center-right"}
+                "#status-bar-right .button"
+                {:-fx-padding "4 10"
+                 ;; doesn't look right when button is coloured.
+                 ;;:-fx-background-radius "4"
+                 :-fx-font-size "11px"
 
-               "#status-bar-right .button"
-               {:-fx-padding "4 10"
-                ;; doesn't look right when button is coloured.
-                ;;:-fx-background-radius "4"
-                :-fx-font-size "11px"
+                 ;; this isn't great but it's better than nothing. revisit when it makes more sense.
+                 ":armed"
+                 {:-fx-background-insets "1 1 0 0,  1,  2,  3"}}
 
-                ;; this isn't great but it's better than nothing. revisit when it makes more sense.
-                ":armed"
-                {:-fx-background-insets "1 1 0 0,  1,  2,  3"}}
+                ".button.with-warning"
+                {:-fx-background-insets "0 0 -1 0,  0,  1,  2"
+                 :-fx-background-color (str "-fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, " (colour :row-warning))
+                 :-fx-text-fill (colour :row-warning-text)}
 
-               ".button.with-warning"
-               {:-fx-background-insets "0 0 -1 0,  0,  1,  2"
-                :-fx-background-color (str "-fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, " (colour :row-warning))
-                :-fx-text-fill (colour :row-warning-text)}
-
-               ".button.with-error"
-               {:-fx-background-insets "0 0 -1 0,  0"
-                :-fx-background-color (str "-fx-shadow-highlight-color, -fx-inner-border, " (colour :row-error))
-                :-fx-text-fill (colour :row-error-text)}
+                ".button.with-error"
+                {:-fx-background-insets "0 0 -1 0,  0"
+                 :-fx-background-color (str "-fx-shadow-highlight-color, -fx-inner-border, " (colour :row-error))
+                 :-fx-text-fill (colour :row-error-text)}}
 
                ;;
                ;; addon-detail
                ;;
 
 
-               ".addon-detail "
+               "#addon-detail-pane "
                {".title"
                 {:-fx-font-size "2.5em"
                  :-fx-padding "1em 0 .5em 1em"
@@ -652,15 +644,15 @@
                 "#addon-detail-button-menu"
                 {:-fx-alignment "center"}
 
-                ;; keep the ignore and delete buttons very separate from the others
+                 ;; keep the ignore and delete buttons very separate from the others
                 ".separator"
                 {:-fx-padding "0 .5em"}
 
-                ".table-view#notice-logger"
+                ".table-view#notice-logger-table"
                 {:-fx-pref-height "10pc"}
 
-                ;; hide column headers in notice-logger in addon-detail pane
-                ".table-view#notice-logger .column-header-background"
+                 ;; hide column headers in notice-logger in addon-detail pane
+                ".table-view#notice-logger-table .column-header-background"
                 {:-fx-max-height 0
                  :-fx-pref-height 0
                  :-fx-min-height 0}
@@ -684,7 +676,7 @@
                                     :-fx-padding "1.7em 0"
                                     :-fx-background-radius "0"
                                     :-fx-font-size "1.1em"
-                                    ":selected" {:-fx-background-color (colour :row-updateable)}}}} ;; ends .addon-detail
+                                    ":selected" {:-fx-background-color (colour :row-updateable)}}}} ;; ends #addon-detail-pane
 
                ;; ---
                }}))]
@@ -722,7 +714,7 @@
 
 (defn find-installed-addons-table
   []
-  (first (select "#installed-addons")))
+  (first (select "#installed-addons-table")))
 
 (defn-spec clear-table-selected-items nil?
   "the context menu isn't being refreshed with new data when selected or installed addons change. 
@@ -1146,7 +1138,7 @@
                        :show-delay 200}}
      :desc {:fx/type :button
             :text text
-            :style-class ["button" "uber"]
+            :style-class ["button" "uber-button"]
             :on-action (fn [_]
                          (cli/add-addon-tab row)
                          (switch-tab-latest))}}))
@@ -1241,7 +1233,7 @@
          :available-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]}
          :combined-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]}
          :game-version {:min-width 70 :pref-width 70 :max-width 100}
-         :uber-button {:min-width 80 :pref-width 80 :max-width 120 :style-class ["button-column"]
+         :uber-button {:min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
                        :cell-value-factory identity
                        :cell-factory {:fx/cell-type :tree-table-cell
                                       :describe (fn [row]
@@ -1663,7 +1655,7 @@
                                                                       (.getValue tree-item))
                                                                     tree-item-list)))}
      :desc {:fx/type :tree-table-view
-            :id "installed-addons"
+            :id "installed-addons-table"
             ;; replaces "tree-table-view" class and keeps all styling attached to table-view.
             :style-class ["table-view"]
             :show-root false
@@ -1782,8 +1774,8 @@
 
         log-message-list (filter log-level-filter log-message-list)]
     {:fx/type :border-pane
+     :id "notice-logger"
      :top {:fx/type :h-box
-           :style-class ["notice-logger-nav-box"]
            :children (utils/items
                       [(when section-title
                          {:fx/type :label
@@ -1798,8 +1790,8 @@
                         :on-action log-level-changed-handler}])}
 
      :center {:fx/type :table-view
-              :id "notice-logger"
-              :style-class ["table-view" "odd-rows"]
+              :id "notice-logger-table"
+              :style-class ["table-view"]
               :placeholder {:fx/type :text
                             :style-class ["table-placeholder-text"]
                             :text ""}
@@ -1829,6 +1821,7 @@
 (defn installed-addons-pane
   [_]
   {:fx/type :border-pane
+   :id "installed-addons"
    :top {:fx/type installed-addons-menu-bar}
    :center {:fx/type installed-addons-table}})
 
@@ -1852,7 +1845,7 @@
         tag-selected (fn [tag]
                        (some #{tag} tag-set))
 
-        column-list [{:text "" :style-class ["button-column" "star-column"]
+        column-list [{:text "" :style-class ["invisible-button-column" "star-column"]
                       :min-width 50 :pref-width 50 :max-width 50
                       :cell-value-factory identity
                       :cell-factory {:fx/cell-type :table-cell
@@ -1889,7 +1882,7 @@
                                      :describe (fn [n]
                                                  (when n
                                                    {:text (format-number n)}))}}
-                     {:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :max-width 120 :resizable false
+                     {:text "" :style-class ["wide-button-column"] :min-width 120 :pref-width 120 :max-width 120 :resizable false
                       :cell-factory {:fx/cell-type :table-cell
                                      :describe (fn [addon]
                                                  {:graphic (button "install" (async-handler #(search-results-install-handler [addon]))
@@ -1901,7 +1894,7 @@
              ;; unlike gui.clj, we have access to the original data here. no need to re-select addons.
              :on-selected-items-changed cli/select-addons-search!}
      :desc {:fx/type :table-view
-            :id "search-addons"
+            :id "search-addons-table"
             :placeholder {:fx/type :label
                           :style-class ["table-placeholder-text"]
                           :text (if empty-next-page
@@ -2001,6 +1994,7 @@
 (defn search-addons-pane
   [_]
   {:fx/type :border-pane
+   :id "search-addons"
    :top {:fx/type search-addons-search-field}
    :center {:fx/type search-addons-table}})
 
@@ -2067,7 +2061,7 @@
            :text "raw data"}
      :center {:fx/type :table-view
               :id "key-vals"
-              :style-class ["table-view" "odd-rows"]
+              :style-class ["table-view"]
               :placeholder {:fx/type :text
                             :style-class ["table-placeholder-text"]
                             :text "(not installed)"}
@@ -2089,7 +2083,7 @@
            :text "grouped addons"}
      :center {:fx/type :table-view
               :id "group-addons"
-              :style-class ["table-view" "odd-rows"]
+              :style-class ["table-view"]
               :placeholder {:fx/type :text
                             :style-class ["table-placeholder-text"]
                             :text "(not grouped)"}
@@ -2104,7 +2098,7 @@
   (let [install-button (fn [release]
                          (component-instance
                           (button "install" (async-handler #(cli/set-version addon release)))))
-        column-list [{:text "" :style-class ["install-button-column"] :min-width 120 :pref-width 120 :max-width 120 :resizable false :cell-value-factory install-button}
+        column-list [{:text "" :style-class ["wide-button-column"] :min-width 120 :pref-width 120 :max-width 120 :resizable false :cell-value-factory install-button}
                      {:text "name" :cell-value-factory #(or (:release-label %) (:version %))}]
         row-list (or (rest (:release-list addon)) [])
         disabled? (not (addon/releases-visible? addon))]
@@ -2114,7 +2108,7 @@
            :text "releases"}
      :center {:fx/type :table-view
               :id "release-list"
-              :style-class ["table-view" "odd-rows"]
+              :style-class ["table-view"]
               :placeholder {:fx/type :text
                             :style-class ["table-placeholder-text"]
                             :text "(no releases)"}
@@ -2170,7 +2164,15 @@
                        :text "addons that this addon (or any of it's grouped addons) overlaps with"}]}
 
      :center {:fx/type :tree-table-view
+              :root root
+              :style-class ["table-view"]
+              :show-root false
+              :disable (< depth 2)
+              :row-factory {:fx/cell-type :tree-table-row
+                            :describe (fn [row]
+                                        {:style-class ["table-row-cell" "tree-table-row-cell"]})}
               :columns [{:fx/type :tree-table-column
+                         :style-class ["table-view"]
                          :text ""
                          :cell-value-factory :arrow
                          :min-width (* depth 14)}
@@ -2189,11 +2191,7 @@
                          :text "directory"
                          :cell-value-factory :dirname}
 
-                        (make-tree-table-column (:installed-version gui-column-map))]
-
-              :root root
-              :show-root false
-              :disable (< depth 2)}}))
+                        (make-tree-table-column (:installed-version gui-column-map))]}}))
 
 (defn addon-detail-centre-pane
   [{:keys [fx/context tab-idx addon]}]
@@ -2327,7 +2325,6 @@
       (let [notice-pane-filter (logging/log-line-filter-with-reports (core/selected-addon-dir) addon)]
         {:fx/type :border-pane
          :id "addon-detail-pane"
-         :style-class ["addon-detail"]
          :top {:fx/type :label
                :style-class ["title"]
                :text (:label addon)}
@@ -2371,7 +2368,7 @@
                      {:id "source-id" :text "source-id" :pref-width 100 :min-width 100 :cell-value-factory :source-id}
                      {:id "name" :text "name" :pref-width 100 :min-width 100 :cell-value-factory :label}
                      {:id "game-track-list" :text "supports" :pref-width 100 :min-width 100 :cell-value-factory (comp str :game-track-list)}
-                     {:id "refresh" :text "" :style-class ["install-button-column"] :pref-width 100 :min-width 100 :resizable false :cell-value-factory refresh-button}]
+                     {:id "refresh" :text "" :style-class ["wide-button-column"] :pref-width 100 :min-width 100 :resizable false :cell-value-factory refresh-button}]
 
         row-list (:addon-summary-list user-catalogue)]
 
@@ -2379,7 +2376,7 @@
      :top {:fx/type :text :text "hiya"}
      :center {:fx/type :table-view
               :id "key-vals"
-              :style-class ["table-view" "odd-rows"]
+              :style-class ["table-view"]
               :placeholder {:fx/type :text
                             :style-class ["table-placeholder-text"]
                             :text "(not installed)"}

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -636,7 +636,7 @@
 
                 ".description"
                 {:-fx-font-size "1.4em"
-                 :-fx-padding "1em 0 2em 1.5em"
+                 :-fx-padding "1em .5em 2em 1.5em"
                  :-fx-wrap-text true
                  :-fx-font-style "italic"
                  :-fx-text-fill "-fx-text-base-color"}
@@ -646,7 +646,7 @@
 
                  ;; keep the ignore and delete buttons very separate from the others
                 ".separator"
-                {:-fx-padding "0 .5em"}
+                {:-fx-padding "0 .25em"}
 
                 ".table-view#notice-logger-table"
                 {:-fx-pref-height "10pc"}
@@ -669,6 +669,12 @@
                 {:-fx-alignment "center-right"
                  :-fx-padding "0 1em 0 0"
                  :-fx-font-style "italic"}
+
+                ".table-view#key-vals .key-column.column-header .label"
+                {:-fx-alignment "center-right"}
+
+                ".table-view#key-vals .val-column.column-header .label"
+                {:-fx-alignment "center-left"}
 
                 "#addon-detail-big-buttons"
                 {:-fx-padding "2em 0"
@@ -2029,7 +2035,7 @@
                :orientation :vertical}
 
               (if (addon/ignored? addon)
-                (button "Stop ignoring" (async-handler #(cli/clear-ignore-selected [addon] (core/selected-addon-dir))))
+                (button "Unignore" (async-handler #(cli/clear-ignore-selected [addon] (core/selected-addon-dir))))
                 (button "Ignore" (async-handler #(cli/ignore-selected [addon]))
                         {:tooltip "Prevent all changes"
                          :disabled? (not (addon/ignorable? addon))}))
@@ -2047,7 +2053,7 @@
   (let [key-col (fn [keypair]
                   ;; shouldn't ever be nil but better safe than sorry
                   (-> keypair :key (or ":nil") str (subs 1)))
-        column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 250 :cell-value-factory key-col}
+        column-list [{:text "key" :min-width 150 :pref-width 150 :max-width 200 :cell-value-factory key-col}
                      {:text "val" :cell-value-factory :val}]
 
         blacklist [:group-addons :release-list :source-map-list]
@@ -2167,6 +2173,7 @@
               :root root
               :style-class ["table-view"]
               :show-root false
+              :column-resize-policy javafx.scene.control.TreeTableView/CONSTRAINED_RESIZE_POLICY
               :disable (< depth 2)
               :row-factory {:fx/cell-type :tree-table-row
                             :describe (fn [row]
@@ -2175,9 +2182,9 @@
                          :style-class ["table-view"]
                          :text ""
                          :cell-value-factory :arrow
-                         :min-width (* depth 14)}
-
-                        (make-tree-table-column (:browse-local gui-column-map))
+                         :min-width (* depth 14)
+                         :pref-width (* depth 14)
+                         :max-width (* depth 14)}
 
                         (make-tree-table-column (:source gui-column-map))
 
@@ -2191,7 +2198,9 @@
                          :text "directory"
                          :cell-value-factory :dirname}
 
-                        (make-tree-table-column (:installed-version gui-column-map))]}}))
+                        {:fx/type :tree-table-column
+                         :text "version"
+                         :cell-value-factory :installed-version}]}}))
 
 (defn addon-detail-centre-pane
   [{:keys [fx/context tab-idx addon]}]
@@ -2208,8 +2217,8 @@
                                         :ref ::toggle-group}})
 
         stub {:fx/type :v-box
-              :min-width 450
-              :pref-width 450
+              :min-width 460
+              :pref-width 460
               :grid-pane/column 1
               :grid-pane/hgrow :never
               :grid-pane/vgrow :always

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1162,10 +1162,12 @@
   "returns a hyperlink description or an empty text description"
   [row (s/nilable (s/keys :opt-un [::sp/url]))]
   (let [url (:url row)
+        fallback-url (:group-id row)
         label (:source row)]
-    (if (and url label)
+    (if (or (and url label)
+            (and fallback-url label))
       {:fx/type :hyperlink
-       :on-action (handler #(utils/browse-to url))
+       :on-action (handler #(utils/browse-to (or url fallback-url)))
        :text (str "↪ " label)}
       {:fx/type :text
        :text ""})))
@@ -2154,7 +2156,9 @@
               :children children}
 
         ;; we want a depth > 1 to show anything meaningful
-        depth (find-depth root 0)]
+        depth (find-depth root 0)
+
+        gui-column-map (gui-column-map nil)]
 
     {:fx/type :border-pane
      :top {:fx/type :v-box
@@ -2170,24 +2174,22 @@
                          :text ""
                          :cell-value-factory :arrow
                          :min-width (* depth 14)}
-                        {:fx/type :tree-table-column
-                         :text "dirname"
-                         :cell-value-factory (comp str :dirname)}
+
+                        (make-tree-table-column (:browse-local gui-column-map))
+
+                        (make-tree-table-column (:source gui-column-map))
+
+                        (make-tree-table-column (:source-id gui-column-map))
+
                         {:fx/type :tree-table-column
                          :text "name"
                          :cell-value-factory :name}
 
                         {:fx/type :tree-table-column
-                         :text "source"
-                         :cell-value-factory :source}
+                         :text "directory"
+                         :cell-value-factory :dirname}
 
-                        {:fx/type :tree-table-column
-                         :text "source-id"
-                         :cell-value-factory :source-id}
-
-                        {:fx/type :tree-table-column
-                         :text "installed-version"
-                         :cell-value-factory :installed-version}]
+                        (make-tree-table-column (:installed-version gui-column-map))]
 
               :root root
               :show-root false

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -666,7 +666,7 @@
                  :-fx-min-height 0}
 
                 "#notice-logger-nav"
-                {:-fx-padding "0 0 .5em 0"
+                {:-fx-padding ".6em 0 .7em 0"
                  :-fx-alignment "bottom-right"
                  :-fx-pref-width 9999.0}
 

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -778,3 +778,12 @@
   [addon (s/nilable map?)]
   (select-keys addon [:source :source-id]))
 
+(defn-spec find-depth int?
+  "given a map `m`, if it contains `:children`, increments `i` and calls self"
+  [m map?, i int?]
+  (if (contains? m :children)
+    (let [children (:children m)]
+      (if (sequential? children)
+        (apply max (conj (mapv #(find-depth % (inc i)) children) (inc i)))
+        (inc i)))
+    i))

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -318,7 +318,7 @@
 
 (deftest add-tab
   (testing "a generic tab can be created"
-    (let [expected [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}]]
+    (let [expected [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"} :addon-detail-nav-key :releases+grouped-addons}]]
       (with-running-app
         (is (= [] (core/get-state :tab-list)))
         (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
@@ -326,8 +326,13 @@
 
 (deftest add-addon-tab
   (testing "an addon can be used to create a tab"
-    (let [addon {:source "curseforge" :source-id 123 :label "Foo"}
-          expected [{:closable? true, :label "Foo", :tab-data {:source "curseforge", :source-id 123}, :tab-id "foobar" :log-level :info}]]
+    (let [addon {:source "wowinterface" :source-id 123 :label "Foo"}
+          expected [{:closable? true
+                     :label "Foo"
+                     :tab-data {:source "wowinterface", :source-id 123}
+                     :tab-id "foobar"
+                     :log-level :info
+                     :addon-detail-nav-key :releases+grouped-addons}]]
       (with-running-app
         (with-redefs [strongbox.utils/unique-id (constantly "foobar")]
           (cli/add-addon-tab addon))
@@ -335,8 +340,18 @@
 
 (deftest remove-all-tabs
   (testing "all tabs can be removed at once"
-    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}
-                    {:tab-id "bar" :label "Bar!" :closable? true :log-level :info :tab-data {:dirname "EveryOtherAddon"}}]
+    (let [tab-list [{:tab-id "foo"
+                     :label "Foo!"
+                     :closable? false
+                     :log-level :info
+                     :tab-data {:dirname "EveryAddon"}
+                     :addon-detail-nav-key :releases+grouped-addons}
+                    {:tab-id "bar"
+                     :label "Bar!"
+                     :closable? true
+                     :log-level :info
+                     :tab-data {:dirname "EveryOtherAddon"}
+                     :addon-detail-nav-key :releases+grouped-addons}]
           expected []]
       (with-running-app
         (cli/add-tab "foo" "Foo!" false {:dirname "EveryAddon"})
@@ -347,9 +362,9 @@
 
 (deftest remove-tab-at-idx
   (testing "all tabs can be removed at once"
-    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"}}
-                    {:tab-id "bar" :label "Bar!" :closable? true :log-level :info :tab-data {:dirname "EveryOtherAddon"}}
-                    {:tab-id "baz" :label "Baz!" :closable? false :log-level :info :tab-data {:dirname "EveryAddonClassic"}}]
+    (let [tab-list [{:tab-id "foo" :label "Foo!" :closable? false :log-level :info :tab-data {:dirname "EveryAddon"} :addon-detail-nav-key :releases+grouped-addons}
+                    {:tab-id "bar" :label "Bar!" :closable? true :log-level :info :tab-data {:dirname "EveryOtherAddon"} :addon-detail-nav-key :releases+grouped-addons}
+                    {:tab-id "baz" :label "Baz!" :closable? false :log-level :info :tab-data {:dirname "EveryAddonClassic"} :addon-detail-nav-key :releases+grouped-addons}]
           expected [(first tab-list)
                     (last tab-list)]]
       (with-running-app

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -875,3 +875,18 @@
 
       (doseq [[given expected] cases]
         (is (= expected (cli/sort-column-list given)))))))
+
+(deftest change-addon-detail-nav
+  (let [addon {:source "wowinterface" :source-id 123 :label "Foo"}
+        tab-idx 0
+        expected {:closable? true
+                  :label "Foo"
+                  :tab-data {:source "wowinterface", :source-id 123}
+                  :tab-id "foobar"
+                  :log-level :info
+                  :addon-detail-nav-key :mutual-dependencies}]
+    (with-running-app
+      (with-redefs [strongbox.utils/unique-id (constantly "foobar")]
+        (cli/add-addon-tab addon)
+        (cli/change-addon-detail-nav :mutual-dependencies tab-idx)
+        (is (= expected (core/get-state :tab-list tab-idx)))))))

--- a/test/strongbox/nfo_test.clj
+++ b/test/strongbox/nfo_test.clj
@@ -347,3 +347,41 @@
       (nfo/unpin (install-dir) addon-dir)
       (is (= expected (nfo/read-nfo (install-dir) addon-dir))))))
 
+(deftest mutual-dependencies--no-dependencies
+  (testing "returns all nfo data the given addon depends on, including itself, as a simple ordered list"
+    (let [nfo-data {:installed-version "1.2.1"
+                    :installed-game-track :classic
+                    :name "EveryAddon"
+                    :group-id "https://foo.bar"
+                    :primary? true
+                    :source "wowinterface"
+                    :source-id 321
+                    :source-map-list [{:source "wowinterface" :source-id 321}]}
+          expected [nfo-data]]
+      (nfo/write-nfo (install-dir) addon-dir nfo-data)
+      (is (= expected (nfo/mutual-dependencies (install-dir) addon-dir))))))
+
+(deftest mutual-dependencies
+  (testing "returns all nfo data the given addon depends on, including itself, as a simple ordered list"
+    (let [nfo-data-a {:installed-version "1.2.1"
+                      :installed-game-track :classic
+                      :name "EveryAddon"
+                      :group-id "https://foo.bar"
+                      :primary? true
+                      :source "wowinterface"
+                      :source-id 321
+                      :source-map-list [{:source "wowinterface" :source-id 321}]}
+
+          nfo-data-b {:installed-version "3.2.1"
+                      :installed-game-track :retail
+                      :name "EveryOtherAddon"
+                      :group-id "https://bar.baz"
+                      :primary? true
+                      :source "github"
+                      :source-id 123
+                      :source-map-list [{:source "github" :source-id 123}]}
+
+          expected [nfo-data-a nfo-data-b]]
+      (nfo/write-nfo (install-dir) addon-dir expected)
+      (is (= expected (nfo/mutual-dependencies (install-dir) addon-dir))))))
+

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -467,3 +467,18 @@
                [{:source "foo" :source-id "bar" :name "baz"} {:source "foo" :source-id "bar"}]]]
     (doseq [[given expected] cases]
       (is (= expected (utils/source-map given))))))
+
+(deftest find-depth
+  (let [cases [[{} 0]
+               [{:foo []} 0]
+
+               ;; we went down one level but not further
+               [{:children {:foo :bar}} 1]
+               [{:children [{:foo :bar}]} 1]
+
+               [{:children [{:children [{:children nil}]}]} 3]
+               [{:children [{:children [{:children :foo}]}]} 3]
+               [{:children [{:children [{:children []}]}]} 3]]]
+
+    (doseq [[given expected] cases]
+      (is (= expected (utils/find-depth given 0))))))

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -464,7 +464,6 @@
                [{:foo "bar"} {}]
                [{:source "foo"} {:source "foo"}]
                [{:source "foo" :source-id "bar"} {:source "foo" :source-id "bar"}]
-               [{:source "foo" :source-id "bar" :name "baz"} {:source "foo" :source-id "bar"}]]
-        ]
+               [{:source "foo" :source-id "bar" :name "baz"} {:source "foo" :source-id "bar"}]]]
     (doseq [[given expected] cases]
       (is (= expected (utils/source-map given))))))


### PR DESCRIPTION
- [x] mutual dependencies pane lists all other addons *this* addon is overwriting
- [x] navigation to switch between panes
- [x] mutual dependencies, row formatting is being nerfed
- [x] 'val' column on key+vals is now far too much in the center
- [x] padding between description and grid pane is too close
- [x] addon detail, button bar is too wide when addon is ignored
- [x] notice pane filter buttons too little vertical padding
- [x] bug, exclude nav from tab when deciding to open a new detail tab or not
- [x] replace 'source' column with a hyperlink
- [x] add a 'browse local files' link
- [x] review
- [x] update CHANGELOG