### PR TITLE
addons that are completely replaced are now uninstalled first.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * `ctrl-f5` now clears the http cache and then does a full refresh, including a reload of the addons from the filesystem.
     - previously it just cleared the cache and checked for updates online.
+* addons that are completely replaced by another addon are now uninstalled first rather than creating a 'mutual dependency'.
+    - I discovered that using the `Find similar` option to replace Curseforge addons was leading to addons from other hosts creating unnecessary mutual dependencies.
 
 ### Fixed
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,23 @@ see CHANGELOG.md for a more formal list of changes by release
     - currently it just wipes out the http cache
     - done
 
+* prompt user when installing an addon will create mutual dependencies
+    - for example:
+        1. user selects 'find similar' to replace a curseforge addon
+        2. user finds a wowi hosted version
+        3. user installs addon
+        4. addon *overwrites* existing version of addon, creating a messy mutual dependency between old and new
+    - when we could have
+        3. user installs addon 'NewFoo'
+        4. if it completely overwrites 'Foo', just uninstall it, don't prompt.
+        4. mutual dependency check - "'NewFoo' overwrites 'Foo', do you want to uninstall 'Foo'?"
+        5. user clicks no, mutual dependency is created
+        5. user clicks yes, 'Foo' is uninstalled, 'NewFoo' has no mutual dependencies.
+
+    - I don't really like such prompts, my eyes tend to glaze over eventually or I get confused/frustrated at how severe the problem actually is.
+        - I've gone with automaticaly uninstalling completely replaced addons with warnings
+    - done
+
 ## todo
 
 * bug, github, questie is kinda fubar
@@ -31,19 +48,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - investigate an make a decision
 
 * github, updated dates are are using '+00:00' instead of 'Z'
-
-* prompt user when installing an addon will create mutual dependencies
-    - for example:
-        1. user selects 'find similar' to replace a curseforge addon
-        2. user finds a wowi hosted version
-        3. user installs addon
-        4. addon *overwrites* existing version of addon, creating a messy mutual dependency between old and new
-    - when we could have
-        3. user installs addon 'NewFoo'
-        4. if it completely overwrites 'Foo', just uninstall it, don't prompt.
-        4. mutual dependency check - "'NewFoo' overwrites 'Foo', do you want to uninstall 'Foo'?"
-        5. user clicks no, mutual dependency is created
-        5. user clicks yes, 'Foo' is uninstalled, 'NewFoo' has no mutual dependencies.
 
 * bug, trade skill master string-converter changed directory names between 2.0.7 and 2.1.0
     - see also Combuctor 9.1.3 vs Combuctor 8.1.1 with 'BagBrother' in old addons

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -3,6 +3,7 @@
    [clojure.string :refer [lower-case starts-with?]]
    [taoensso.timbre :as timbre :refer [debug info warn error spy]]
    [clojure.spec.alpha :as s]
