### PR TITLE
more stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* 'stats' thats serves to centralise a bunch of numbers that are used internally and might be interesting to the user.
+    - see the `more stats` button in the bottom left corner.
+* Github rate limit information is now fetched as part of the stats
+    - but no more than once a minute
+    - see https://github.com/ogri-la/strongbox#user-content-github-api-authentication
 * manually refreshing the user catalogue will now switch to the `log` pane before doing so.
     - see `Catalogue -> Refresh user catalogue`.
     - the intent is to show that *something* is happening.
@@ -25,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* the main window is now always split with the bottom pane hidden by default.
+    - if can be dragged open or either of the two status bar buttons can be clicked to toggle it.
+* clicking the status bar buttons to open the bottom pane is now much quicker.
 * refreshing the user-catalogue now checks imported/starred addons against the full catalogue before checking online.
     - if it fails to find addon in catalogue, it will fall back to checking online like before.
     - the user-catalogue is ostensibly for addons without a catalogue (github, gitlab) but is now also for 'starred' addons. Now that we have a github catalogue, attempting to refresh addons from the catalogue is much faster.

--- a/TODO.md
+++ b/TODO.md
@@ -93,18 +93,11 @@ see CHANGELOG.md for a more formal list of changes by release
         - scheduled refreshes happen in background
     - done
 
-## todo
-
-* size column should be right aligned
-
 * display github requests remaining
-    - ...
+    - done
 
 * user-catalogue, don't switch to user catalogue if sub-pane is up and notice logger is showing
-    - ...
-
-* user catalogue, refreshing may guarantee exceeding github limit.
-    - if we know this, add a warning? refuse? stop?
+    - done
 
 * 'core/state :db-stats', seems like a nice idea to put more information here
     - known-hosts
@@ -114,6 +107,11 @@ see CHANGELOG.md for a more formal list of changes by release
     - total size of addons
     - ...?
     - a button on the opposite of the log popup button but similar that will show some overall stats
+    - done
+
+## todo
+
+* size column should be right aligned
 
 * update screenshots
 
@@ -125,6 +123,9 @@ see CHANGELOG.md for a more formal list of changes by release
         - ...
 
 ## todo bucket (no particular order)
+
+* user catalogue, refreshing may guarantee exceeding github limit.
+    - if we know this, add a warning? refuse? stop?
 
 * support NO_COLOR envvar, http://no-color.org
 

--- a/TODO.md
+++ b/TODO.md
@@ -83,6 +83,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* size column should be right aligned
+
 * user-catalogue
     - switch to log window to see progress when refresh-catalogue triggered
 

--- a/TODO.md
+++ b/TODO.md
@@ -85,7 +85,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - ...
 
 * user catalogue, refreshing may guarantee exceeding github limit.
-    - if we know this, add a warning? refuse?
+    - if we know this, add a warning? refuse? stop?
 
 * 'core/state :db-stats', seems like a nice idea to put more information here
     - known-hosts

--- a/TODO.md
+++ b/TODO.md
@@ -117,6 +117,13 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * update screenshots
 
+* remove tukui
+    - I'm not keeping all this logic for two addons
+    - stop catalogue addons from being merged
+        -...
+    - can the addons be mirrored/hosted on github?
+        - ...
+
 ## todo bucket (no particular order)
 
 * support NO_COLOR envvar, http://no-color.org

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -36,7 +36,8 @@
 
 (defn-spec set-sub-pane nil?
   [sub-pane keyword?]
-  (swap! core/state assoc :gui-sub-pane sub-pane))
+  (swap! core/state assoc :gui-sub-pane sub-pane)
+  nil)
 
 ;; selecting addons
 
@@ -97,8 +98,6 @@
   (core/load-all-installed-addons)
   (core/match-all-installed-addons-with-catalogue)
   (core/check-for-updates)
-  (future
-    (core/update-stats!))
   (core/save-settings!))
 
 (defn-spec set-addon-dir! nil?

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -30,12 +30,14 @@
   nil)
 
 (defn-spec set-split-pane nil?
+  "set `selected?` to `true` to split the main pane horizontally."
   [selected? boolean?]
   (swap! core/state assoc :gui-split-pane selected?)
   nil)
 
 (defn-spec set-sub-pane nil?
-  [sub-pane keyword?]
+  "sets the content of the bottom (sub) pane. either `:notice-logger` (default) or `:stats`"
+  [sub-pane :gui/sub-pane-content]
   (swap! core/state assoc :gui-sub-pane sub-pane)
   nil)
 
