### PR TITLE
addon folder size 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* user.clj, where the repl will take you by default during development.
+* new column for installed addons "size" with the total size of the addon on disk, including any grouped addons.
+    - you can find it under `View` -> `Columns` -> `size`
+* `user.clj`, where the REPL will take you by default during development.
     - this lets me separate some development dependencies and logic from what is released.
 
 ### Changed
 
+* the 'fat' column profile includes the new 'size' column.
+    - you can find it under `View` -> `Columns` -> `fat`
 * `jlink compress=2` changed to `jlink compress=1` during the building of the linux AppImage.
     - `2` means 'zip', which interferes with the final AppImage compression.
     - this shaves off ~7MB from the final AppImage.

--- a/LICENCE.txt
+++ b/LICENCE.txt
@@ -688,3 +688,4 @@ Program grant you additional permission to convey the resulting work.
 * cljfxcss
 * clj-http-fake
 * tolitius/lasync
+* clj-commons/humanize

--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,9 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* gui, bug, sorting isn't preserved between addon dir switches
+    - for example, sorting by 'size' in one addon dir, then switching to another will see random sorting
+
 * gui, 'set-icon' is taking a long time to do it's thing.
 
 * gui, raw data, add textual versions of this data as well

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,20 @@ see CHANGELOG.md for a more formal list of changes by release
     - is the version check happening async too?
     - done
 
+* size of addon on disk
+    - I'd like to see a column with 'size on disk'
+        - "1024KiB", "1MiB", "1.04MB"
+        - done
+    - I'd like to see a total size of all addons in addon dir
+        - "1024MiB", "1GiB"
+        - see :db-stats
+    - I'd like to see size of disk and free space
+        - "2TiB of 14TiB free"
+        - nah
+    - and everything mooshed together
+        - "1GiB of addons on /dev/foo with 2TiB of 14TiB available"
+        - nah
+
 ## todo
 
 * user catalogue, what is happening now that regular, non-github, addons can be favourited?
@@ -36,21 +50,12 @@ see CHANGELOG.md for a more formal list of changes by release
 * search, a 'clear' button
     - resets favourited, search input, tags, etc
 
-* size of addon on disk
-    - I'd like to see a column with 'size on disk'
-        - "1024KiB", "1MiB", "1.04MB"
-    - I'd like to see a total size of all addons in addon dir
-        - "1024MiB", "1GiB"
-    - I'd like to see size of disk and free space
-        - "2TiB of 14TiB free"
-    - and everything mooshed together
-        - "1GiB of addons on /dev/foo with 2TiB of 14TiB available"
-
 * 'core/state :db-stats', seems like a nice idea to put more information here
     - known-hosts
     - num addons per-host
     - num addons favourited/user-catalogue
     - num addons
+    - total size of addons
     - ...?
     - a button on the opposite of the log popup button but similar that will show some overall stats
 

