### PR TITLE
search, add 'clear' button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* a "clear" button to the search addons tab that removes all search filters, including search terms.
 * new column for installed addons "starred" that will add an installed addon to the 'user-catalogue'.
     - star button disabled when addon is being ignored or isn't matched against the catalogue.
 * new column for installed addons "size" with the total size of the addon on disk, including any grouped addons.
@@ -43,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* minor cosmetic fix. the buttons on the search tab are now a consistent height.
 * possible cache stampede fetching strongbox release info. A lock is now acquired to ensure checks happen sequentially.
     - it was possible for the GUI to fire off many requests to Github simultaneously, bypassing cache and overwriting each other.
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,12 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* search, a 'clear' button
+    - resets favourited, search input, tags, etc
+
+* search, buttons are slightly different sizes
+    - input star and dropdown are a few pixels shorter than the buttons on either side
+
 * user catalogue, schedule refreshes
     - ensure the user catalogue doesn't get too stale and perform an update in the background if it looks like it's very old
         - update README
@@ -76,8 +82,6 @@ see CHANGELOG.md for a more formal list of changes by release
 * user catalogue, refreshing may guarantee exceeding github limit.
     - if we know this, add a warning? refuse?
 
-* search, a 'clear' button
-    - resets favourited, search input, tags, etc
 
 * 'core/state :db-stats', seems like a nice idea to put more information here
     - known-hosts

--- a/TODO.md
+++ b/TODO.md
@@ -68,6 +68,9 @@ see CHANGELOG.md for a more formal list of changes by release
 * search, a 'clear' button
     - resets favourited, search input, tags, etc
 
+* user-catalogue
+    - switch to log window to see progress when refresh-catalogue triggered
+
 * search, buttons are slightly different sizes
     - input star and dropdown are a few pixels shorter than the buttons on either side
 

--- a/TODO.md
+++ b/TODO.md
@@ -63,16 +63,18 @@ see CHANGELOG.md for a more formal list of changes by release
                 - import it with find-addon?
     - done
 
-## todo
-
 * search, a 'clear' button
     - resets favourited, search input, tags, etc
-
-* user-catalogue
-    - switch to log window to see progress when refresh-catalogue triggered
+    - done
 
 * search, buttons are slightly different sizes
     - input star and dropdown are a few pixels shorter than the buttons on either side
+    - done
+
+## todo
+
+* user-catalogue
+    - switch to log window to see progress when refresh-catalogue triggered
 
 * user catalogue, schedule refreshes
     - ensure the user catalogue doesn't get too stale and perform an update in the background if it looks like it's very old
@@ -84,7 +86,6 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * user catalogue, refreshing may guarantee exceeding github limit.
     - if we know this, add a warning? refuse?
-
 
 * 'core/state :db-stats', seems like a nice idea to put more information here
     - known-hosts

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -222,6 +222,7 @@
   nil)
 
 (defn-spec clear-search! nil?
+  "resets the search state to defaults and jogs the search results"
   []
   (core/reset-search-state!)
   (bump-search))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -923,10 +923,22 @@
          (partition-all cap (seque 100 (filter match-fn db))))))))
 
 (defn-spec empty-search-results nil?
-  "empties app state of search results.
-  this is to clear out anything between catalogue reloads."
+  "empties app state of *search results* but not filters.
+  this handles catalogue reloads but preserves user filtering."
   []
   (swap! state update-in [:search] merge (select-keys -search-state-template [:page :results :selected-results-list]))
+  nil)
+
+(defn-spec reset-search-navigation nil?
+  "resets the search results to page 1"
+  []
+  (swap! state assoc-in [:search :page] 0)
+  nil)
+
+(defn-spec reset-search-state! nil?
+  "replaces search state with default settings."
+  []
+  (swap! state update-in [:search] merge -search-state-template)
   nil)
 
 (defn-spec db-load-user-catalogue nil?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -923,7 +923,7 @@
          (partition-all cap (seque 100 (filter match-fn db))))))))
 
 (defn-spec empty-search-results nil?
-  "empties app state of *search results* but not filters.
+  "empties app state of search *results* but not filters.
   this handles catalogue reloads but preserves user filtering."
   []
   (swap! state update-in [:search] merge (select-keys -search-state-template [:page :results :selected-results-list]))

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -516,8 +516,6 @@
                 "#search-text-field "
                 {:-fx-min-width "100px"
                  :-fx-padding ".4em .5em"
-                 ;; also works, but fx-padding also lets me squish horizontally a bit more.
-                 ;;:-fx-pref-height "2em"
                  :-fx-background-radius "0"
                  :-fx-text-fill (colour :table-font-colour)}
 
@@ -537,9 +535,7 @@
                                        :-fx-effect (str "dropshadow( gaussian , " (colour :star-starred) " , 10, 0.0 , 0 , 0 )")}}}
 
                 "#search-addon-hosts-list"
