### PR TITLE
cli, fixed bug where gui was expecting a job-id as a keyset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * fixed handling for empty game track lists in the github csv catalogue.
+* fixed bug where the GUI would look for parallel jobs matching a complex ID when jobs with a simple ID were present.
 
 ### Removed
 

--- a/src/strongbox/joblib.clj
+++ b/src/strongbox/joblib.clj
@@ -2,7 +2,7 @@
   (:require
    [lasync.core :as lasync]
    [clojure.set]
-   [taoensso.timbre :as timbre :refer [warn spy]]
+   [taoensso.timbre :as timbre :refer [debug warn spy]]
    [flatland.ordered.map :refer [ordered-map]]
    [clojure.spec.alpha :as s]
    [orchestra.core :refer [defn-spec]]
@@ -208,7 +208,10 @@
   [job-id :joblib/job-id]
   (if (set? job-id)
     (fn [[queue-key _]]
-      (clojure.set/subset? job-id queue-key))
+      ;; note@2022-05: this case was 'fixed' by using `create-addon-job!` instead of `create-job!`
+      (when-not (set? queue-key)
+        (debug "expecting a set, got job-id" job-id "and queue key" queue-key))
+      (clojure.set/subset? job-id (set #{queue-key})))
     (fn [[queue-key _]]
       (= queue-key job-id))))
 

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -322,9 +322,8 @@
                                                                                  (zipfile-locks downloaded-file))]
                                              (utils/with-lock current-locks locks-needed
                                                (core/install-addon-affective addon install-dir downloaded-file)
-                                               (core/refresh-addon addon))))
-                                  job-id (joblib/addon-job-id addon :download-addon)]
-                              (joblib/create-job! queue-atm job-fn job-id)))]
+                                               (core/refresh-addon addon))))]
+                              (joblib/create-addon-job! queue-atm addon job-fn)))]
     (run! add-download-job! updateable-addon-list)
     (joblib/run-jobs! queue-atm core/num-concurrent-downloads)
     nil))
@@ -359,17 +358,16 @@
   a bit different from the other installation functions, this one returns a list of maps with the installation results."
   [addon-list :addon/summary-list]
   (let [queue-atm (core/get-state :job-queue)
-        job (fn [addon]
-              (fn []
-                (let [error-messages
-                      (logging/buffered-log
-                       :warn
-                       (some-> addon
-                               core/expand-summary-wrapper
-                               core/install-addon-guard-affective))]
-                  {:label (:label addon)
-                   :error-messages error-messages})))]
-    (run! (partial joblib/create-job! queue-atm) (mapv job addon-list))
+        job-fn (fn [addon]
+                 (let [error-messages
+                       (logging/buffered-log
+                        :warn
+                        (some-> addon
+                                core/expand-summary-wrapper
+                                core/install-addon-guard-affective))]
+                   {:label (:label addon)
+                    :error-messages error-messages}))]
+    (run! #(joblib/create-addon-job! queue-atm % job-fn) addon-list)
     (joblib/run-jobs! (core/get-state :job-queue) core/num-concurrent-downloads)))
 
 (defn-spec update-selected nil?

--- a/src/strongbox/ui/cli.clj
+++ b/src/strongbox/ui/cli.clj
@@ -358,16 +358,16 @@
   a bit different from the other installation functions, this one returns a list of maps with the installation results."
   [addon-list :addon/summary-list]
   (let [queue-atm (core/get-state :job-queue)
-        job-fn (fn [addon]
-                 (let [error-messages
-                       (logging/buffered-log
-                        :warn
-                        (some-> addon
-                                core/expand-summary-wrapper
-                                core/install-addon-guard-affective))]
-                   {:label (:label addon)
-                    :error-messages error-messages}))]
-    (run! #(joblib/create-addon-job! queue-atm % job-fn) addon-list)
+        job (fn [addon]
+              (let [error-messages
+                    (logging/buffered-log
+                     :warn
+                     (some-> addon
+                             core/expand-summary-wrapper
+                             core/install-addon-guard-affective))]
+                {:label (:label addon)
+                 :error-messages error-messages}))]
+    (run! #(joblib/create-addon-job! queue-atm % job) addon-list)
     (joblib/run-jobs! (core/get-state :job-queue) core/num-concurrent-downloads)))
 
 (defn-spec update-selected nil?


### PR DESCRIPTION
but was instead getting a keyword.
this was because I was mixing create-job! (keyword job-ids) and create-addon-job! (keyset) usages.
all jobs are created with create-addon-job! now.

- [x] review
- [x] update CHANGELOG