+   [clojure.set]
    [orchestra.core :refer [defn-spec]]
    [me.raynes.fs :as fs]
    [strongbox
@@ -189,9 +190,12 @@
           addon-dirname (str (fs/base-name addon-dir))
 
           ;; todo: this sucks. is there another way we can figure out the relationships between addons in an install-dir other than reading them *all* in?
-          all-addon-data (load-all-installed-addons install-dir game-track)]
-
-      (first (filter #(= addon-dirname (:dirname %)) all-addon-data)))))
+          all-addon-data (load-all-installed-addons install-dir game-track)
+          addon (first (filter (fn [some-addon]
+                                 (let [flattened (mapv :dirname (flatten-addon some-addon))]
+                                   (not (nil? (some #{addon-dirname} flattened)))))
+                               all-addon-data))]
+      addon)))
 
 
 ;; ---
@@ -248,6 +252,13 @@
   "installs an addon given an addon description, a place to install the addon and the addon zip file itself.
   handles suspicious looking bundles, conflicts with other addons, uninstalling previous addon version and updating nfo files."
   [addon :addon/nfo-input-minimum, install-dir ::sp/writeable-dir, downloaded-file ::sp/archive-file]
+
+  (let [nom (or (:label addon) (:name addon) (fs/base-name downloaded-file))
+        v (:version addon)]
+    (if v
+      (info (format "installing \"%s\" version \"%s\"" nom v))
+      (info (format "installing \"%s\"" nom))))
+
   (let [zipfile-entries (zip/zipfile-normal-entries downloaded-file)
         toplevel-dirs (zip/top-level-directories zipfile-entries)
         primary-dirname (determine-primary-subdir toplevel-dirs)
@@ -272,7 +283,37 @@
 
         update-nfo-files (fn []
                            ;; write the nfo files, return a list of all nfo files written
-                           (mapv update-nfo-fn toplevel-dirs))]
+                           (mapv update-nfo-fn toplevel-dirs))
+
+        ;; an addon may completely replace another addon.
+        ;; if it's a complete replacement, remove addon instead of creating a mutual dependency.
+        remove-completely-overwritten-addons
+        (fn []
+          ;; find the full addons for each 
+
+          (let [strip-trailing-slash #(utils/rtrim % "/")
+
+                ;; all of the directories this addon will create
+                dir-superset (->> toplevel-dirs
+                                  (map :path)
+                                  (map fs/base-name)
+                                  (map strip-trailing-slash)
+                                  set)
+
+                ;; we don't care which game track is used, just that addons are logically grouped.
+                all-addon-data (load-all-installed-addons install-dir :retail) ;; (:game-track addon)) ;; game-track here is problematic
+
+                removeable? (fn [some-addon]
+                              (let [dir-subset (->> some-addon
+                                                    ;;load-installed-addon
+                                                    flatten-addon
+                                                    (map :dirname)
+                                                    set)]
+                                (clojure.set/subset? dir-subset dir-superset)))]
+
+            (->> all-addon-data
+                 (filterv removeable?)
+                 (mapv (partial remove-addon install-dir)))))]
 
     (suspicious-bundle-check)
 
@@ -281,9 +322,7 @@
     (when (s/valid? :addon/toc addon)
       (remove-addon install-dir addon))
 
-    (if-let [v (:version addon)]
-      (info (format "installing \"%s\" version \"%s\"" nom v))
-      (info (format "installing \"%s\"" nom)))
+    (remove-completely-overwritten-addons)
 
     (unzip-addon)
     (update-nfo-files)))

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -195,3 +195,31 @@
       (catch Exception e
         ;; this addon failed to parse somehow. don't propagate the exception, just report it and return `nil`.
         (error e (utils/reportable-error (format "unexpected error parsing addon in directory '%s': %s" addon-dir (.getMessage e))))))))
