### PR TITLE
jfx, adds patch release name as tooltip to 'WoW' column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* the tooltip for values in the 'WoW' column is now the long-form patch name.
+    - for example, '9.2.5' will have the tooltip 'Shadowlands: Eternity's End'.
+
 ### Changed
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -6,31 +6,27 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## done
 
+* tooltip on WoW column with patch name
+    - done
+
 ## todo
 
-## todo bucket (no particular order)
+* bug, github, questie is kinda fubar
+    - https://github.com/ogri-la/strongbox/issues/339
+    - it's also breaking being installed from a zipfile when spec is turned on
 
-* zip, switch to apache commons compress for decompressing
-    - https://commons.apache.org/proper/commons-compress/
-    - .tar.gz and 7z support would be interesting
-    - rar should just die already
-    - this would fix a major showstopper in porting to windows
-    - 2022-05-29: returned to bucket, gazumped by installing addon from file.
+* bug, github, BigWigs_Classic from Github cannot be installed when 'retail strict' is set
+    - it can be installed from wowi fine
 
-* bug, addon detail, highlighted installed version is causing rows to be highlighted in the raw data column?
-    - looks like a javafx problem, no idea how to fix
-    - try reducing to smallest possible reproduction
+* 'local' source
+    - https://github.com/ogri-la/strongbox/issues/355
+    - investigate and make a decision
 
-* tooltip on WoW column with patch name
+* 'update check only'
+    - https://github.com/ogri-la/strongbox/issues/356
+    - investigate an make a decision
 
 * github, updated dates are are using '+00:00' instead of 'Z'
-
-* bug, BigWigs_Classic from Github cannot be installed when 'retail strict' is set
-    - it can be installed from wowi fine
-* create a parser for that shit markup that is preventing reconcilation
-* manually select the primary addon in a group of addons to prevent synthetic titles
-* finer grained control over grouping of addons
-* gui, better copying from the interface, especially the log box
 
 * prompt user when installing an addon will create mutual dependencies
     - for example:
@@ -48,7 +44,7 @@ see CHANGELOG.md for a more formal list of changes by release
 * ctrl-f5 should re-load addons from the addon dir as well
     - currently it just wipes out the http cache
 
-* trade skill master string-converter changed directory names between 2.0.7 and 2.1.0
+* bug, trade skill master string-converter changed directory names between 2.0.7 and 2.1.0
     - see also Combuctor 9.1.3 vs Combuctor 8.1.1 with 'BagBrother' in old addons
         - BagBrother was removed but also got 
             00:35:37.982 [info] [BagBrother] downloading 'Combuctor' version '8.1.1'
@@ -61,16 +57,30 @@ see CHANGELOG.md for a more formal list of changes by release
         find 'combuctor' and install from wowi (8.1.1)
         get weird orphaned BagBrother addon
 
+## todo bucket (no particular order)
+
+* zip, switch to apache commons compress for decompressing
+    - https://commons.apache.org/proper/commons-compress/
+    - .tar.gz and 7z support would be interesting
+    - rar should just die already
+    - this would fix a major showstopper in porting to windows
+    - 2022-05-29: returned to bucket, gazumped by installing addon from file.
+
+* bug, addon detail, highlighted installed version is causing rows to be highlighted in the raw data column?
+    - looks like a javafx problem, no idea how to fix
+    - try reducing to smallest possible reproduction
+
+* create a parser for that shit markup that is preventing reconcilation
+* manually select the primary addon in a group of addons to prevent synthetic titles
+* finer grained control over grouping of addons
+* gui, better copying from the interface, especially the log box
+
 * clean up this confusion between 'install-dir' and 'addon-dir'
     - install-dir is where addons are installed
     - addon-dir is either where addons are installed or a specific addon's directory
         - i.e., ambiguous
 
-* catalogue, descriptions for wowinterface addons
 * catalogue, download counts for github addons
-* wowinterface, multiple game tracks
-    - investigate just what is being downloaded when a classic version of a wowi addon is downloaded
-    - see 'LagBar'
 * search, add ability to browse catalogue page by page
     - returned to bucket 2022-03-02
 
@@ -94,7 +104,7 @@ see CHANGELOG.md for a more formal list of changes by release
 * investigate better popularity metric than 'downloads'
     - if we make an effort to scrape everyday, we can generate this popularity graph ourselves
 * wowinterface, revisit the pages that are being scraped, make sure we're not missing any
-* github, questie is kinda fubar
+
 
 * github, preference to sync stars with github repo, if authenticated
 

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -46,6 +46,8 @@
 (def curseforge-cutoff-label "Feb 1st, 2022")
 
 (def releases
+  "https://wowpedia.fandom.com/wiki/Patch"
+
   {"9.2" "Shadowlands: Eternity's End"
    "9.1" "Shadowlands: Chains of Domination"
    "9" "Shadowlands"

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -44,3 +44,57 @@
    })
 
 (def curseforge-cutoff-label "Feb 1st, 2022")
