### PR TITLE
user-catalogue, adds star button to installed addons tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* new column for installed addons "starred" that will add an installed addon to the 'user-catalogue'.
+    - star button disabled when addon is being ignored or isn't matched against the catalogue.
 * new column for installed addons "size" with the total size of the addon on disk, including any grouped addons.
     - you can find it under `View` -> `Columns` -> `size`
 * `user.clj`, where the REPL will take you by default during development.
@@ -15,7 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* the 'fat' column profile includes the new 'size' column.
+* menu labels for the installed addons table columns have been tweaked (see `View` -> `Columns`)
+    - "installed" is now "installed version"
+    - "available" is now "available version"
+    - "version" is now "installed+available version"
+    - "WoW" is now "game version (WoW)"
+* the 'fat' column profile now uses the "installed" and "available" columns rather than the combined "version" column.
+* the 'fat' column profile includes the new 'starred' and 'size' columns.
     - you can find it under `View` -> `Columns` -> `fat`
 * `jlink compress=2` changed to `jlink compress=1` during the building of the linux AppImage.
     - `2` means 'zip', which interferes with the final AppImage compression.

--- a/TODO.md
+++ b/TODO.md
@@ -64,6 +64,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * gui, raw data, 'key' column too small for 'supported-game-tracks'
 
+* update screenshots
+
 ## todo bucket (no particular order)
 
 * gui, bug, sorting isn't preserved between addon dir switches

--- a/TODO.md
+++ b/TODO.md
@@ -24,6 +24,10 @@ see CHANGELOG.md for a more formal list of changes by release
         - "1GiB of addons on /dev/foo with 2TiB of 14TiB available"
         - nah
 
+* user catalogue, add a 'add to user-catalogue' option to make an addon always available despite selected catalogue
+    - done, via favouriting, but! it's not available on the installed addon pane page
+    - done
+
 ## todo
 
 * user catalogue, what is happening now that regular, non-github, addons can be favourited?
@@ -43,9 +47,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * user catalogue, refreshing may guarantee exceeding github limit.
     - if we know this, add a warning? refuse?