@@ -78,45 +80,23 @@
 
 ;; ui refreshing
 
-(defn-spec hard-refresh nil?
-  "unlike `core/refresh`, `cli/hard-refresh` clears the http cache before checking for addon updates."
-  []
-  ;; why can't we be more specific, like just the addons for the current addon-dir?
-  ;; the url used to 'expand' an addon from the catalogue isn't preserved.
-  ;; it may also change with the game track (tukui, historically) or not even exist (tukui, currently).
-  ;; a thorough inspection would be too much code.
-  ;; this also removes the etag cache. the etag db only applies to catalogues and downloaded zip files.
-  (core/delete-http-cache!)
-  (core/refresh))
-
-;; move to core.clj?
-(defn-spec half-refresh nil?
-  "like `core/refresh` but excludes reloading catalogues, focusing on re-reading installed addons,
-  matching them to the catalogue and reapplying host updates."
-  []
-  (report "refresh")
-  (core/load-all-installed-addons)
-  (core/match-all-installed-addons-with-catalogue)
-  (core/check-for-updates)
-  (core/save-settings!))
-
 (defn-spec set-addon-dir! nil?
   "adds and sets the given `addon-dir`, then reloads addons."
   [addon-dir ::sp/addon-dir]
   (core/set-addon-dir! addon-dir)
-  (half-refresh))
+  (core/half-refresh))
 
 (defn-spec set-game-track-strictness! nil?
   "changes the the 'strict' flag for the current addon directory, then reloads addons."
   [new-strictness-level ::sp/strict?]
   (core/set-game-track-strictness! new-strictness-level)
-  (half-refresh))
+  (core/half-refresh))
 
 (defn-spec remove-addon-dir! nil?
   "deletes an addon-dir, selects first available addon dir, partial refresh of application state"
   []
   (core/remove-addon-dir!) ;; the next addon dir is selected, if any
-  (half-refresh))
+  (core/half-refresh))
 
 ;; search
 
@@ -280,7 +260,7 @@
              (info (format "pinning to \"%s\"" (:installed-version addon)))
              (addon/pin! (core/selected-addon-dir) addon)))
          addon-list)
-   (half-refresh)))
+   (core/half-refresh)))
 
 (defn-spec unpin nil?
   "unpins the addons in given `addon-list` regardless of whether they are pinned or not.
@@ -729,7 +709,7 @@
   [addon :addon/toc+nfo, new-source-map :addon/source-map]
   (when-not (= (:source addon) (:source new-source-map))
     (addon/switch-source! (core/selected-addon-dir) addon new-source-map)
-    (half-refresh)))
+    (core/half-refresh)))
 
 ;;
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -81,6 +81,7 @@
   (core/delete-http-cache!)
   (core/refresh))
 
+;; move to core.clj?
 (defn-spec half-refresh nil?
   "like `core/refresh` but excludes reloading catalogues, focusing on re-reading installed addons,
   matching them to the catalogue and reapplying host updates."
@@ -89,6 +90,7 @@
   (core/load-all-installed-addons)
   (core/match-all-installed-addons-with-catalogue)
   (core/check-for-updates)
+  (core/update-stats!)
   (core/save-settings!))
 
 (defn-spec set-addon-dir! nil?

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -90,7 +90,8 @@
   (core/load-all-installed-addons)
   (core/match-all-installed-addons-with-catalogue)
   (core/check-for-updates)
-  (core/update-stats!)
+  (future
+    (core/update-stats!))
   (core/save-settings!))
 
 (defn-spec set-addon-dir! nil?

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -29,6 +29,15 @@
   (swap! core/state update-in [:gui-split-pane] not)
   nil)
 