+
+;; --
+
+(defn-spec gen-tocfile string?
+  [addon :addon/toc]
+  (let [unslug
+        (fn [string]
+          (clojure.string/join "" (map clojure.string/capitalize (clojure.string/split string #"-"))))
+
+        render-line
+        (fn [[key val]]
+          (format "## %s: %s" (unslug (name key)) val))
+
+        rename-map {:interface-version :interface
+                    :label :title
+                    :installed-version :version}
+        toc (clojure.set/rename-keys addon rename-map)
+
+        white-list [:interface :title :version :author :description
+                    :default-state :required-deps :optional-deps :saved-variables]
+        sort-order (keep-indexed vector white-list)
+        sorted-map (sort-by #(get sort-order %1) (select-keys toc white-list))
+
+        footer (str (:dirname addon) ".lua")
+        footer (str "\n" footer)]
+    (clojure.string/join "\n" (conj (mapv render-line sorted-map) footer))))
+
+

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -199,6 +199,9 @@
 ;; --
 
 (defn-spec gen-tocfile string?
+  "given `addon` toc data, generates the contents of a `.toc` file.
+  order of keys is deterministic, some keys are renamed.
+  only used during testing."
   [addon :addon/toc]
   (let [unslug
         (fn [string]

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -17,7 +17,8 @@
    [java-time :as jt]
    [java-time.format])
   (:import
-   [java.util Base64]
+   [java.lang StringBuilder]
+   [java.util Base64 Random]
    [org.ocpsoft.prettytime.units Decade]
    [org.ocpsoft.prettytime PrettyTime]))
 
@@ -634,9 +635,22 @@
   []
   (str (java.util.UUID/randomUUID)))
 
+;; `rand-str2`, Istvan
+;; - https://stackoverflow.com/questions/64034761/fast-random-string-generator-in-clojure
 (defn short-unique-id
-  []
-  (subs (unique-id) 0 8))
+  ^String
+  ([]
+   (short-unique-id 8))
+  ([^Long len]
+   (let [leftLimit 97
+         rightLimit 122
+         random (java.util.Random.)
+         stringBuilder (StringBuilder. len)
+         diff (- rightLimit leftLimit)]
+     (dotimes [_ len]
+       (let [ch (char (.intValue ^Double (+ leftLimit (* (.nextFloat ^Random random) (+ diff 1)))))]
+         (.append ^StringBuilder stringBuilder ch)))
+     (.toString ^StringBuilder stringBuilder))))
 
 (defn count-occurances
   ;; {"Foo-v1.zip" 1, "Foo-v2.zip 1, "Foo.zip" 5}

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -634,6 +634,10 @@
   []
   (str (java.util.UUID/randomUUID)))
 
+(defn short-unique-id
+  []
+  (subs (unique-id) 0 8))
+
 (defn count-occurances
   ;; {"Foo-v1.zip" 1, "Foo-v2.zip 1, "Foo.zip" 5}
   [my-list my-key]

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1740,6 +1740,7 @@
             [[addon-b] downloaded-file-b] (helper/gen-addon! fs/*cwd* {:num-dirs 1, :base-url "https://example.net" :override {1 {:i 2}}})
 
             ;; addon C is three directories, replacing A and B, grouped by 'example.com'
+            ;; any of the three sets of addon data could be used to install the addon, we'll use the third, 'addon-c3'
             [[_ _ addon-c3] downloaded-file-c] (helper/gen-addon! fs/*cwd* {:num-dirs 3, :base-url "https://example.com"})
 
             ;; after installing A, then B then C, we expect C to have cleanly replaced A and B

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1723,3 +1723,108 @@
         (is (= installed-addon-list (core/get-state :installed-addon-list)))
         (core/update-installed-addon! updated-addon)
         (is (= expected-addon-list (core/get-state :installed-addon-list)))))))
+
+;;
+
+(deftest install-addon--uninstall-fully-replaced-mutual-dependencies
+  (testing "installing an addon that completely replaces one or more addons will uninstall those addons and issue warnings rather than create mutual dependencies."
+    (with-running-app
+      (let [install-dir (helper/install-dir)
+
+            ;; install three distinct addons: A, B, C
+
+            ;; addon A is a single directory, grouped by 'example.org'
+            [[addon-a] downloaded-file-a] (helper/gen-addon! fs/*cwd* {:num-dirs 1})
+
+            ;; addon B is a single directory, grouped by 'example.net'
+            [[addon-b] downloaded-file-b] (helper/gen-addon! fs/*cwd* {:num-dirs 1, :base-url "https://example.net" :override {1 {:i 2}}})
+
+            ;; addon C is three directories, replacing A and B, grouped by 'example.com'
+            [[_ _ addon-c3] downloaded-file-c] (helper/gen-addon! fs/*cwd* {:num-dirs 3, :base-url "https://example.com"})
+
+            ;; after installing A, then B then C, we expect C to have cleanly replaced A and B
+            expected {:description "group record for the EveryAddonThree addon",
+                      :dirname "EveryAddonOne",
+                      :group-addon-count 3,
+                      :group-addons [{:description "Does what no other addon does, slightly differently.",
+                                      :dirname "EveryAddonOne",
+                                      :group-id "https://example.com/EveryAddonThree",
+                                      :installed-game-track :retail,
+                                      :installed-version "1.2.3",
+                                      :interface-version 70000,
+                                      :label "EveryAddon",
+                                      :name "everyaddon",
+                                      :primary? false,
+                                      :source "wowinterface",
+                                      :source-id "999",
+                                      :source-map-list [{:source "wowinterface",
+                                                         :source-id "999"}],
+                                      :supported-game-tracks [:retail]}
+                                     {:description "Does what no other addon does, slightly differently.",
+                                      :dirname "EveryAddonThree",
+                                      :group-id "https://example.com/EveryAddonThree",
+                                      :installed-game-track :retail,
+                                      :installed-version "1.2.3",
+                                      :interface-version 70000,
+                                      :label "EveryAddon",
+                                      :name "everyaddon",
+                                      :primary? false,
+                                      :source "wowinterface",
+                                      :source-id "999",
+                                      :source-map-list [{:source "wowinterface",
+                                                         :source-id "999"}],
+                                      :supported-game-tracks [:retail]}
+                                     {:description "Does what no other addon does, slightly differently.",
+                                      :dirname "EveryAddonTwo",
+                                      :group-id "https://example.com/EveryAddonThree",
+                                      :installed-game-track :retail,
+                                      :installed-version "1.2.3",
+                                      :interface-version 70000,
+                                      :label "EveryAddon",
+                                      :name "everyaddon",
+                                      :primary? false,
+                                      :source "wowinterface",
+                                      :source-id "999",
+                                      :source-map-list [{:source "wowinterface",
+                                                         :source-id "999"}],
+                                      :supported-game-tracks [:retail]}],
+                      :group-id "https://example.com/EveryAddonThree",
+                      :installed-game-track :retail,
+                      :installed-version "1.2.3",
+                      :interface-version 70000,
+                      :label "EveryAddonThree (group)",
+                      :name "everyaddon",
+                      :primary? false,
+                      :source "wowinterface",
+                      :source-id "999",
+                      :source-map-list [{:source "wowinterface", :source-id "999"}],
+                      :supported-game-tracks [:retail]}
+
+            expected-nfo
+            {:group-id "https://example.com/EveryAddonThree",
+             :installed-game-track :retail,
+             :installed-version "1.2.3",
+             :name "everyaddon",
+             :primary? false,
+             :source "wowinterface",
+             :source-id "999",
+             :source-map-list [{:source "wowinterface", :source-id "999"}]}]
+
+        ;; A and B can live happily side by side
+        (core/install-addon (:installable addon-a) install-dir downloaded-file-a)
+        (core/install-addon (:installable addon-b) install-dir downloaded-file-b)
+
+        ;; C wipes out both A and B
+        (core/install-addon (:installable addon-c3) install-dir downloaded-file-c)
+
+        ;; because C *completely* replaces both A and B, A and B should be uninstalled by C rather
+        ;; than overwritten and turned into mutual dependencies of C.
+        (is (= expected (addon/load-installed-addon (->> addon-a :toc :dirname (fs/file install-dir) str) (-> addon-a :nfo :game-track))))
+        (is (= expected (addon/load-installed-addon (->> addon-b :toc :dirname (fs/file install-dir) str) (-> addon-b :nfo :game-track))))
+        (is (= expected (addon/load-installed-addon (->> addon-c3 :toc :dirname (fs/file install-dir) str) (-> addon-c3 :nfo :game-track))))
+
+        ;; a mutual dependency has a list of nfo data with the bottommost nfo data being the most recent.
+        ;; in this case we expect a single map, not a list, with the A, B and C addons all using the nfo generated by installing addon-c3.
+        (is (= expected-nfo (nfo/read-nfo-file install-dir (-> addon-a :toc :dirname))))
+        (is (= expected-nfo (nfo/read-nfo-file install-dir (-> addon-b :toc :dirname))))
+        (is (= expected-nfo (nfo/read-nfo-file install-dir (-> addon-c3 :toc :dirname))))))))

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -176,6 +176,12 @@
        first))
 
 (defn gen-addon-data
+  "generates a complete set of addon data, including toc, nfo, summary, expanded (`:installable`) as well as
+  a struct that can be used to create a zipfile that includes a .toc file.
+  accepts a map with options:
+  `:num-dirs` - the number of addons to generate.
+  `:override` - a map of per-addon overrides, keyed by `i`, for example: {:override {1 {:version '5.4.3'}}}
+  `:base-url` - the hostname used to generate a unique group ID."
   [& [{:keys [num-dirs override base-url]}]]
   (let [num-dirs (or num-dirs 1)
         override (or override {})
@@ -191,6 +197,7 @@
 
         base-url (or base-url "https://example.org")
 
+        ;; generate a single addon with a single zipfile directory
         -gen-addon
         (fn [i]
           (let [override-map (get override i {})
@@ -248,7 +255,7 @@
              :nfo nfo
              :addon-summary addon-summary
              :source-updates source-updates
-             :installable (merge addon-summary source-updates)
+             :installable (merge addon-summary source-updates) ;; aka 'expanded' 
 
              ;; single dir zip file contents
              :zip-contents filename+content-list}))
@@ -265,6 +272,7 @@
     [addon-data zipfile+contents]))
 
 (defn gen-addon!
+  "just like `gen-addon`, but will write the generated zip file to the given `output-dir`, returning a pair of `(addon-data, output-dir+filename)`"
   [output-dir & [opts]]
   (let [[addon-data [output-filename zipfile-contents]] (gen-addon-data opts)
         output-path (utils/join output-dir output-filename)]


### PR DESCRIPTION
When one addon *completely* replaces one or more _unrelated_ addons, those addons to be replaced are now uninstalled (rather than overwritten) so they don't become messy mutual dependencies.

This usecase is common when:
* the 'Find similar' feature is used to find and replace an installed addon with the same addon from the catalogue but from a different host.
   * and the inverse, installing an addon from a file replacing an addon installed from the catalogue
* an addon bundle from wowinterface is installed

- [x] review
- [x] update CHANGELOG