-
-* user catalogue, add a 'add to user-catalogue' option to make an addon always available despite selected catalogue
-    - done, via favouriting, but! it's not available on the installed addon pane page
 
 * search, a 'clear' button
     - resets favourited, search input, tags, etc

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -833,7 +833,8 @@
     (if-let [catalogue-addon (sp/valid-or-nil :addon/summary (installed-addon-to-addon-summary addon))]
       (add-summary-to-user-catalogue catalogue-addon)
       ;; todo: not a helpful error message
-      (error "cannot add non-catalogue addon to user-catalogue.")))
+      (logging/with-addon addon
+        (error "cannot add non-catalogue addon to user-catalogue."))))
   nil)
 
 (defn-spec remove-summary-from-user-catalogue nil?

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -818,6 +818,8 @@
   (core/write-user-catalogue!))
 
 (defn-spec add-addon-to-user-catalogue nil?
+  "given an `addon` with only a `:source` and `:source-id`, find it in the catalogue and add it to the user-catalogue.
+  fails if addon cannot be found in catalogue."
   [addon map?]
   (logging/with-addon addon
     (if-not (s/valid? :addon/source-map addon)

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -774,51 +774,6 @@
     :else (or (:version row)
               (:installed-version row))))
 
-;; todo: do we really need this separate to jfx/gui-column-map ?
-(def column-map
-  "common column names mapped to labels and value-generating functions.
-  jfx.clj takes this and merges/augments it with jfx-specific stuff."
-  {:browse-local {:label "browse" :value-fn :addon-dir}
-   :source {:label "source" :value-fn :source}
-   :source-id {:label "ID" :value-fn :source-id}
-   :source-map-list {:label "other sources" :value-fn (fn [row]
-                                                        (->> row
-                                                             :source-map-list
-                                                             (map :source)
-                                                             (remove #(= % (:source row)))
-                                                             utils/nilable
-                                                             (clojure.string/join ", ")))}
-   :name {:label "name" :value-fn (comp utils/no-new-lines :label)}
-   :description {:label "description" :value-fn (comp utils/no-new-lines :description)}
-   :dirsize {:label "size" :value-fn :dirsize}
-   :tag-list {:label "tags" :value-fn (fn [row]
-                                        (when-not (empty? (:tag-list row))
-                                          (str (:tag-list row))))}
-   :updated-date {:label "updated" :value-fn (comp utils/format-dt :updated-date)}
-   :created-date {:label "created" :value-fn (comp utils/format-dt :created-date)}
-   :installed-version {:label "installed" :value-fn :installed-version}
-   :available-version {:label "available" :value-fn available-versions-v1}
-   :combined-version {:label "version" :value-fn available-versions-v2}
-   :game-version {:label "WoW"
-                  :value-fn (fn [row]
-                              (some-> row :interface-version str utils/interface-version-to-game-version))}
-
-   :uber-button {:label nil ;; the gui will use the column-id (`:uber-button`) for the column menu when label is `nil`
-                 :value-fn (fn [row]
-                             (let [queue (core/get-state :job-queue)
-                                   job-id (joblib/addon-id row)]
-                               (if (and (core/unsteady? (:name row))
-                                        (joblib/has-job? queue job-id))
-                                 ;; parallel job in progress, show a ticker.
-                                 "*"
-                                 (cond
-                                   (:ignore? row) (:ignored constants/glyph-map)
-                                   (:pinned-version row) (:pinned constants/glyph-map)
-                                   (core/unsteady? (:name row)) (:unsteady constants/glyph-map)
-                                   (addon-has-errors? row) (:errors constants/glyph-map)
-                                   (addon-has-warnings? row) (:warnings constants/glyph-map)
-                                   :else (:tick constants/glyph-map)))))}})
-
 (defn-spec toggle-ui-column nil?
   "toggles the display of the given `column-id` in the user preferences."
   [column-id keyword?, selected? boolean?]

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -817,6 +817,25 @@
   (core/add-user-addon! addon-summary)
   (core/write-user-catalogue!))
 
+(defn-spec installed-addon-to-addon-summary (s/nilable :addon/summary)
+  [addon :addon/source-map]
+
+  ;; if-let ...
+  (first
+   (core/db-addon-by-source-and-source-id
+    (core/get-state :db) (:source addon) (:source-id addon)))
+
+  ;; else ... try a dry-run install? gussy something up?
+  )
+(defn-spec add-addon-to-user-catalogue nil?
+  [addon map?] ;;:addon/source-map]
+  (when (s/valid? :addon/source-map addon)
+    (if-let [catalogue-addon (sp/valid-or-nil :addon/summary (installed-addon-to-addon-summary addon))]
+      (add-summary-to-user-catalogue catalogue-addon)
+      ;; todo: not a helpful error message
+      (error "cannot add non-catalogue addon to user-catalogue.")))
+  nil)
+
 (defn-spec remove-summary-from-user-catalogue nil?
   "removes an `addon-summary` (catalogue entry) from the user-catalogue, but only if it's present."
   [addon-summary :addon/summary]

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -817,24 +817,17 @@
   (core/add-user-addon! addon-summary)
   (core/write-user-catalogue!))
 
-(defn-spec installed-addon-to-addon-summary (s/nilable :addon/summary)
-  [addon :addon/source-map]
-
-  ;; if-let ...
-  (first
-   (core/db-addon-by-source-and-source-id
-    (core/get-state :db) (:source addon) (:source-id addon)))
-
-  ;; else ... try a dry-run install? gussy something up?
-  )
 (defn-spec add-addon-to-user-catalogue nil?
-  [addon map?] ;;:addon/source-map]
-  (when (s/valid? :addon/source-map addon)
-    (if-let [catalogue-addon (sp/valid-or-nil :addon/summary (installed-addon-to-addon-summary addon))]
-      (add-summary-to-user-catalogue catalogue-addon)
-      ;; todo: not a helpful error message
-      (logging/with-addon addon
-        (error "cannot add non-catalogue addon to user-catalogue."))))
+  [addon map?]
+  (logging/with-addon addon
+    (if-not (s/valid? :addon/source-map addon)
+      (error "failed to star addon, it is missing some basic information ('source' and 'source-id').")
+      (let [catalogue-addon (first
+                             (core/db-addon-by-source-and-source-id
+                              (core/get-state :db) (:source addon) (:source-id addon)))]
+        (if-not (s/valid? :addon/summary catalogue-addon)
+          (error "failed to star addon, it isn't matched to the catalogue yet.")
+          (add-summary-to-user-catalogue catalogue-addon)))))
   nil)
 
 (defn-spec remove-summary-from-user-catalogue nil?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -838,6 +838,13 @@
       (or (-find-first-in-db db installed-addon match-on-list)
           installed-addon))))
 
