### PR TITLE
6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file. This change
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.1.1 - 2023-05-07
+
+### Fixed
+
+* bad or missing 'content-length' HTTP header fields are now handled without errors.
+* the "All" patch level returned by Tukui is now supported when checking the updated details of an addon.
+
 ## 6.1.0 - 2023-03-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Arch Linux users can install `strongbox` from the [AUR](https://aur.archlinux.or
 
 For other Linux users:
 
-1. download: [./releases/strongbox](https://github.com/ogri-la/strongbox/releases/download/6.1.0/strongbox)
+1. download: [./releases/strongbox](https://github.com/ogri-la/strongbox/releases/download/6.1.1/strongbox)
 2. make executable: `chmod +x strongbox`
 3. run: `./strongbox`
 
 If you're on macOS or having a problem with the binary or just prefer Java `.jar` files (requires Java 11+):
 
-1. download: [./releases/strongbox-6.1.0-standalone.jar](https://github.com/ogri-la/strongbox/releases/download/6.1.0/strongbox-6.1.0-standalone.jar)
-2. run: `java -jar strongbox-6.1.0-standalone.jar`
+1. download: [./releases/strongbox-6.1.1-standalone.jar](https://github.com/ogri-la/strongbox/releases/download/6.1.1/strongbox-6.1.1-standalone.jar)
+2. run: `java -jar strongbox-6.1.1-standalone.jar`
 
 ## Usage
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>ogri-la</groupId>
   <artifactId>strongbox</artifactId>
   <packaging>jar</packaging>
-  <version>6.1.0</version>
+  <version>6.1.1</version>
   <name>strongbox</name>
   <description>World Of Warcraft Addon Manager</description>
   <url>https://github.com/ogri-la/strongbox</url>
@@ -18,7 +18,7 @@
     <url>https://github.com/ogri-la/strongbox</url>
     <connection>scm:git:git://github.com/ogri-la/strongbox.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/ogri-la/strongbox.git</developerConnection>
-    <tag>ed0d06e07da058c8b97330a5d5b97a6e033ce9be</tag>
+    <tag>e074a679b01f592c2330058d008544707cf7f7ce</tag>
   </scm>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject ogri-la/strongbox "6.1.0"
+(defproject ogri-la/strongbox "6.1.1"
   :description "World Of Warcraft Addon Manager"
   :url "https://github.com/ogri-la/strongbox"
   :license {:name "GNU Affero General Public License (AGPL)"

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -197,7 +197,7 @@
 
                                              ;; count bytes transferred so we can update the job progress (if one exists). taken from:
                                              ;; - https://github.com/dakrone/clj-http/blob/7aa6d02ad83dff9af6217f39e517cde2ded73a25/examples/progress_download.clj
-                                             (let [length (:length resp)
+                                             (let [length  (-> resp (get-in [:headers "content-length"]) (or -1) utils/to-int)
                                                    buffer-size (* 1024 10)]
                                                (with-open [^java.io.InputStream input (:body resp)
                                                            output (clojure.java.io/output-stream partial-output-file)]

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -197,7 +197,7 @@
 
                                              ;; count bytes transferred so we can update the job progress (if one exists). taken from:
                                              ;; - https://github.com/dakrone/clj-http/blob/7aa6d02ad83dff9af6217f39e517cde2ded73a25/examples/progress_download.clj
-                                             (let [length  (-> resp (get-in [:headers "content-length"]) utils/to-int (or -1))
+                                             (let [length (-> resp (get-in [:headers "content-length"]) utils/to-int (or -1))
                                                    buffer-size (* 1024 10)]
                                                (with-open [^java.io.InputStream input (:body resp)
                                                            output (clojure.java.io/output-stream partial-output-file)]

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -197,7 +197,7 @@
 
                                              ;; count bytes transferred so we can update the job progress (if one exists). taken from:
                                              ;; - https://github.com/dakrone/clj-http/blob/7aa6d02ad83dff9af6217f39e517cde2ded73a25/examples/progress_download.clj
-                                             (let [length (-> resp (get-in [:headers "content-length"] 0) utils/to-int)
+                                             (let [length (:length resp)
                                                    buffer-size (* 1024 10)]
                                                (with-open [^java.io.InputStream input (:body resp)
                                                            output (clojure.java.io/output-stream partial-output-file)]
@@ -207,7 +207,8 @@
                                                      (let [size (.read input buffer)]
                                                        (when (pos? size)
                                                          (.write output buffer 0 size)
-                                                         (joblib/*tick* (joblib/progress length (.getByteCount counter)))
+                                                         (when (> length 0)
+                                                           (joblib/*tick* (joblib/progress length (.getByteCount counter))))
                                                          (recur))))))))
 
                                            (when streaming-response?

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -197,7 +197,7 @@
 
                                              ;; count bytes transferred so we can update the job progress (if one exists). taken from:
                                              ;; - https://github.com/dakrone/clj-http/blob/7aa6d02ad83dff9af6217f39e517cde2ded73a25/examples/progress_download.clj
-                                             (let [length  (-> resp (get-in [:headers "content-length"]) (or -1) utils/to-int)
+                                             (let [length  (-> resp (get-in [:headers "content-length"]) utils/to-int (or -1))
                                                    buffer-size (* 1024 10)]
                                                (with-open [^java.io.InputStream input (:body resp)
                                                            output (clojure.java.io/output-stream partial-output-file)]

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -57,8 +57,11 @@
 
         ti (->> addon-list (filter #(= source-id-str (:id %))) first)
 
-        interface-version (when-let [patch (:patch ti)]
-                            {:interface-version (utils/game-version-to-interface-version patch)})]
+        patch (:patch ti)
+        interface-version (cond
+                            (nil? patch) {}
+                            (= patch "All") {:interface-version (utils/game-version-to-interface-version (utils/game-track-to-latest-game-version game-track))}
+                            :else {:interface-version (utils/game-version-to-interface-version patch)})]
     (when ti
       [(merge {:download-url (:url ti)
                :version (:version ti)


### PR DESCRIPTION
- [x] http, recover from bad 'content-length' value
- [x] tukui, support 'all' patch value
- [ ] tukui, support new download urls
  - it looks like ElvUI for TBC has got a bad ID (`2` instead of `-2`) and URL somehow
    - the 'classic-tbc' catalogue entry has this url: `https://www.tukui.org/classic-wotlk-addons.php?id=2`
      - all tbc addons have wotlk urls: https://www.tukui.org/api.php?classic-tbc-addons
    - aaand downloading it gets me the bad HTTP response.
- [x] review
- [x] update CHANGELOG