-                {;;:-fx-padding ".4em .5em"
-                 ;;:-fx-pref-height "26px"
-                 :-fx-pref-height "2em"}
+                {:-fx-pref-height "2em"}
 
                 "#search-prev-button"
                 {:-fx-min-width "80px"}

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2097,6 +2097,11 @@
                 ;; :text "random"
                 ;; :on-action (handler cli/random-search)}
 
+                {:fx/type :button
+                 :id "search-clear-button"
+                 :text "clear"
+                 :on-action donothing}
+                
                 {:fx/type :h-box
                  :id "spacer"
                  :h-box/hgrow :ALWAYS}

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2088,6 +2088,7 @@
                  :title "addon host"
                  :items known-host-list
                  :show-checked-count false
+                 :id "search-addon-hosts-list"
                  :on-checked-items-changed (fn [val]
                                              (cli/search-add-filter :source val))
                  :disable disable-host-selector?}
@@ -2100,8 +2101,19 @@
                 {:fx/type :button
                  :id "search-clear-button"
                  :text "clear"
-                 :on-action donothing}
-                
+                 :on-action (fn [_]
+                              (when-let [ccb (first (select "#search-addon-hosts-list"))]
+                                (.clearChecks (.getCheckModel ccb)))
+                              (cli/clear-search!))
+                 :disable (let [ss (dissoc search-state :results)
+                                as (dissoc core/-search-state-template :results)]
+                            (if (clojure.string/blank? (:term ss))
+                              ;; we use alternating `" "` and `nil` to 'bump' search results.
+                              ;; if we have one of those, don't consider the search term.
+                              (= (dissoc ss :term)
+                                 (dissoc as :term))
+                              (= ss as)))}
+
                 {:fx/type :h-box
                  :id "spacer"
                  :h-box/hgrow :ALWAYS}

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -510,7 +510,16 @@
 
                "#search-addons "
                {"#search-install-button"
-                {:-fx-min-width "90px"}
+                {:-fx-min-width "90px"
+                 :-fx-padding ".4em 1em"}
+
+                "#search-text-field "
+                {:-fx-min-width "100px"
+                 :-fx-padding ".4em .5em"
+                 ;; also works, but fx-padding also lets me squish horizontally a bit more.
+                 ;;:-fx-pref-height "2em"
+                 :-fx-background-radius "0"
+                 :-fx-text-fill (colour :table-font-colour)}
 
                 "#search-random-button"
                 {:-fx-min-width "80px"}
@@ -518,7 +527,7 @@
                 "#search-user-catalogue-button"
                 {:-fx-font-weight "bold"
                  :-fx-font-size "1.2em"
-                 :-fx-padding "2 7 "
+                 :-fx-padding "3 7 "
 
                  ".starred" {:-fx-text-fill (colour :star-starred)
                              ;; the yellow of the star doesn't stand out from the gray gradient behind it.
@@ -527,15 +536,16 @@
                                        :-fx-stroke-width ".2"
                                        :-fx-effect (str "dropshadow( gaussian , " (colour :star-starred) " , 10, 0.0 , 0 , 0 )")}}}
 
+                "#search-addon-hosts-list"
+                {;;:-fx-padding ".4em .5em"
+                 ;;:-fx-pref-height "26px"
+                 :-fx-pref-height "2em"}
+
                 "#search-prev-button"
                 {:-fx-min-width "80px"}
 
                 "#search-next-button"
                 {:-fx-min-width "70px"}
-
-                "#search-text-field "
-                {:-fx-min-width "100px"
-                 :-fx-text-fill (colour :table-font-colour)}
 
                 "#search-selected-tag-bar"
                 {:-fx-padding "0 0 10 10"


### PR DESCRIPTION
- [x] clear button resets: search input, stars, hosts, tags and selected page
- [x] clear button is disabled when there are no filters
- [x] search buttons all have a uniform height
- [x] review
- [x] update CHANGELOG