+(defn-spec db-addon-by-source-and-source-id :addon/summary-list
+  "returns a list of addon summaries from `db` whose source and name match (exactly) the given `source` and `name`"
+  [db :addon/summary-list, source :addon/source, source-id :addon/source-id]
+  (let [xf (filter #(and (= source (:source %))
+                         (= source-id (:source-id %))))]
+    (into [] xf db)))
+
 (defn-spec db-addon-by-source-and-name :addon/summary-list
   "returns a list of addon summaries from `db` whose source and name match (exactly) the given `source` and `name`"
   [db :addon/summary-list, source :addon/source, name ::sp/name]

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -839,21 +839,21 @@
           installed-addon))))
 
 (defn-spec db-addon-by-source-and-source-id :addon/summary-list
-  "returns a list of addon summaries from `db` whose source and name match (exactly) the given `source` and `name`"
+  "returns a list of addon summaries from `db` whose source and source-id exactly match the given `source` and `source-id`."
   [db :addon/summary-list, source :addon/source, source-id :addon/source-id]
   (let [xf (filter #(and (= source (:source %))
                          (= source-id (:source-id %))))]
     (into [] xf db)))
 
 (defn-spec db-addon-by-source-and-name :addon/summary-list
-  "returns a list of addon summaries from `db` whose source and name match (exactly) the given `source` and `name`"
+  "returns a list of addon summaries from `db` whose source and name exactly match the given `source` and `name`."
   [db :addon/summary-list, source :addon/source, name ::sp/name]
   (let [xf (filter #(and (= source (:source %))
                          (= name (:name %))))]
     (into [] xf db)))
 
 (defn-spec db-addon-by-name :addon/summary-list
-  "returns a list of addon summaries from `db` whose name matches (exactly) the given `name`"
+  "returns a list of addon summaries from `db` whose name exactly matches the given `name`."
   [db :addon/summary-list, name ::sp/name]
   (let [xf (filter #(= name (:name %)))]
     (into [] xf db)))

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1198,6 +1198,8 @@
      :text "↪ browse local files"}))
 
 (defn gui-column-map
+  "list of columns for the installed-addons-table that needs to be separately defined so a menu can be built.
+  called with no arguments, the various attached functions will probably fail."
   ([]
    (gui-column-map nil))
   ([context]
@@ -1729,8 +1731,8 @@
         user-selected-column-list (cli/sort-column-list
                                    (fx/sub-val context get-in [:app-state :cfg :preferences :ui-selected-columns]))
 
-        ;; can't be part of the column map because it's actually attached to the row.
-        ;; this is just a spacer so the arrow always has room and isn't overlapped by another column's values.
+        ;; can't be part of the column map because the arrow glyph is actually embedded in the row.
+        ;; this is just a spacer so the arrow always has a fixed amount of room and is not overlapped by other columns.
         arrow-column {:text ""
                       :fx/type :tree-table-column
                       :min-width 25 :max-width 25 :resizable false
@@ -1739,6 +1741,7 @@
         selected-columns (or user-selected-column-list sp/default-column-list)
         column-list (utils/select-vals (gui-column-map context) selected-columns)
         column-list (mapv make-tree-table-column column-list)
+        ;; the column list can be empty if the user removes all columns!
         column-list (if-not (empty? column-list) (into [arrow-column] column-list) [])
         column-list (mapv #(dissoc % :menu-label) column-list)
 

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1270,7 +1270,8 @@
                 :cell-value-factory identity
                 :cell-factory {:fx/cell-type :tree-table-cell
                                :describe (fn [installed-addon]
-                                           (if (addon/ignored? installed-addon)
+                                           (if (or (addon/ignored? installed-addon)
+                                                   (not (:matched? installed-addon)))
                                              {:text ""}
                                              (let [starred (starred? installed-addon)
                                                    f (if starred cli/remove-summary-from-user-catalogue

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2,7 +2,6 @@
   (:require
    [me.raynes.fs :as fs]
    [clojure.pprint]
-   [clojure.set]
    [clojure.java.io :as io]
    ;;[clojure.core.cache :as cache]
    [clojure.string :refer [lower-case join capitalize replace] :rename {replace str-replace}]
@@ -1198,108 +1197,144 @@
      :on-action (handler #(utils/browse-to (format "%s/%s" (core/selected-addon-dir) dirname)))
      :text "↪ browse local files"}))
 
+;; todo: integrate star column logic
 (defn gui-column-map
-  "overrides and additional column information for the GUI. see `cli/column-map`."
   [queue]
-  (let [-gui-column-map
-        {:expand-group {:label "" :min-width 25 :pref-width 25 :max-width 25 :cell-value-factory (constantly "")}
-         :browse-local {:min-width 135 :pref-width 143 :max-width 150
-                        :cell-factory {:fx/cell-type :tree-table-cell
-                                       :describe (fn [row]
-                                                   {:graphic (or (addon-fs-link (:dirname row))
-                                                                 {:fx/type :label
-                                                                  :text (get row :dirname "")})})}
-                        :cell-value-factory identity}
-         :source {:min-width 130 :pref-width 135 :max-width 145
+  {:browse-local {:text "browse"
+                  :min-width 135 :pref-width 143 :max-width 150
+                  :cell-value-factory identity
                   :cell-factory {:fx/cell-type :tree-table-cell
                                  :describe (fn [row]
-                                             (when (map? row)
-                                               {:graphic (href-to-hyperlink row)}))}
-                  :cell-value-factory identity}
-         :source-id {:min-width 60 :pref-width 150}
-         :source-map-list {:cell-factory {:fx/cell-type :tree-table-cell
-                                          :describe (fn [row]
-                                                      (let [urls (for [source-map (:source-map-list row)
-                                                                       :let [url (cli/addon-source-map-to-url row source-map)]
-                                                                       :when (and url
-                                                                                  (not (= (:source row) (:source source-map))))]
-                                                                   (href-to-hyperlink (assoc source-map :url url)))
-                                                            urls (utils/nilable (vec urls))]
-                                                        (if urls
-                                                          {:graphic {:fx/type :h-box
-                                                                     :children urls}}
-                                                          {:graphic {:fx/type :label
-                                                                     :text ""}})))}
-                           :cell-value-factory identity}
+                                             {:graphic (or (addon-fs-link (:dirname row))
+                                                           {:fx/type :label
+                                                            :text (get row :dirname "")})})}}
 
-         :name {:min-width 100 :pref-width 300}
-         :description {:min-width 150 :pref-width 450}
-         :tag-list {:min-width 200 :pref-width 300 :style-class ["tag-button-column"]
-                    :cell-value-factory identity
-                    :cell-factory {:fx/cell-type :tree-table-cell
-                                   :describe (fn [row]
-                                               {:graphic {:fx/type :h-box
-                                                          :children (mapv (fn [tag]
-                                                                            (button (name tag)
-                                                                                    (async-handler #(do (switch-tab! SEARCH-TAB)
-                                                                                                        (cli/search-add-filter :tag tag)))
-                                                                                    {:tooltip (name tag)}))
-                                                                          (:tag-list row))}})}}
-         :dirsize {:min-width 80 :pref-width 80 :cell-value-factory :dirsize
-                   :cell-factory {:fx/cell-type :tree-table-cell
-                                  :describe (fn [bytes]
-                                              (when (number? bytes)
-                                                {:text (utils/filesize bytes)}))}}
-         :created-date {:min-width 90 :pref-width 110 :max-width 120
-                        :cell-value-factory :created-date
-                        :cell-factory {:fx/cell-type :tree-table-cell
-                                       :describe (fn [dt]
-                                                   ;; for some reason I'm getting the whole row here ... (:uber button column?)!
-                                                   {:text (if-not (string? dt) "" (utils/format-dt dt))})}}
-         :updated-date {:min-width 90 :pref-width 110 :max-width 120
-                        :cell-value-factory :updated-date
-                        :cell-factory {:fx/cell-type :tree-table-cell
-                                       :describe (fn [dt]
-                                                   {:text (if-not (string? dt) "" (utils/format-dt dt))})}}
-         :installed-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["installed-column"]}
-         :available-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["available-version-column"]}
-         :combined-version {:min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]}
-         :game-version {:min-width 70 :pref-width 70 :max-width 100
-                        :cell-factory {:fx/cell-type :tree-table-cell
-                                       :describe (fn [text]
-                                                   ;; for some reason I'm getting the whole row here
-                                                   (let [text (if-not (string? text) "" text)]
-                                                     {:graphic {:fx/type fx.ext.node/with-tooltip-props
-                                                                :props {:tooltip {:fx/type :tooltip
-                                                                                  :text (-> text utils/patch-name (or "?"))
-                                                                                  ;; the tooltip will be long and intrusive, make delay longer than typical.
-                                                                                  :show-delay 400}}
-                                                                :desc {:fx/type :label
-                                                                       :style-class ["table-cell"]
-                                                                       :text text}}}))}}
+   :source {:text "source"
+            :min-width 130 :pref-width 135 :max-width 145
+            :cell-value-factory identity
+            :cell-factory {:fx/cell-type :tree-table-cell
+                           :describe (fn [row]
+                                       (when (map? row)
+                                         {:graphic (href-to-hyperlink row)}))}}
 
-         :uber-button {:min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
-                       :cell-value-factory identity
-                       :cell-factory {:fx/cell-type :tree-table-cell
-                                      :describe (fn [row]
-                                                  (if (or (not row)
-                                                          (not (map? row)))
-                                                    ;; for some reason I'm getting the contents of the :created-date column here
-                                                    {:text ""}
+   :source-id {:text "ID"
+               :min-width 60 :pref-width 150
+               :cell-value-factory :source-id}
 
-                                                    (let [job-id (joblib/addon-id row)]
-                                                      {:graphic (if (and (core/unsteady? (:name row))
-                                                                         (joblib/has-job? queue job-id))
-                                                                  (addon-progress-bar row queue job-id)
-                                                                  (uber-button row))})))}}}
+   :source-map-list {:text "other sources"
+                     :cell-value-factory identity
+                     :cell-factory {:fx/cell-type :tree-table-cell
+                                    :describe (fn [row]
+                                                (let [urls (for [source-map (:source-map-list row)
+                                                                 :let [url (cli/addon-source-map-to-url row source-map)]
+                                                                 :when (and url
+                                                                            (not (= (:source row) (:source source-map))))]
+                                                             (href-to-hyperlink (assoc source-map :url url)))
+                                                      urls (utils/nilable (vec urls))]
+                                                  (if urls
+                                                    {:graphic {:fx/type :h-box
+                                                               :children urls}}
+                                                    {:graphic {:fx/type :label
+                                                               :text ""}})))}}
 
-        ;; rename some UI column keys and then merge with the gui columns
-        merge-ui-gui-columns (fn [[key val]]
-                               [key (merge
-                                     (clojure.set/rename-keys val {:label :text, :value-fn :cell-value-factory})
-                                     (get -gui-column-map key))])
-        column-map (->> cli/column-map (map merge-ui-gui-columns) (into {}))]
-    column-map))
+   :name {:text "name"
+          :min-width 100 :pref-width 300
+          :cell-value-factory (comp utils/no-new-lines :label)}
+
+   :description {:text "description"
+                 :min-width 150 :pref-width 450
+                 :cell-value-factory (comp utils/no-new-lines :description)}
+
+   :dirsize {:text "size"
+             :min-width 80 :pref-width 80
+             :cell-value-factory :dirsize
+             :cell-factory {:fx/cell-type :tree-table-cell
+                            :describe (fn [bytes]
+                                        (when (number? bytes)
+                                          {:text (utils/filesize bytes)}))}}
+
+   :starred {:text "" :menu-label "starred"
+             :min-width 50 :pref-width 50 :max-width 50 :style-class ["invisible-button-column" "star-column"]
+             :cell-value-factory identity
+             :cell-factory {:fx/cell-type :tree-table-cell
+                            :describe (fn [addon-summary]
+                                        (let [starred false ;(starred? addon-summary)
+                                              f (if starred cli/remove-summary-from-user-catalogue cli/add-summary-to-user-catalogue)]
+                                          {:graphic (button (:star constants/glyph-map)
+                                                            (async-handler (partial f addon-summary))
+                                                            {:style-class (if starred "starred" "unstarred")})}))}}
+
+   :tag-list {:text "tags"
+              :min-width 200 :pref-width 300 :style-class ["tag-button-column"]
+              :cell-value-factory identity
+              :cell-factory {:fx/cell-type :tree-table-cell
+                             :describe (fn [row]
+                                         {:graphic {:fx/type :h-box
+                                                    :children (mapv (fn [tag]
+                                                                      (button (name tag)
+                                                                              (async-handler #(do (switch-tab! SEARCH-TAB)
+                                                                                                  (cli/search-add-filter :tag tag)))
+                                                                              {:tooltip (name tag)}))
+                                                                    (:tag-list row))}})}}
+
+   :updated-date {:text "updated"
+                  :min-width 90 :pref-width 110 :max-width 120
+                  :cell-value-factory :updated-date
+                  :cell-factory {:fx/cell-type :tree-table-cell
+                                 :describe (fn [dt]
+                                             {:text (if-not (string? dt) "" (utils/format-dt dt))})}}
+
+   :created-date {:text "created"
+                  :min-width 90 :pref-width 110 :max-width 120
+                  :cell-value-factory :created-date
+                  :cell-factory {:fx/cell-type :tree-table-cell
+                                 :describe (fn [dt]
+                                             ;; for some reason I'm getting the whole row here ... (:uber button column?)!
+                                             {:text (if-not (string? dt) "" (utils/format-dt dt))})}}
+
+   :installed-version {:text "installed"
+                       :min-width 100 :pref-width 175 :max-width 250 :style-class ["installed-column"]
+                       :cell-value-factory :installed-version}
+
+   :available-version {:text "available"
+                       :min-width 100 :pref-width 175 :max-width 250 :style-class ["available-version-column"]
+                       :cell-value-factory cli/available-versions-v1}
+
+   :combined-version {:text "version"
+                      :min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]
+                      :cell-value-factory cli/available-versions-v2}
+
+   :game-version {:text "WoW"
+                  :min-width 70 :pref-width 70 :max-width 100
+                  :cell-value-factory identity
+                  :cell-factory {:fx/cell-type :tree-table-cell
+                                 :describe (fn [row]
+                                             (let [text (some-> row :interface-version str utils/interface-version-to-game-version)
+                                                   text (if-not (string? text) "" text)]
+                                               {:graphic {:fx/type fx.ext.node/with-tooltip-props
+                                                          :props {:tooltip {:fx/type :tooltip
+                                                                            :text (-> text utils/patch-name (or "?"))
+                                                                            ;; the tooltip will be long and intrusive, make delay longer than typical.
+                                                                            :show-delay 400}}
+                                                          :desc {:fx/type :label
+                                                                 :style-class ["table-cell"]
+                                                                 :text text}}}))}}
+
+   :uber-button {:text "uber-button" ;; the gui will use the column-id (`:uber-button`) for the column menu when label is `nil`
+                 :min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
+                 :cell-value-factory identity
+                 :cell-factory {:fx/cell-type :tree-table-cell
+                                :describe (fn [row]
+                                            (if (or (not row)
+                                                    (not (map? row)))
+                                              ;; for some reason I'm getting the contents of the :created-date column here
+                                              {:text ""}
+                                              ;; else
+                                              (let [job-id (joblib/addon-id row)]
+                                                {:graphic (if (and (core/unsteady? (:name row))
+                                                                   (joblib/has-job? queue job-id))
+                                                            (addon-progress-bar row queue job-id)
+                                                            (uber-button row))})))}}})
 
 (defn-spec make-table-column map?
   "returns a description of a table column that lives within a table."
@@ -1389,14 +1424,14 @@
 (defn-spec build-column-menu ::sp/list-of-maps
   "returns a list of columns that are 'selected' if present in `selected-column-list`."
   [selected-column-list :ui/column-list]
-  (let [column-list (cli/sort-column-list (keys cli/column-map))
-        queue nil
+  (let [queue nil
         gui-column-map (gui-column-map queue)
+        column-list (cli/sort-column-list (keys gui-column-map))
         toggle-column-menu-item
         (fn [column-id]
           (let [column (column-id gui-column-map)]
             {:fx/type :check-menu-item
-             :text (or (:text column) (name column-id))
+             :text (or (:menu-label column) (:text column) (name column-id))
              :selected (utils/in? column-id selected-column-list)
              :on-action (async-event-handler #(cli/toggle-ui-column column-id (-> % .getTarget .isSelected)))}))
 
@@ -1681,13 +1716,16 @@
 
         ;; can't be part of the column map because it's actually attached to the row.
         ;; this is just a spacer so the arrow always has room and isn't overlapped by another column's values.
-        arrow-column {:fx/type :tree-table-column :cell-value-factory (constantly "")
-                      :min-width 25 :max-width 25 :resizable false}
+        arrow-column {:text ""
+                      :fx/type :tree-table-column
+                      :min-width 25 :max-width 25 :resizable false
+                      :cell-value-factory (constantly "")}
 
         selected-columns (or user-selected-column-list sp/default-column-list)
         column-list (utils/select-vals (gui-column-map queue) selected-columns)
         column-list (mapv make-tree-table-column column-list)
         column-list (if-not (empty? column-list) (into [arrow-column] column-list) [])
+        column-list (mapv #(dissoc % :menu-label) column-list)
 
         ;; wraps the list of addons in a :`tree-item` component to model the parent->child relationship.
         row-list (mapv (fn [row]

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1271,7 +1271,9 @@
                 :cell-factory {:fx/cell-type :tree-table-cell
                                :describe (fn [addon-summary]
                                            (let [starred (starred? addon-summary)
-                                                 f (if starred cli/remove-summary-from-user-catalogue cli/add-summary-to-user-catalogue)]
+                                                 f (if starred cli/remove-summary-from-user-catalogue
+                                                       ;; we're not dealing with an :addon/summary here not an :addon/installed.
+                                                       cli/add-addon-to-user-catalogue)]
                                              {:graphic (button (:star constants/glyph-map)
                                                                (async-handler (partial f addon-summary))
                                                                {:style-class (if starred "starred" "unstarred")})}))}}

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1269,14 +1269,16 @@
                               (if (starred? a) 1 0))
                 :cell-value-factory identity
                 :cell-factory {:fx/cell-type :tree-table-cell
-                               :describe (fn [addon-summary]
-                                           (let [starred (starred? addon-summary)
-                                                 f (if starred cli/remove-summary-from-user-catalogue
-                                                       ;; we're not dealing with an :addon/summary here not an :addon/installed.
-                                                       cli/add-addon-to-user-catalogue)]
-                                             {:graphic (button (:star constants/glyph-map)
-                                                               (async-handler (partial f addon-summary))
-                                                               {:style-class (if starred "starred" "unstarred")})}))}}
+                               :describe (fn [installed-addon]
+                                           (if (addon/ignored? installed-addon)
+                                             {:text ""}
+                                             (let [starred (starred? installed-addon)
+                                                   f (if starred cli/remove-summary-from-user-catalogue
+                                                         ;; we're not dealing with an :addon/summary here not an :addon/installed.
+                                                         cli/add-addon-to-user-catalogue)]
+                                               {:graphic (button (:star constants/glyph-map)
+                                                                 (async-handler (partial f installed-addon))
+                                                                 {:style-class (if starred "starred" "unstarred")})})))}}
 
       :tag-list {:text "tags"
                  :min-width 200 :pref-width 300 :style-class ["tag-button-column"]

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1270,13 +1270,14 @@
                 :cell-value-factory identity
                 :cell-factory {:fx/cell-type :tree-table-cell
                                :describe (fn [installed-addon]
-                                           (if (or (addon/ignored? installed-addon)
+                                           (if (or (not (map? installed-addon))
+                                                   (addon/ignored? installed-addon)
                                                    (not (:matched? installed-addon)))
                                              {:text ""}
                                              (let [starred (starred? installed-addon)
-                                                   f (if starred cli/remove-summary-from-user-catalogue
-                                                         ;; we're not dealing with an :addon/summary here not an :addon/installed.
-                                                         cli/add-addon-to-user-catalogue)]
+                                                   f (if starred
+                                                       cli/remove-summary-from-user-catalogue
+                                                       cli/add-addon-to-user-catalogue)]
                                                {:graphic (button (:star constants/glyph-map)
                                                                  (async-handler (partial f installed-addon))
                                                                  {:style-class (if starred "starred" "unstarred")})})))}}
@@ -1309,19 +1310,19 @@
                                                 ;; for some reason I'm getting the whole row here ... (:uber button column?)!
                                                 {:text (if-not (string? dt) "" (utils/format-dt dt))})}}
 
-      :installed-version {:text "installed"
+      :installed-version {:text "installed" :menu-label "installed version"
                           :min-width 100 :pref-width 175 :max-width 250 :style-class ["installed-column"]
                           :cell-value-factory :installed-version}
 
-      :available-version {:text "available"
+      :available-version {:text "available" :menu-label "available version"
                           :min-width 100 :pref-width 175 :max-width 250 :style-class ["available-version-column"]
                           :cell-value-factory cli/available-versions-v1}
 
-      :combined-version {:text "version"
+      :combined-version {:text "version" :menu-label "installed+available version"
                          :min-width 100 :pref-width 175 :max-width 250 :style-class ["version-column"]
                          :cell-value-factory cli/available-versions-v2}
 
-      :game-version {:text "WoW"
+      :game-version {:text "WoW" :menu-label "game version (WoW)"
                      :min-width 70 :pref-width 70 :max-width 100
                      :cell-value-factory identity
                      :cell-factory {:fx/cell-type :tree-table-cell
@@ -1337,7 +1338,7 @@
                                                                     :style-class ["table-cell"]
                                                                     :text text}}}))}}
 
-      :uber-button {:text "" :menu-label "uber-button"
+      :uber-button {:text "" :menu-label "über button"
                     :min-width 80 :pref-width 80 :max-width 120 :style-class ["invisible-button-column"]
                     :cell-value-factory identity
                     :cell-factory {:fx/cell-type :tree-table-cell

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -158,7 +158,8 @@
 ;; defined here to prevent coupling between cli.clj and config.clj (I guess?)
 
 ;; all known columns. also constitutes the column order.
-(def known-column-list [:browse-local :source :source-id :source-map-list :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
+;; arrow column/group expander always comes first
+(def known-column-list [:starred :dirsize :browse-local :source :source-id :source-map-list :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
 
 ;; default set of columns
 (def default-column-list--v1 [:source :name :description :installed-version :available-version :game-version :uber-button])

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -159,15 +159,39 @@
 
 ;; all known columns. also constitutes the column order.
 ;; arrow column/group expander always comes first
-(def known-column-list [:starred :dirsize :browse-local :source :source-id :source-map-list :name :description :tag-list :created-date :updated-date :installed-version :available-version :combined-version :game-version :uber-button])
+(def known-column-list
+  [:starred :dirsize :browse-local
+   :source :source-id :source-map-list
+   :name :description :tag-list
+   :created-date :updated-date
+   :installed-version :available-version :combined-version :game-version
+   :uber-button])
 
 ;; default set of columns
-(def default-column-list--v1 [:source :name :description :installed-version :available-version :game-version :uber-button])
-(def default-column-list--v2 [:source :name :description :combined-version :game-version :uber-button])
+(def default-column-list--v1
+  [:source
+   :name :description
+   :installed-version :available-version :game-version
+   :uber-button])
+(def default-column-list--v2
+  [:source
+   :name :description
+   :combined-version :game-version
+   :uber-button])
 (def default-column-list default-column-list--v2)
 
-(def skinny-column-list [:name :version :combined-version :game-version :uber-button])
-(def fat-column-list [:dirsize :browse-local :source :source-id :name :description :tag-list :created-date :updated-date :combined-version :game-version :uber-button])
+(def skinny-column-list
+  [:name
+   :version :combined-version :game-version
+   :uber-button])
+
+(def fat-column-list
+  [:starred :dirsize :browse-local
+   :source :source-id
+   :name :description :tag-list
+   :created-date :updated-date
+   :installed-version :available-version :game-version
+   :uber-button])
 
 (def column-preset-list [[:default default-column-list]
                          [:skinny skinny-column-list]

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -778,6 +778,25 @@
         (is (= expected (core/get-state :user-catalogue)))
         (is (= expected (catalogue/read-catalogue user-catalogue-file)))))))
 
+(deftest add-addon-to-user-catalogue
+  (testing "random addons can be added to the user catalogue, provided they can be found in the catalogue."
+    (with-running-app
+      (let [expected (catalogue/new-catalogue [helper/addon-summary])
+            given (select-keys helper/addon-summary [:source :source-id])
+            user-catalogue-file (core/paths :user-catalogue-file)
+            db [helper/addon-summary]]
+
+        (is (nil? (core/get-state :db)))
+        (is (nil? (core/get-state :user-catalogue)))
+        (is (not (fs/exists? user-catalogue-file)))
+
+        (swap! core/state assoc :db db)
+
+        (cli/add-addon-to-user-catalogue given)
+
+        (is (= expected (core/get-state :user-catalogue)))
+        (is (= expected (catalogue/read-catalogue user-catalogue-file)))))))
+
 ;; test doesn't seem to live comfortably in `core_test.clj`
 
 (deftest install-update-these-in-parallel--bad-download

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1867,3 +1867,9 @@
 
           expected [toc]]
       (is (= expected (core/db-match-installed-addon-list-with-catalogue db installed-addon-list))))))
+
+(deftest db-addon-by-source-and-source-id
+  (let [db [helper/addon-summary]
+        {:keys [source source-id]} helper/addon-summary]
+    (is (= db (core/db-addon-by-source-and-source-id db source source-id)))
+    (is (= [] (core/db-addon-by-source-and-source-id db "wowinterface" "foo")))))

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -89,11 +89,11 @@
                   {:fx/type :check-menu-item, :text "tags", :selected false}
                   {:fx/type :check-menu-item, :text "created", :selected false}
                   {:fx/type :check-menu-item, :text "updated", :selected false}
-                  {:fx/type :check-menu-item, :text "installed", :selected false}
-                  {:fx/type :check-menu-item, :text "available", :selected false}
-                  {:fx/type :check-menu-item, :text "version", :selected false}
-                  {:fx/type :check-menu-item, :text "WoW", :selected false}
-                  {:fx/type :check-menu-item, :text "uber-button", :selected false}]
+                  {:fx/type :check-menu-item, :text "installed version", :selected false}
+                  {:fx/type :check-menu-item, :text "available version", :selected false}
+                  {:fx/type :check-menu-item, :text "installed+available version", :selected false}
+                  {:fx/type :check-menu-item, :text "game version (WoW)", :selected false}
+                  {:fx/type :check-menu-item, :text "über button", :selected false}]
 
         selected-columns [:foo :bar :baz :source :source-id]
 

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -78,6 +78,7 @@
                   {:fx/type :menu-item, :text "skinny"}
                   {:fx/type :menu-item, :text "fat"}
                   jfx/separator
+                  {:fx/type :check-menu-item, :text "starred", :selected false}
                   {:fx/type :check-menu-item, :text "size", :selected false}
                   {:fx/type :check-menu-item, :text "browse", :selected false}
                   {:fx/type :check-menu-item, :text "source", :selected true}


### PR DESCRIPTION
- [x] 'star' column present on installed addons tab
- [x] addons matched against the catalogue can be starred/unstarred from the installed addons tab
- [x] addons **not** matched against the catalogue (no source or source-id) are handled gracefully (somehow)
  - try reconstructing a url and importing them?
- [x] star column is sorted correctly (bool)
- [x] hide/disable star button on ignored addons
- [x] error upon failure to star addon is recorded against the addon
- [x] search results are updated to reflect new starring outside of search results
  - for example, if I unstar an addon on the installed pane, the search results are not updated
    - looks like an unrelated error was preventing me from seeing this
- [x] star column styling is identical to that in search addons tab
- [x] do not write invalid content to user-catalogue
  - I *can't*, so how was it happening??
    - it wasn't invalid, it was an installed addon merged with a catalogue summary, so just too much data.
- [x] star column is available in 'fat' profile
- [x] review
- [x] update CHANGELOG