+(defn-spec set-split-pane nil?
+  [selected? boolean?]
+  (swap! core/state assoc :gui-split-pane selected?)
+  nil)
+
+(defn-spec set-sub-pane nil?
+  [sub-pane keyword?]
+  (swap! core/state assoc :gui-sub-pane sub-pane))
+
 ;; selecting addons
 
 (defn-spec select-addons-for-search! nil?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -148,8 +148,11 @@
    ;; per-tab log levels are attached to each tab in the `:tab-list`
    :gui-log-level :info
 
-   ;; split the gui in two horizontally with the notice logger on the bottom.
+   ;; split the gui in two horizontally with the sub-pane on the bottom.
    :gui-split-pane false
+
+   ;; default widget for the sub-pane
+   :gui-sub-pane :notice-logger
 
    ;; addons in an 'unsteady' state (data being updated, addon being installed, etc)
    ;; allows a UI to watch and update the gui with progress.
@@ -1436,16 +1439,13 @@
   "summarises application state and returns a map of stats"
   [state map?]
   (let [num-addons (-> state :db count)
-        known-host-list (->> state
-                             :db
-                             (map :source)
-                             distinct
-                             sort
-                             vec)
+        known-host-list (->> state :db (map :source) distinct sort vec)
         num-addons-starred (-> state :user-catalogue-idx count)
+
         num-addons-installed (-> state :installed-addon-list count)
-        num-addons-ignored (->> state :installed-addon-list (filter addon/ignored?) count)
-        bytes-installed-addons (->> state :installed-addon-list (map :dirsize) (reduce +))
+        num-addons-installed-matched (->> state :installed-addon-list (filter :matched?) count)
+        num-addons-installed-ignored (->> state :installed-addon-list (filter addon/ignored?) count)
+        num-addons-installed-bytes (->> state :installed-addon-list (map :dirsize) (reduce +))
 
         num-addons-reducer (fn [acc addon]
                              (update acc (-> addon :source (or "no-host")) (fnil inc 0)))
@@ -1455,14 +1455,15 @@
     (merge
      {:known-host-list known-host-list
       :num-addons num-addons
+      :num-addons-starred num-addons-starred
       ;; {"wowinterface" 7261, "github" 1374, "tukui" 123, "gitlab" 6, "tukui-classic" 59, "tukui-classic-tbc" 44, "tukui-classic-wotlk" 49}
       :num-addons-per-host num-addons-per-host
       :num-addons-installed num-addons-installed
+      :num-addons-installed-matched num-addons-installed-matched
       ;; {"wowinterface" 20, nil 1, "github" 9, "tukui-classic-tbc" 2, "curseforge" 1}
       :num-addons-installed-per-host num-addons-installed-per-host
-      :num-addons-starred num-addons-starred
-      :num-addons-ignored num-addons-ignored
-      :bytes-installed-addons bytes-installed-addons
+      :num-addons-installed-ignored num-addons-installed-ignored
+      :num-addons-installed-bytes num-addons-installed-bytes
 
       :github-requests-limit nil
       :github-requests-limit-reset nil

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -17,7 +17,7 @@
   (:import
    [org.apache.commons.io.input CountingInputStream]))
 
-(def expiry-offset-hours 1) ;; hours
+(def ^:dynamic *expiry-offset-minutes* 60)
 (def ^:dynamic *cache* nil)
 (def ^:dynamic *default-pause* 1000)
 (def ^:dynamic *default-attempts* 3)
@@ -89,7 +89,7 @@
   "returns `true` if the last modification time on given file is before the expiry date of +N hours"
   [output-file]
   (when (and output-file (fs/exists? output-file))
-    (not (utils/file-older-than output-file expiry-offset-hours))))
+    (not (utils/file-older-than output-file *expiry-offset-minutes* :minutes))))
 
 (defn-spec url-to-filename ::sp/file
   "safely encode a URI to something that can live cached on the filesystem"
@@ -402,12 +402,12 @@
 ;;
 
 (defn-spec prune-cache-dir nil?
-  "deletes files in the given `cache-dir` that are older than the `expiry-offset-hours`"
+  "deletes files in the given `cache-dir` that are older than the `expiry-offset-minutes`"
   [cache-dir ::sp/extant-dir]
-  (let [expiry-date (* 2 expiry-offset-hours)]
+  (let [expiry (+ *expiry-offset-minutes* 1)]
     (doseq [cache-file (fs/list-dir cache-dir)
             :when (and (fs/file? cache-file)
-                       (utils/file-older-than (str cache-file) expiry-date))]
+                       (utils/file-older-than (str cache-file) expiry :minutes))]
       (fs/delete cache-file)
       (debug "deleted expired cache file:" cache-file))))
 

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2045,7 +2045,7 @@
   [{:keys [fx/context]}]
   (let [search-state (fx/sub-val context get-in [:app-state, :search])
         ;;known-host-list (fx/sub-val context get-in [:app-state, :db-stats :known-host-list])
-        known-host-list (core/get-state :db-stats :known-host-list)
+        known-host-list (or (core/get-state :db-stats :known-host-list) [])
         disable-host-selector? (= 1 (count known-host-list))
 
         tag-set (->> search-state :filter-by :tag)

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -136,6 +136,7 @@
                                     false))))
 
 (s/def ::zoned-dt-obj #(instance? java.time.ZonedDateTime %))
+(s/def ::local-dt-obj #(instance? java.time.LocalDateTime %))
 
 ;; javafx, cljfx, gui
 ;; no references to cljfx or javafx please!

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -146,6 +146,7 @@
 (s/def :javafx/node #(instance? javafx.scene.Node %))
 
 (s/def :gui/column-data (s/keys :opt-un [:gui/text :gui/cell-value-factory :gui/style-class]))
+(s/def :gui/sub-pane-content #{:notice-logger :stats})
 
 (s/def :addon/id (s/or :regular (s/keys :req-un [:addon/source :addon/source-id]) ;; installed addons and catalogue addons
                        :edge (s/keys :req-in [::dirname]))) ;; unmatched and ignored addons
@@ -487,3 +488,16 @@
 ;; search
 
 (s/def :search/filter-by #{:source :tag :tag-membership :user-catalogue})
+
+;; github
+
+(s/def :github/requests-used ::gte-zero)
+(s/def :github/remaining ::gte-zero)
+(s/def :github/requests-limit-reset-minutes number?)
+(s/def :github/requests-limit ::gte-zero)
+(s/def :github/token-set? boolean?)
+(s/def :github/requests-stats (s/keys :req [:github/token-set?
+                                            :github/requests-limit
+                                            :github/requests-limit-reset-minutes
+                                            :github/requests-remaining
+                                            :github/requests-used]))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -851,3 +851,10 @@
           value (float (/ bytes (Math/pow base base-pow)))]
 
       (str (format format-string value) suffix))))
+
+(defn-spec unix-time-to-java-time ::sp/local-dt-obj
+  [unix-time-seconds number?]
+  (-> unix-time-seconds
+      (* 1000)
+      java-time/instant
+      (java-time/local-date-time (jt/zone-id))))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -903,4 +903,5 @@
     (map? v) (clojure.string/join ", " (mapv (fn [[key val]]
                                                (format "%s: %s" (valifyval key) (valifyval val))) (sort-by first v)))
     (boolean? v) (-> v str clojure.string/capitalize)
+    (keyword? v) (name v)
     :else (str v)))

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :refer [starts-with? ends-with?]]
    [clojure.test :refer [deftest testing is use-fixtures]]
