### PR TITLE
adds test demonstrating how part of an addon can be orphaned

### DIFF
--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1848,13 +1848,13 @@
             ;; install two distinct addons: A, B
 
             ;; addon A is from curseforge, has two directories, One and Two uses "example.net" for it's group-id
-            [[addon-a1 addon-a2] downloaded-file-a] (helper/gen-addon! fs/*cwd* {:num-dirs 2, :base-url "http://example.net", :override {:source "curseforge"}})
+            [[addon-a1 addon-a2] downloaded-file-a] (helper/gen-addon! fs/*cwd* {:num-dirs 2, :base-url "https://example.net", :override {:source "curseforge"}})
 
             ;; addon B is from wowinterface, has a single directory, One, and uses "example.org" for it's group-id
             [[addon-b] downloaded-file-b] (helper/gen-addon! fs/*cwd* {:num-dirs 1, :override {2 {:i 2}}})
 
             expected-nfo-addon-a1
-            [{:group-id "http://example.net/EveryAddonOne",
+            [{:group-id "https://example.net/EveryAddonOne",
               :installed-game-track :retail,
               :installed-version "1.2.3",
               :name "everyaddon",

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -180,9 +180,9 @@
   a struct that can be used to create a zipfile that includes a .toc file.
   accepts a map with options:
   `:num-dirs` - the number of addons to generate.
-  `:override` - a map of per-addon overrides, keyed by `i`, for example: {:override {1 {:version '5.4.3'}}}
+  `:override` - a map of overrides. per-addon overrides can be keyed by `i`, for example: {:override {1 {:version '5.4.3'}}}
   `:base-url` - the hostname used to generate a unique group ID."
-  [& [{:keys [num-dirs override base-url]}]]
+  [& [{:keys [num-dirs base-url override]}]]
   (let [num-dirs (or num-dirs 1)
         override (or override {})
 
@@ -191,7 +191,7 @@
         description (get override :description "Does what no other addon does, slightly differently.")
         interface-version (get override :interface-version 70000)
 
-        source "wowinterface"
+        source (get override :source "wowinterface")
         source-id "999"
         game-track :retail
 


### PR DESCRIPTION
Not sure how to tackle this.

~I'm thinking of modifying how addons are loaded so that overwritten addons are loaded first, then for each overwritten addon, replacing it with the next one, then the next one, etc, recursively, until we have a layered representation.~

No, the problem isn't the load order, even if we're careful about how addons are loaded a decision would still need to be made to suppress (hide) the orphaned addon, because you can't know if it's important or not.