+
+(def releases
+  {"9.2" "Shadowlands: Eternity's End"
+   "9.1" "Shadowlands: Chains of Domination"
+   "9" "Shadowlands"
+
+   "8.3" "Battle for Azeroth: Visions of N'Zoth"
+   "8.2" "Battle for Azeroth: Eternity's End"
+   "8.1" "Battle for Azeroth: Tides of Vengeance"
+   "8" "Battle for Azeroth"
+
+   "7.3" "Legion: Shadows of Argus"
+   "7.2" "Legion: The Tomb of Sargeras"
+   "7.1" "Legion: Return to Karazhan"
+   "7" "Legion"
+
+   "6.2" "Warlords of Draenor: Fury of Hellfire"
+   ;; "6.1" "'Garrisons Update'" ?
+   "6" "Warlords of Draenor"
+
+   "5.4" "Mists of Pandaria: Siege of Orgrimmar"
+   "5.3" "Mists of Pandaria: Escalation"
+   "5.2" "Mists of Pandaria: The Thunder King"
+   "5.1" "Mists of Pandaria: Landfall"
+   "5" "Mists of Pandaria"
+
+   "4.3" "Cataclysm: Hour of Twilight"
+   "4.2" "Cataclysm: Rage of the Firelands"
+   "4.1" "Cataclysm: Rise of the Zandalari"
+   "4" "Cataclysm"
+
+   "3.3" "Wrath of the Lich King: Fall of the Lich King"
+   "3.2" "Wrath of the Lich King: Call of the Crusade"
+   "3.1" "Wrath of the Lich King: Secrets of Ulduar"
+   "3" "Wrath of the Lich King"
+
+   "2.4" "The Burning Crusade: Fury of the Sunwell"
+   "2.3" "The Burning Crusade: The Gods of Zul'Aman"
+   ;; "2.2" "'Voice Chat!'" ?
+   "2.1" "The Burning Crusade: Black Temple"
+   "2" "The Burning Crusade"
+
+   "1.12" "World of Warcraft: Drums of War"
+   "1.11" "World of Warcraft: Shadow of the Necropolis"
+   "1.10" "World of Warcraft: Storms of Azeroth"
+   "1.9" "World of Warcraft: The Gates of Ahn'Qiraj"
+   "1.8" "World of Warcraft: Dragons of Nightmare"
+   "1.7" "World of Warcraft: Rise of the Blood God"
+   "1.6" "World of Warcraft: Assault on Blackwing Lair"
+   "1.5" "World of Warcraft: Battlegrounds"
+   "1.4" "World of Warcraft: The Call to War"
+   "1.3" "World of Warcraft: Ruins of the Dire Maul"
+   "1.2" "World of Warcraft: Mysteries of Maraudon"
+   "1" "World of Warcraft"})

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1255,14 +1255,14 @@
          :combined-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]}
          :game-version {:min-width 70 :pref-width 70 :max-width 100
                         :cell-factory {:fx/cell-type :tree-table-cell
-                                       :describe (fn [x]
+                                       :describe (fn [text]
                                                    {:graphic {:fx/type fx.ext.node/with-tooltip-props
                                                               :props {:tooltip {:fx/type :tooltip
-                                                                                :text (utils/patch-name x)
+                                                                                :text (-> text (or "") utils/patch-name (or "?"))
                                                                                 ;; the tooltip will be long and intrusive, make delay longer than typical.
                                                                                 :show-delay 400}}
                                                               :desc {:fx/type :label
-                                                                     :text x}}})}}
+                                                                     :text text}}})}}
 
          :uber-button {:min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
                        :cell-value-factory identity

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1253,7 +1253,17 @@
          :installed-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["installed-column"]}
          :available-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["available-version-column"]}
          :combined-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]}
-         :game-version {:min-width 70 :pref-width 70 :max-width 100}
+         :game-version {:min-width 70 :pref-width 70 :max-width 100
+                        :cell-factory {:fx/cell-type :tree-table-cell
+                                       :describe (fn [x]
+                                                   {:graphic {:fx/type fx.ext.node/with-tooltip-props
+                                                              :props {:tooltip {:fx/type :tooltip
+                                                                                :text (utils/patch-name x)
+                                                                                ;; the tooltip will be long and intrusive, make delay longer than typical.
+                                                                                :show-delay 400}}
+                                                              :desc {:fx/type :label
+                                                                     :text x}}})}}
+
          :uber-button {:min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
                        :cell-value-factory identity
                        :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -830,10 +830,13 @@
   (let [matching (keyfn given)]
     (vec (remove #(= (keyfn %) matching) item-list))))
 
-(defn patch-name
-  [game-version] ;; 9.2.5
+(defn-spec patch-name (s/or :ok string?, :not-found nil?)
+  "returns the 'patch' name for the given `game-version`, considering only the major and minor values.
+  if a precise match is not found, the major version is then considered.
+  if a major version is not found, nil is returned.
+  For example, 9.2.5 has no patch name, but 9.2 is 'Shadowlands: Eternity's End'"
+  [game-version string?]
   (let [[major, minor] (clojure.string/split game-version #"\.")
         major-minor (clojure.string/join "." [major minor])]
     (or (get constants/releases major-minor)
-        (get constants/releases major)
-        "???")))
+        (get constants/releases major))))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -830,3 +830,10 @@
   (let [matching (keyfn given)]
     (vec (remove #(= (keyfn %) matching) item-list))))
 
+(defn patch-name
+  [game-version] ;; 9.2.5
+  (let [[major, minor] (clojure.string/split game-version #"\.")
+        major-minor (clojure.string/join "." [major minor])]
+    (or (get constants/releases major-minor)
+        (get constants/releases major)
+        "???")))

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -539,3 +539,10 @@
       (is (= expected log-messages))
       (is (empty? @current-locks)))))
 
+(deftest patch-name
+  (let [cases [["" nil]
+               ["foo" nil]
+               ["a.b" nil]
+               ["1.2" "World of Warcraft: Mysteries of Maraudon"]]]
+    (doseq [[given expected] cases]
+      (is (= expected (utils/patch-name given))))))


### PR DESCRIPTION
- [x] review
- [x] update CHANGELOG