--- a/cloverage.clj
+++ b/cloverage.clj
@@ -2,6 +2,7 @@
   (:require
    [strongbox
     [main :as main]
+    [utils :as utils]
     [http :as http]
     [joblib :as joblib]
     [logging :as logging]
@@ -22,7 +23,8 @@
                   http/*default-pause* 1 ;; ms
                   http/*default-attempts* 1
                   ;;joblib/tick-delay joblib/*tick*
-                  catalogue/host-disabled? (constantly false)]
+                  catalogue/host-disabled? (constantly false)
+                  utils/folder-size-bytes (constantly 0)]
       (core/reset-logging!)
       (apply require (map symbol ns-list))
       {:errors (reduce + ((juxt :error :fail)

--- a/repl/strongbox/user.clj
+++ b/repl/strongbox/user.clj
@@ -34,7 +34,8 @@
                   ;;cli/install-update-these-in-parallel cli/install-update-these-serially
                   ;;core/check-for-updates core/check-for-updates-serially
                   ;; for testing purposes, no addon host is disabled
-                  catalogue/host-disabled? (constantly false)]
+                  catalogue/host-disabled? (constantly false)
+                  utils/folder-size-bytes (constantly 0)]
       (core/reset-logging!)
 
       (if ns-kw

--- a/repl/strongbox/user.clj
+++ b/repl/strongbox/user.clj
@@ -5,7 +5,7 @@
    [clojure.test]
    [clojure.tools.namespace.repl :as tn :refer [refresh]]
    [strongbox
-    [main :as main :refer [restart]]
+    [main :as main :refer [restart stop]]
     [catalogue :as catalogue]
     [http :as http]
     [core :as core]

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -120,9 +120,12 @@
                                   {:label (format "%s (group)" next-best-label)
                                    :description (format "group record for the %s addon" next-best-label)}))
 
-                         addon-str (clojure.string/join ", " (map :dirname addons))]
+                         ;; count total size in bytes, update top-level :dirsize
+                         addon (assoc addon :dirsize (apply + (map :dirsize (:group-addons addon))))
 
-                     (logging/addon-log addon :info (format "contains %s addons: %s" (count addons) addon-str))
+                         msg-str (clojure.string/join ", " (map :dirname addons))]
+
+                     (logging/addon-log addon :info (format "contains %s addons: %s" (count addons) msg-str))
                      addon)))
 
         ;; this flattens the newly grouped addons from a map into a list and joins the unknowns

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -121,7 +121,10 @@
                                    :description (format "group record for the %s addon" next-best-label)}))
 
                          ;; count total size in bytes, update top-level :dirsize
-                         addon (assoc addon :dirsize (apply + (map :dirsize (:group-addons addon))))
+                         total-grouped-size (apply + (remove nil? (map :dirsize (:group-addons addon))))
+                         addon (if (> total-grouped-size 0)
+                                 (assoc addon :dirsize total-grouped-size)
+                                 addon)
 
                          msg-str (clojure.string/join ", " (map :dirname addons))]
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -790,6 +790,7 @@
                                                              (clojure.string/join ", ")))}
    :name {:label "name" :value-fn (comp utils/no-new-lines :label)}
    :description {:label "description" :value-fn (comp utils/no-new-lines :description)}
+   :dirsize {:label "size" :value-fn :dirsize}
    :tag-list {:label "tags" :value-fn (fn [row]
                                         (when-not (empty? (:tag-list row))
                                           (str (:tag-list row))))}

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1213,7 +1213,8 @@
          :source {:min-width 130 :pref-width 135 :max-width 145
                   :cell-factory {:fx/cell-type :tree-table-cell
                                  :describe (fn [row]
-                                             {:graphic (href-to-hyperlink row)})}
+                                             (when (map? row)
+                                               {:graphic (href-to-hyperlink row)}))}
                   :cell-value-factory identity}
          :source-id {:min-width 60 :pref-width 150}
          :source-map-list {:cell-factory {:fx/cell-type :tree-table-cell
@@ -1244,10 +1245,11 @@
                                                                                                         (cli/search-add-filter :tag tag)))
                                                                                     {:tooltip (name tag)}))
                                                                           (:tag-list row))}})}}
-         :dirsize {:cell-value-factory :dirsize
+         :dirsize {:min-width 80 :pref-width 80 :cell-value-factory :dirsize
                    :cell-factory {:fx/cell-type :tree-table-cell
                                   :describe (fn [bytes]
-                                              {:text (utils/filesize (if-not bytes 0 bytes))})}}
+                                              (when (number? bytes)
+                                                {:text (utils/filesize (if-not bytes 0 bytes))}))}}
          :created-date {:min-width 90 :pref-width 110 :max-width 120
                         :cell-value-factory :created-date
                         :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1244,6 +1244,10 @@
                                                                                                         (cli/search-add-filter :tag tag)))
                                                                                     {:tooltip (name tag)}))
                                                                           (:tag-list row))}})}}
+         :dirsize {:cell-value-factory :dirsize
+                   :cell-factory {:fx/cell-type :tree-table-cell
+                                  :describe (fn [bytes]
+                                              {:text (utils/filesize (if-not bytes 0 bytes))})}}
          :created-date {:min-width 90 :pref-width 110 :max-width 120
                         :cell-value-factory :created-date
                         :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1249,7 +1249,7 @@
                    :cell-factory {:fx/cell-type :tree-table-cell
                                   :describe (fn [bytes]
                                               (when (number? bytes)
-                                                {:text (utils/filesize (if-not bytes 0 bytes))}))}}
+                                                {:text (utils/filesize bytes)}))}}
          :created-date {:min-width 90 :pref-width 110 :max-width 120
                         :cell-value-factory :created-date
                         :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -108,6 +108,7 @@
 (s/def ::ignore-flag (s/keys :req-un [::ignore?]))
 (s/def ::download-url ::url)
 (s/def ::dirname (s/and string? #(not (empty? %)))) ;; and doesn't contain any '/' characters
+(s/def ::dirsize (s/and int? #(>= % 0)))
 (s/def ::description (s/nilable string?))
 (s/def ::matched? boolean?)
 (s/def ::group-id string?)
@@ -259,7 +260,8 @@
                    ::interface-version
                    ::installed-version
                    :addon/supported-game-tracks]
-          :opt-un [;; toc file may contain addon host information but it's not guaranteed.
+          :opt-un [::dirsize ;; not present if there was an error calculating it, zero during testing.
+                   ;; toc file may contain addon host information but it's not guaranteed.
                    :addon/source
                    :addon/source-id
                    :addon/source-map-list]))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -260,7 +260,7 @@
                    ::interface-version
                    ::installed-version
                    :addon/supported-game-tracks]
-          :opt-un [::dirsize ;; not present if there was an error calculating it, zero during testing.
+          :opt-un [::dirsize ;; not present on error during calculation. zero during testing.
                    ;; toc file may contain addon host information but it's not guaranteed.
                    :addon/source
                    :addon/source-id

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -161,7 +161,7 @@
 
 ;; default set of columns
 (def default-column-list--v1 [:source :name :description :installed-version :available-version :game-version :uber-button])
-(def default-column-list--v2 [:dirsize :source :name :description :combined-version :game-version :uber-button])
+(def default-column-list--v2 [:source :name :description :combined-version :game-version :uber-button])
 (def default-column-list default-column-list--v2)
 
 (def skinny-column-list [:name :version :combined-version :game-version :uber-button])

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -161,11 +161,11 @@
 
 ;; default set of columns
 (def default-column-list--v1 [:source :name :description :installed-version :available-version :game-version :uber-button])
-(def default-column-list--v2 [:source :name :description :combined-version :game-version :uber-button])
+(def default-column-list--v2 [:dirsize :source :name :description :combined-version :game-version :uber-button])
 (def default-column-list default-column-list--v2)
 
 (def skinny-column-list [:name :version :combined-version :game-version :uber-button])
-(def fat-column-list [:browse-local :source :source-id :name :description :tag-list :created-date :updated-date :combined-version :game-version :uber-button])
+(def fat-column-list [:dirsize :browse-local :source :source-id :name :description :tag-list :created-date :updated-date :combined-version :game-version :uber-button])
 
 (def column-preset-list [[:default default-column-list]
                          [:skinny skinny-column-list]

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -80,6 +80,7 @@
     (mapv (fn [[filename-game-track filename]]
             (merge (read-toc-file (utils/join toc-dir filename))
                    {:dirname (fs/base-name addon-dir) ;; /foo/bar/baz => baz
+                    :dirsize (utils/folder-size-bytes addon-dir)
                     :-filename filename
                     :-filename-game-track filename-game-track}))
           (find-toc-files toc-dir))))
@@ -172,6 +173,10 @@
                 ;;:required-dependencies (:requireddeps keyvals)
                 }
 
+         addon (if-let [dirsize (:dirsize keyvals)]
+                 (assoc addon :dirsize dirsize)
+                 addon)
+         
          ;; prefers tukui over wowi, wowi over github. I'd like to prefer github over wowi, but github
          ;; requires API calls to interact with and these are limited unless authenticated.
          addon (merge addon

--- a/src/strongbox/toc.clj
+++ b/src/strongbox/toc.clj
@@ -176,7 +176,7 @@
          addon (if-let [dirsize (:dirsize keyvals)]
                  (assoc addon :dirsize dirsize)
                  addon)
-         
+
          ;; prefers tukui over wowi, wowi over github. I'd like to prefer github over wowi, but github
          ;; requires API calls to interact with and these are limited unless authenticated.
          addon (merge addon

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -750,11 +750,12 @@
 
 (def -with-lock-lock (Object.))
 
+(def -with-lock-wait-time 10) ;; ms
+
 (defmacro with-lock
   "executes `form` once all items in given `user-set` are available in `lock-set-atom`."
   [lock-set-atom user-set & form]
-  `(let [wait-time# 10] ;; ms
-     (loop [waited# 0]
+  `(loop [waited# 0]
 
        ;; ensure reading the atom is single threaded (locking) and that when we read it and test the result,
        ;; we update it in the same operation (dosync).
@@ -780,9 +781,9 @@
 
            ;; something else holds one or more of the desired locks! wait a duration and try again
            (do (debug "blocked!")
-               (Thread/sleep wait-time#)
-               (debug (format "recurring in %s ms, have waited %s ms" wait-time# waited#))
-               (recur (+ waited# wait-time#))))))))
+               (Thread/sleep -with-lock-wait-time)
+               (debug (format "recurring in %s ms, have waited %s ms" -with-lock-wait-time waited#))
+               (recur (+ waited# -with-lock-wait-time)))))))
 
 (defn-spec patch-name (s/or :ok string?, :not-found nil?)
   "returns the 'patch' name for the given `game-version`, considering only the major and minor values.

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -812,8 +812,7 @@
                                     (count-files root file-list)))]
     (+ (-> path fs/file .length)
        (reduce + (flatten (fs/walk count-subdirs+files path))))))
-  
-  
+
 ;; ---
 ;; copied from: https://github.com/clj-commons/humanize/blob/master/src/clj_commons/humanize.cljc
 ;; on: 2023-04-08
@@ -836,26 +835,25 @@
     ;; special case for zero
     "0"
 
-  (let [decimal-sizes  [:B, :KB, :MB, :GB, :TB,
-                        :PB, :EB, :ZB, :YB]
-        binary-sizes [:B, :KiB, :MiB, :GiB, :TiB,
-                      :PiB, :EiB, :ZiB, :YiB]
+    (let [decimal-sizes  [:B, :KB, :MB, :GB, :TB,
+                          :PB, :EB, :ZB, :YB]
+          binary-sizes [:B, :KiB, :MiB, :GiB, :TiB,
+                        :PiB, :EiB, :ZiB, :YiB]
 
-        units (if binary binary-sizes decimal-sizes)
-        base  (if binary 1024 1000)
+          units (if binary binary-sizes decimal-sizes)
+          base  (if binary 1024 1000)
 
         ;;base-pow  (int (floor (logn bytes base)))
-        base-pow  (int (Math/floor (logn bytes base)))
+          base-pow  (int (Math/floor (logn bytes base)))
         ;; if base power shouldn't be larger than biggest unit
-        base-pow  (if (< base-pow (count units))
-                    base-pow
-                    (dec (count units)))
-        suffix (name (get units base-pow))
+          base-pow  (if (< base-pow (count units))
+                      base-pow
+                      (dec (count units)))
+          suffix (name (get units base-pow))
         ;; TODO: Math/pow isn't a drop-in for `expt`:
         ;; https://github.com/clojure/math.numeric-tower/blob/97827be66f35feebc3c89ba81c546fef4adc7947/src/main/clojure/clojure/math/numeric_tower.clj#L89-L103
         ;;value (float (/ bytes (expt base base-pow)))
-        value (float (/ bytes (Math/pow base base-pow)))
-        ]
+          value (float (/ bytes (Math/pow base base-pow)))]
 
-    ;;(str (num-format format value) suffix))))
-    (str (format format-string value) suffix))))
+;;(str (num-format format value) suffix))))
+      (str (format format-string value) suffix))))

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -182,6 +182,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
+                    :dirsize 138
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300,
@@ -214,6 +215,7 @@
           expected {;; toc data
                     :name "someaddon"
                     :dirname "SomeAddon"
+                    :dirsize 390
                     :label "SomeAddon"
                     :description "asdf"
                     :interface-version 80300
@@ -255,6 +257,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
+                    :dirsize 138
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300,
@@ -279,6 +282,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
+                    :dirsize 230
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300
@@ -298,6 +302,7 @@
         expected [;; description has been modified in "-Classic" vs "-Vanilla"
                   {:description "Slightly differently does what no other addon does."
                    :dirname "EveryAddon",
+                   :dirsize 1297
                    :installed-version "1.2.3",
                    :interface-version 11307,
                    :label "EveryAddon 1.2.3",

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -182,7 +182,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
-                    :dirsize 138
+                    :dirsize 0
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300,
@@ -215,7 +215,7 @@
           expected {;; toc data
                     :name "someaddon"
                     :dirname "SomeAddon"
-                    :dirsize 390
+                    :dirsize 0
                     :label "SomeAddon"
                     :description "asdf"
                     :interface-version 80300
@@ -257,7 +257,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
-                    :dirsize 138
+                    :dirsize 0
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300,
@@ -282,7 +282,7 @@
 
           expected {:name "someaddon",
                     :dirname "SomeAddon",
-                    :dirsize 230
+                    :dirsize 0
                     :label "SomeAddon",
                     :description "asdf",
                     :interface-version 80300
@@ -302,7 +302,7 @@
         expected [;; description has been modified in "-Classic" vs "-Vanilla"
                   {:description "Slightly differently does what no other addon does."
                    :dirname "EveryAddon",
-                   :dirsize 1297
+                   :dirsize 0
                    :installed-version "1.2.3",
                    :interface-version 11307,
                    :label "EveryAddon 1.2.3",

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -446,7 +446,7 @@
           ;; a mush of the above (.nfo written during install) and the EveryAddon .toc file
           expected {:description "Does what no other addon does, slightly differently",
                     :dirname "EveryAddon",
-                    :dirsize 675
+                    :dirsize 0
                     :group-id "https://www.wowinterface.com/downloads/info25079",
                     :installed-game-track :retail,
                     :installed-version "1.2.3",
@@ -576,7 +576,7 @@
           ;; a mush of the above (.nfo written during install) and the EveryAddon .toc file
           expected {:description "Does what no other addon does, slightly differently",
                     :dirname "EveryAddon",
-                    :dirsize 638
+                    :dirsize 0
                     :group-id "https://www.tukui.org/addons.php?id=98",
                     :installed-game-track :retail,
                     :installed-version "0.960",

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -446,6 +446,7 @@
           ;; a mush of the above (.nfo written during install) and the EveryAddon .toc file
           expected {:description "Does what no other addon does, slightly differently",
                     :dirname "EveryAddon",
+                    :dirsize 675
                     :group-id "https://www.wowinterface.com/downloads/info25079",
                     :installed-game-track :retail,
                     :installed-version "1.2.3",
@@ -575,6 +576,7 @@
           ;; a mush of the above (.nfo written during install) and the EveryAddon .toc file
           expected {:description "Does what no other addon does, slightly differently",
                     :dirname "EveryAddon",
+                    :dirsize 638
                     :group-id "https://www.tukui.org/addons.php?id=98",
                     :installed-game-track :retail,
                     :installed-version "0.960",

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1351,10 +1351,10 @@
 
               expected {:description "group record for the fetched addon",
                         :dirname "EveryAddon-BundledAddon",
-                        :dirsize 616
+                        :dirsize 1296
                         :group-addons [{:description "A useful addon that everyone bundles with their own.",
                                         :dirname "EveryAddon-BundledAddon",
-                                        :dirsize 616
+                                        :dirsize 633
                                         :group-id "https://group.id/also/never/fetched",
 
                                         :ignore? true,
@@ -1400,9 +1400,11 @@
               target-idx 0
               expected-2 (-> expected
                              (dissoc :ignore?)
-                             (dissoc :dirsize)
                              (assoc :update? false)
-                             (update-in [:group-addons target-idx] dissoc :ignore?))]
+                             (update-in [:group-addons target-idx] dissoc :ignore?)
+                             ;; the ':ignore? true' information has been removed, resulting in fewer bytes
+                             (assoc :dirsize 1279)
+                             (update-in [:group-addons target-idx] assoc :dirsize 616))]
           (core/install-addon-guard addon)
           (nfo/ignore! install-dir "EveryAddon-BundledAddon")
           (core/load-all-installed-addons)
@@ -1721,7 +1723,7 @@
             ;; after installing A, then B then C, we expect C to have cleanly replaced A and B
             expected {:description "group record for the EveryAddonThree addon",
                       :dirname "EveryAddonOne",
-                      :dirsize 515
+                      :dirsize 1547
                       :group-addons [{:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonOne",
                                       :dirsize 515

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -264,6 +264,7 @@
           expected [{:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon3",
+                     :dirsize 650
                      :download-count 3,
                      :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=3",
                      :game-track :retail,
@@ -291,6 +292,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon4",
+                     :dirsize 629
                      :download-count 4,
                      :download-url "https://www.tukui.org/addons.php?download=4",
                      :game-track :retail,
@@ -318,6 +320,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon5",
+                     :dirsize 658
                      :download-count 5,
                      :download-url "https://github.com/author/addon5/releases/download/Addon5-v1.2.3/Addon5-v1.2.3.zip",
                      :game-track :classic-tbc,
@@ -408,6 +411,7 @@
           expected [{:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon3",
+                     :dirsize 651
                      :download-count 3,
                      :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=3",
                      :game-track :retail ;; addon supports retail and classic, addon dir game track is set to retail
@@ -435,6 +439,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon4",
+                     :dirsize 629
                      :download-count 4,
                      :download-url "https://www.tukui.org/addons.php?download=4",
                      :game-track :retail,
@@ -462,6 +467,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon5",
+                     :dirsize 658
                      :download-count 5,
                      :download-url "https://github.com/author/addon5/releases/download/Addon5-v1.2.3/Addon5-v1.2.3.zip",
                      :game-track :classic-tbc
@@ -1266,6 +1272,7 @@
                       ;;:version ...
                       :description "Does what no other addon does, slightly differently",
                       :dirname "EveryAddon",
+                      :dirsize 661
                       :group-id "https://group.id/never/fetched",
                       :installed-game-track :retail,
                       :installed-version "1.2.3",
@@ -1300,6 +1307,7 @@
             expected {;;:ignore? false, ;; removed rather than set to false.
                       :description "Does what no other addon does, slightly differently",
                       :dirname "EveryAddon",
+                      :dirsize 644
                       :group-id "https://group.id/never/fetched",
                       :installed-game-track :retail,
                       :installed-version "1.2.3",
@@ -1343,8 +1351,10 @@
 
               expected {:description "group record for the fetched addon",
                         :dirname "EveryAddon-BundledAddon",
+                        :dirsize 616
                         :group-addons [{:description "A useful addon that everyone bundles with their own.",
                                         :dirname "EveryAddon-BundledAddon",
+                                        :dirsize 616
                                         :group-id "https://group.id/also/never/fetched",
 
                                         :ignore? true,
@@ -1362,6 +1372,7 @@
 
                                        {:description "Does what every addon does, just better",
                                         :dirname "EveryOtherAddon",
+                                        :dirsize 663
                                         :group-id "https://group.id/also/never/fetched",
                                         :installed-game-track :retail,
                                         :installed-version "5.6.7",
@@ -1389,6 +1400,7 @@
               target-idx 0
               expected-2 (-> expected
                              (dissoc :ignore?)
+                             (dissoc :dirsize)
                              (assoc :update? false)
                              (update-in [:group-addons target-idx] dissoc :ignore?))]
           (core/install-addon-guard addon)
@@ -1421,6 +1433,7 @@
               expected {:ignore? false, ;; explicit `false` rather than removed
                         :description "Does what no other addon does, slightly differently",
                         :dirname "EveryAddon",
+                        :dirsize 722
                         :group-id "https://group.id/never/fetched",
                         :installed-game-track :retail,
                         :installed-version "1.2.3",
@@ -1708,8 +1721,10 @@
             ;; after installing A, then B then C, we expect C to have cleanly replaced A and B
             expected {:description "group record for the EveryAddonThree addon",
                       :dirname "EveryAddonOne",
+                      :dirsize 515
                       :group-addons [{:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonOne",
+                                      :dirsize 515
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",
@@ -1724,6 +1739,7 @@
                                       :supported-game-tracks [:retail]}
                                      {:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonThree",
+                                      :dirsize 517
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",
@@ -1738,6 +1754,7 @@
                                       :supported-game-tracks [:retail]}
                                      {:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonTwo",
+                                      :dirsize 515
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -264,7 +264,7 @@
           expected [{:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon3",
-                     :dirsize 650
+                     :dirsize 0
                      :download-count 3,
                      :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=3",
                      :game-track :retail,
@@ -292,7 +292,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon4",
-                     :dirsize 629
+                     :dirsize 0
                      :download-count 4,
                      :download-url "https://www.tukui.org/addons.php?download=4",
                      :game-track :retail,
@@ -320,7 +320,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon5",
-                     :dirsize 658
+                     :dirsize 0
                      :download-count 5,
                      :download-url "https://github.com/author/addon5/releases/download/Addon5-v1.2.3/Addon5-v1.2.3.zip",
                      :game-track :classic-tbc,
@@ -411,7 +411,7 @@
           expected [{:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon3",
-                     :dirsize 651
+                     :dirsize 0
                      :download-count 3,
                      :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=3",
                      :game-track :retail ;; addon supports retail and classic, addon dir game track is set to retail
@@ -439,7 +439,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon4",
-                     :dirsize 629
+                     :dirsize 0
                      :download-count 4,
                      :download-url "https://www.tukui.org/addons.php?download=4",
                      :game-track :retail,
@@ -467,7 +467,7 @@
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
                      :dirname "Addon5",
-                     :dirsize 658
+                     :dirsize 0
                      :download-count 5,
                      :download-url "https://github.com/author/addon5/releases/download/Addon5-v1.2.3/Addon5-v1.2.3.zip",
                      :game-track :classic-tbc
@@ -1272,7 +1272,7 @@
                       ;;:version ...
                       :description "Does what no other addon does, slightly differently",
                       :dirname "EveryAddon",
-                      :dirsize 661
+                      :dirsize 0
                       :group-id "https://group.id/never/fetched",
                       :installed-game-track :retail,
                       :installed-version "1.2.3",
@@ -1307,7 +1307,7 @@
             expected {;;:ignore? false, ;; removed rather than set to false.
                       :description "Does what no other addon does, slightly differently",
                       :dirname "EveryAddon",
-                      :dirsize 644
+                      :dirsize 0
                       :group-id "https://group.id/never/fetched",
                       :installed-game-track :retail,
                       :installed-version "1.2.3",
@@ -1351,10 +1351,10 @@
 
               expected {:description "group record for the fetched addon",
                         :dirname "EveryAddon-BundledAddon",
-                        :dirsize 1296
+                        :dirsize 0
                         :group-addons [{:description "A useful addon that everyone bundles with their own.",
                                         :dirname "EveryAddon-BundledAddon",
-                                        :dirsize 633
+                                        :dirsize 0
                                         :group-id "https://group.id/also/never/fetched",
 
                                         :ignore? true,
@@ -1372,7 +1372,7 @@
 
                                        {:description "Does what every addon does, just better",
                                         :dirname "EveryOtherAddon",
-                                        :dirsize 663
+                                        :dirsize 0
                                         :group-id "https://group.id/also/never/fetched",
                                         :installed-game-track :retail,
                                         :installed-version "5.6.7",
@@ -1401,10 +1401,7 @@
               expected-2 (-> expected
                              (dissoc :ignore?)
                              (assoc :update? false)
-                             (update-in [:group-addons target-idx] dissoc :ignore?)
-                             ;; the ':ignore? true' information has been removed, resulting in fewer bytes
-                             (assoc :dirsize 1279)
-                             (update-in [:group-addons target-idx] assoc :dirsize 616))]
+                             (update-in [:group-addons target-idx] dissoc :ignore?))]
           (core/install-addon-guard addon)
           (nfo/ignore! install-dir "EveryAddon-BundledAddon")
           (core/load-all-installed-addons)
@@ -1435,7 +1432,7 @@
               expected {:ignore? false, ;; explicit `false` rather than removed
                         :description "Does what no other addon does, slightly differently",
                         :dirname "EveryAddon",
-                        :dirsize 722
+                        :dirsize 0
                         :group-id "https://group.id/never/fetched",
                         :installed-game-track :retail,
                         :installed-version "1.2.3",
@@ -1723,10 +1720,10 @@
             ;; after installing A, then B then C, we expect C to have cleanly replaced A and B
             expected {:description "group record for the EveryAddonThree addon",
                       :dirname "EveryAddonOne",
-                      :dirsize 1547
+                      :dirsize 0
                       :group-addons [{:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonOne",
-                                      :dirsize 515
+                                      :dirsize 0
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",
@@ -1741,7 +1738,7 @@
                                       :supported-game-tracks [:retail]}
                                      {:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonThree",
-                                      :dirsize 517
+                                      :dirsize 0
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",
@@ -1756,7 +1753,7 @@
                                       :supported-game-tracks [:retail]}
                                      {:description "Does what no other addon does, slightly differently.",
                                       :dirname "EveryAddonTwo",
-                                      :dirsize 515
+                                      :dirsize 0
                                       :group-id "https://example.com/EveryAddonThree",
                                       :installed-game-track :retail,
                                       :installed-version "1.2.3",

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -78,6 +78,7 @@
                   {:fx/type :menu-item, :text "skinny"}
                   {:fx/type :menu-item, :text "fat"}
                   jfx/separator
+                  {:fx/type :check-menu-item, :text "size", :selected false}
                   {:fx/type :check-menu-item, :text "browse", :selected false}
                   {:fx/type :check-menu-item, :text "source", :selected true}
                   {:fx/type :check-menu-item, :text "ID", :selected true}

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -87,7 +87,7 @@ SomeAddon.lua")
           toc-file-path (join addon-path "SomeAddon.toc")
           expected [{:name "addon-name"
                      :dirname "SomeAddon"
-                     :dirsize 660
+                     :dirsize 0
                      :label "Addon Name"
                      :description "Description of the addon here"
                      :interface-version 80205

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -87,6 +87,7 @@ SomeAddon.lua")
           toc-file-path (join addon-path "SomeAddon.toc")
           expected [{:name "addon-name"
                      :dirname "SomeAddon"
+                     :dirsize 660
                      :label "Addon Name"
                      :description "Description of the addon here"
                      :interface-version 80205

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -564,3 +564,22 @@
     (doseq [[given expected] cases]
       (is (= expected (utils/patch-name given))))))
 
+(deftest filesize
+  (let [cases [[0 "0"] ;; special case
+               [1 "1.0B"]
+               [1000 "1.0KB"]
+               [1024 "1.0KB"]
+               [10000 "10.0KB"]
+               [100000 "100.0KB"]
+               [1000000 "1.0MB"]
+               [1500000 "1.5MB"]
+
+               [-1 "-1.0B"]
+
+               [nil ""]
+               ["foo" ""]
+               [:foo ""]
+               [{:foo "bar"} ""]]]
+
+    (doseq [[given expected] cases]
+      (is (= expected (utils/filesize given))))))

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -534,7 +534,7 @@
                         :debug
                         (let [fn1-ref (fn1)
                               ;; ensure fn1 is always executed first. it will always finish last.
-                              _ (Thread/sleep 7)
+                              _ (Thread/sleep 5)
                               fn2-ref (fn2)]
                           @fn1-ref
                           @fn2-ref))


### PR DESCRIPTION
- [x] grouped addons should have :dirsize that is the sum of the :dirsize of it's components
- [x] is the 'size' column position good? on the other side of 'browse local' perhaps
- [x] should an ignored addon be included in :dirsize calculations? I think it should
- [x] 'size' should be present in 'fat' profile
- [x] review
- [x] update CHANGELOG