-   [clj-http.fake :refer [with-global-fake-routes-in-isolation]]
+   [clj-http.fake :refer [with-global-fake-routes-in-isolation with-global-fake-routes]]
    [envvar.core :refer [with-env]]
    [me.raynes.fs :as fs]
    [taoensso.timbre :as log :refer [debug info warn error spy]]

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :refer [starts-with? ends-with?]]
    [clojure.test :refer [deftest testing is use-fixtures]]
-   [clj-http.fake :refer [with-global-fake-routes-in-isolation with-global-fake-routes]]
+   [clj-http.fake :refer [with-global-fake-routes-in-isolation]]
    [envvar.core :refer [with-env]]
    [me.raynes.fs :as fs]
    [taoensso.timbre :as log :refer [debug info warn error spy]]

--- a/test/strongbox/test_helper.clj
+++ b/test/strongbox/test_helper.clj
@@ -177,7 +177,11 @@
 
                      ;; latest strongbox version
                      "https://api.github.com/repos/ogri-la/strongbox/releases/latest"
-                     {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}}]
+                     {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}
+
+                     ;; github requests remaining
+                     "https://api.github.com/rate_limit"
+                     {:get (fn [req] {:status 200 :body (utils/to-json {:resources {:core {:limit 0, :remaining 0, :reset 978307200, :used 0, :resource "core"}}})})}}]
     (try
       (debug "stopping application if it hasn't already been stopped")
       (main/stop)

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -108,8 +108,8 @@
         (try
           (fs/touch path 0) ;; created Jan 1st 1970
           (.setLastModified (fs/file path) 0) ;; modified Jan 1st 1970
-          (is (utils/file-older-than path 1))
-          (is (not (utils/file-older-than path 3)))
+          (is (utils/file-older-than path 1 :hours))
+          (is (not (utils/file-older-than path 3 :hours)))
           (finally
             (fs/delete path)))))))
 


### PR DESCRIPTION
- [x] github authenticated? num requests remaining?
- [x] replace stats in status bar at bottom
- [x] popup split pane with stats
- [x] if user-catalogue refresh manually triggered and split-pane is on ...
  - [x] don't switch to log tab
  - [x] switch to log sub-pane
- [x] keyvals from addon detail look better than these, use their formatting
  - in fact, can the two share the same widget?
- [x] review
- [x] update CHANGELOG