### PR TITLE
removes tukui support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+* Tukui support. Tukui addons are:
+    - no longer checked for updates.
+    - excluded from being imported.
+    - excluded from the user-catalogue.
+    - no longer scraped from the tukui.org API into a catalogue.
+    - no longer present in the 'full' or 'short' catalogues.
+    - excluded from search results.
+    - removed from the 'emergency' (built-in, hardcoded) catalogue (used when remote catalogues are unavailable).
+    - removed from lists of available addon hosts to switch an addon between.
+
 ## 6.1.2 - 2023-05-16
 
 * issue #402, fixed a freezing bug in the search results, introduced in 5.1.0 (2022-03-02).

--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
 # strongbox, a World of Warcraft addon manager
 
-`strongbox` is an **open source**, **[advertisement free](#recognition)** and **[privacy respecting](#privacy)** addon manager for World of Warcraft.
+`strongbox` is an **open source**, **[advertisement free](#recognition)** and **[privacy respecting](#privacy)** addon
+manager for World of Warcraft.
 
 It runs on Linux and macOS.
 
-It supports addons hosted by ~Curseforge,~ wowinterface.com, Tukui, Github and Gitlab.
+It supports addons hosted by ~Curseforge,~ wowinterface.com, ~Tukui~, Github and Gitlab.
 
 ---
 
-***Notice***: tukui.org hosted addons no longer receive updates as of 2023-06-01 except `elvui` and `tukui`.
+***Notice***: tukui.org no longer hosts addons except `elvui` and `tukui` as of 2023-06-01.
 
 Unfortunately the location of these two addons has changed as well as details around their access.
 
-I've decied to drop support for tukui.org and instead mirror the `tukui` and `elvui` releases on Github so they will be
-incorporated into the Github catalogue.
-
-In the meantime `File -> Import addon` and pasting the below URLs will install them:
-
-* https://github.com/ogri-la/tukui
-* https://github.com/ogri-la/elvui
+I've dropped support for tukui.org in **7.0.0** and instead mirror the `tukui` and `elvui` releases on Github. This
+allows them to be incorporated into the Github catalogue.
 
 ---
 
 ***Notice***: Curseforge addons no longer receive updates as of version **5.0.0**, released Feb 1st, 2022.
 
-Use the *"Source"* and *"Find similar"* actions from the addon context menu ([added **4.9.0**](https://github.com/ogri-la/strongbox/releases)) to help migrate addons away from Curseforge.
+Use the *"Source"* and *"Find similar"* actions from the addon context menu
+([added **4.9.0**](https://github.com/ogri-la/strongbox/releases)) to help migrate addons away from Curseforge.
 
 I also maintain a list of [other addon managers](https://ogri-la.github.io/wow-addon-managers/).
 
@@ -82,7 +79,7 @@ Afterwards, use the `Update all` button to update all addons with new versions a
 * [install addons from multiple sources](#install-addons-from-multiple-sources):
     - ~Curseforge~
     - wowinterface.com
-    - Tukui
+    - ~Tukui~
     - Github (using *releases*)
     - Gitlab (using *releases*)
 * [import and export lists of addons](#import-and-export-lists-of-addons)
@@ -121,9 +118,7 @@ that it's my privilege to offer this small piece back.
 
 This software interacts with the following remote hosts:
 
-* ~Overwolf/Twitch/Curseforge [Addons API](https://addons-ecs.forgesvc.net/) and its [CDN](https://edge.forgecdn.net/)~
 * [wowinterface.com](https://wowinterface.com)
-* [www.tukui.org](https://www.tukui.org/api.php)
 * [api.github.com](https://developer.github.com/v3/repos/releases)
     - to download repository and release data for addons hosted on Github
     - to download the latest `strongbox` release information
@@ -162,7 +157,8 @@ bug. *Some* of the details it contains are:
 
 ### classic and retail addon support
 
-"Classic", "Classic (The Burning Crusade)", "Classic (Wrath of the Lich King)" and "Retail" versions of WoW are all distinct addon systems.
+"Classic", "Classic (The Burning Crusade)", "Classic (Wrath of the Lich King)" and "Retail" versions of WoW are all
+distinct addon systems.
 
 Some addons support all systems in a single download, some support classic as an alternate build of the same addon, 
 some addons support classic only, some addons have been split up into multiple addons. There is a lot of variation.
@@ -196,9 +192,7 @@ Click `File` from the top menu and select `Import addon` and paste the URL of th
 
 Strongbox supports searching for addons from the following addon hosts:
 
-* ~[Curseforge](https://www.curseforge.com/wow/addons)~
 * [wowinterface.com](https://wowinterface.com/addons.php)
-* [Tukui](https://www.tukui.org)
 * [Github](https://github.com)
 
 Click the `search` tab and start typing.
@@ -238,9 +232,7 @@ Click the `Update all` button next to your addon directory.
 
 Strongbox supports installing addons from the following addon hosts:
 
-* ~[Curseforge](https://www.curseforge.com/wow/addons)~
 * [wowinterface.com](https://wowinterface.com/addons.php)
-* [Tukui](https://www.tukui.org)
 * [Github](https://www.github.com)
 * [Gitlab](https://gitlab.com)
 
@@ -327,7 +319,6 @@ Right-click an addon and select `Release`.
 
 Strongbox currently supports installing previous releases for:
 
-* ~Curseforge~
 * Github
 * Gitlab
 
@@ -408,6 +399,6 @@ Prior to `1.0.0`, `strongbox` was known as `wowman`. The [AUR package](https://a
 
 ## License
 
-Copyright © 2018-2022 Torkus
+Copyright © 2018-2023 Torkus
 
 Distributed under the GNU Affero General Public Licence, version 3 [with additional permissions](LICENCE.txt#L665)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports addons hosted by ~Curseforge,~ wowinterface.com, ~Tukui~, Github and
 
 ---
 
-***Notice***: tukui.org no longer hosts addons except `elvui` and `tukui` as of 2023-06-01.
+***Notice***: tukui.org no longer hosts addons except `elvui` and `tukui` as of **2023-06-01**.
 
 Unfortunately the location of these two addons has changed as well as details around their access.
 

--- a/TODO.md
+++ b/TODO.md
@@ -127,6 +127,12 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* expand-summary, can the game track wrangling logic be made generic rather than per-host?
+    - this would tie in with returning *all* releases from a host
+    - it would insulate host logic from selected game tracks and game track strictness
+    - it would handle pinned logic as well
+        - currently handled in catalogue
+
 * user catalogue, refreshing may guarantee exceeding github limit.
     - if we know this, add a warning? refuse? stop?
 

--- a/TODO.md
+++ b/TODO.md
@@ -112,10 +112,6 @@ see CHANGELOG.md for a more formal list of changes by release
 * size column should be right aligned
     - done
 
-## todo
-
-* update screenshots
-
 * remove tukui
     - I'm not keeping all this logic for two addons
     - stop catalogue addons from being merged into full catalogue
@@ -123,7 +119,11 @@ see CHANGELOG.md for a more formal list of changes by release
     - can the addons be mirrored/hosted on github?
         - done
     - follow curseforge removal pr
-        - ...
+        - done
+
+## todo
+
+* update screenshots
 
 ## todo bucket (no particular order)
 

--- a/TODO.md
+++ b/TODO.md
@@ -114,15 +114,15 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
-
-
 * update screenshots
 
 * remove tukui
     - I'm not keeping all this logic for two addons
-    - stop catalogue addons from being merged
-        -...
+    - stop catalogue addons from being merged into full catalogue
+        - done
     - can the addons be mirrored/hosted on github?
+        - done
+    - follow curseforge removal pr
         - ...
 
 ## todo bucket (no particular order)

--- a/TODO.md
+++ b/TODO.md
@@ -127,6 +127,10 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* search results, if there are addons from the same host (github) with the same name (tukui), disambiguate them
+    - 'tukui' in the search results shouldn't mean 'ogri-la/tukui' if 'tukui.org/tukui' is also available
+        - which it isn't, but that's not the point.
+
 * expand-summary, can the game track wrangling logic be made generic rather than per-host?
     - this would tie in with returning *all* releases from a host
     - it would insulate host logic from selected game tracks and game track strictness

--- a/cloverage.clj
+++ b/cloverage.clj
@@ -7,8 +7,7 @@
     [http :as http]
     [joblib :as joblib]
     [logging :as logging]
-    [core :as core]
-    [catalogue :as catalogue]]
+    [core :as core]]
    [clojure.test :as test]
    [cloverage.coverage :as c]))
 
@@ -24,7 +23,6 @@
                   http/*default-pause* 1 ;; ms
                   http/*default-attempts* 1
                   ;;joblib/tick-delay joblib/*tick*
-                  catalogue/host-disabled? (constantly false)
                   utils/folder-size-bytes (constantly 0)
                   constants/max-user-catalogue-age 9999]
       (core/reset-logging!)

--- a/repl/strongbox/user.clj
+++ b/repl/strongbox/user.clj
@@ -5,6 +5,7 @@
    [clojure.test]
    [clojure.tools.namespace.repl :as tn :refer [refresh]]
    [strongbox
+    [addon :as addon]
     [constants :as constants]
     [main :as main :refer [restart stop]]
     [catalogue :as catalogue]
@@ -35,7 +36,6 @@
                   ;;cli/install-update-these-in-parallel cli/install-update-these-serially
                   ;;core/check-for-updates core/check-for-updates-serially
                   ;; for testing purposes, no addon host is disabled
-                  catalogue/host-disabled? (constantly false)
                   utils/folder-size-bytes (constantly 0)
                   constants/max-user-catalogue-age 9999
                   ]

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -18,6 +18,12 @@
 
 (def dummy-dirname "not-the-addon-dir-you-are-looking-for")
 
+(defn-spec host-disabled? boolean?
+  "returns `true` if the addon host has been disabled"
+  [addon map?]
+  (or (-> addon :source (= "curseforge"))
+      (-> addon :source (utils/in? sp/tukui-source-list))))
+
 (defn-spec -remove-addon! nil?
   "safely removes the given `addon-dirname` from `install-dir`.
   if the given `addon-dirname` is a mutual dependency with another addon, just remove it's entry from
@@ -155,14 +161,9 @@
 (defn-spec merge-toc-nfo (s/or :ok map?, :empty nil?)
   "merges `toc` data with `nfo` data with special handling for the `source-map-list`."
   [toc (s/nilable map?), nfo (s/nilable map?)]
-  (let [curse? (fn [source-map]
-                 (= (:source source-map) "curseforge"))
-        tukui? (fn [source-map]
-                 (utils/in? (:source source-map) sp/tukui-source-list))
-        source-map-list (some->> (merge-lists (extract-source-map-list toc)
+  (let [source-map-list (some->> (merge-lists (extract-source-map-list toc)
                                               (extract-source-map-list nfo))
-                                 (remove curse?)
-                                 (remove tukui?)
+                                 (remove host-disabled?)
                                  vec
                                  (assoc {} :source-map-list))]
     (merge toc nfo source-map-list)))

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -157,9 +157,12 @@
   [toc (s/nilable map?), nfo (s/nilable map?)]
   (let [curse? (fn [source-map]
                  (= (:source source-map) "curseforge"))
+        tukui? (fn [source-map]
+                 (utils/in? (:source source-map) sp/tukui-source-list))
         source-map-list (some->> (merge-lists (extract-source-map-list toc)
                                               (extract-source-map-list nfo))
                                  (remove curse?)
+                                 (remove tukui?)
                                  vec
                                  (assoc {} :source-map-list))]
     (merge toc nfo source-map-list)))

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -19,7 +19,7 @@
   "returns `true` if the addon host has been disabled"
   [addon map?]
   (or (-> addon :source (= "curseforge")
-      (-> addon :source (utils/in? sp/tukui-source-list))))
+      (-> addon :source (utils/in? sp/tukui-source-list)))))
 
 (defn-spec -expand-summary (s/or :ok :addon/expanded, :error nil?)
   "fetches updates from the addon host for the given `addon` and `game-track`.

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -15,12 +15,6 @@
     [gitlab-api :as gitlab-api]
     [github-api :as github-api]]))
 
-(defn-spec host-disabled? boolean?
-  "returns `true` if the addon host has been disabled"
-  [addon map?]
-  (or (-> addon :source (= "curseforge")
-      (-> addon :source (utils/in? sp/tukui-source-list)))))
-
 (defn-spec -expand-summary (s/or :ok :addon/expanded, :error nil?)
   "fetches updates from the addon host for the given `addon` and `game-track`.
   does *not* support multiple game tracks or warning the user, see `expand-summary`.
@@ -66,7 +60,7 @@
       (not game-track)
       (error (format "unsupported game track '%s'." (str game-track*)))
 
-      (host-disabled? addon)
+      (strongbox.addon/host-disabled? addon)
       (if (= (:source addon) "curseforge")
         (warn (utils/message-list (str "addon host 'curseforge' was disabled " constants/curseforge-cutoff-label ".")
                                   ["use 'Source' and 'Find similar' from the addon context menu for alternatives."]))

--- a/src/strongbox/config.clj
+++ b/src/strongbox/config.clj
@@ -28,7 +28,11 @@
   (let [curse-idx 3]
     (utils/drop-idx -default-catalogue-list--v2 curse-idx)))
 
-(def -default-catalogue-list -default-catalogue-list--v3)
+(def -default-catalogue-list--v4
+  (let [tukui-idx 2]
+    (utils/drop-idx -default-catalogue-list--v3 tukui-idx)))
+
+(def -default-catalogue-list -default-catalogue-list--v4)
 
 (def default-cfg
   {:addon-dir-list []
@@ -124,6 +128,12 @@
   (let [new-catalogue-list (vec (remove #(= :curseforge (:name %)) (:catalogue-location-list cfg)))]
     (assoc cfg :catalogue-location-list new-catalogue-list)))
 
+(defn-spec remove-tukui-catalogue map?
+  "removes the tukui catalogue from the user config."
+  [cfg map?]
+  (let [new-catalogue-list (vec (remove #(= :tukui (:name %)) (:catalogue-location-list cfg)))]
+    (assoc cfg :catalogue-location-list new-catalogue-list)))
+
 (defn-spec handle-column-preferences map?
   "handles upgrading of the default column list.
   if the config is using the v1 defaults, upgrade to v2 defaults."
@@ -174,6 +184,7 @@
                 remove-invalid-catalogue-location-entries
                 add-github-catalogue
                 remove-curseforge-catalogue
+                remove-tukui-catalogue
                 handle-column-preferences
                 strip-unspecced-keys)
         message (format "configuration from %s is invalid and will be ignored: %s"

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -64,6 +64,7 @@
 (def glyph-map glyph-map--fontawesome)
 
 (def curseforge-cutoff-label "Feb 1st, 2022")
+(def tukui-cutoff-label "June 1st, 2023")
 
 (def releases
   "https://wowpedia.fandom.com/wiki/Patch"

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -733,7 +733,7 @@
   "returns the contents of the user catalogue or `nil` if it doesn't exist."
   []
   (let [catalogue (catalogue/read-catalogue (paths :user-catalogue-file) {:bad-data? nil})
-        new-summary-list (->> catalogue :addon-summary-list (remove catalogue/host-disabled?) vec)]
+        new-summary-list (->> catalogue :addon-summary-list (remove addon/host-disabled?) vec)]
     (when catalogue
       (catalogue/new-catalogue new-summary-list))))
 
@@ -1616,7 +1616,7 @@
                                                  :invalid-data? nil-me
                                                  :transform-map {:game-track keyword}})
 
-        addon-list (remove catalogue/host-disabled? addon-list)
+        addon-list (remove addon/host-disabled? addon-list)
 
         full-data? (fn [addon]
                      (utils/all (mapv #(contains? addon %) [:source :source-id :name])))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -690,7 +690,7 @@
       :short (catalogue/shorten-catalogue catalogue)
       ;;:curseforge (catalogue/filter-catalogue catalogue "curseforge")
       :wowinterface (catalogue/filter-catalogue catalogue "wowinterface")
-      :tukui (catalogue/filter-catalogue catalogue "tukui")
+      ;;:tukui (catalogue/filter-catalogue catalogue "tukui")
       :github (catalogue/filter-catalogue catalogue "github") ;; todo: add a test for this. I expect all derivable catalogues to be available
       nil)))
 
@@ -733,9 +733,7 @@
   "returns the contents of the user catalogue or `nil` if it doesn't exist."
   []
   (let [catalogue (catalogue/read-catalogue (paths :user-catalogue-file) {:bad-data? nil})
-        curse? (fn [addon]
-                 (-> addon :source (= "curseforge")))
-        new-summary-list (->> catalogue :addon-summary-list (remove curse?) vec)]
+        new-summary-list (->> catalogue :addon-summary-list (remove catalogue/host-disabled?) vec)]
     (when catalogue
       (catalogue/new-catalogue new-summary-list))))
 
@@ -1221,6 +1219,9 @@
                               (= source "curseforge")
                               (error (str "addon host 'curseforge' was disabled " constants/curseforge-cutoff-label "."))
 
+                              (utils/in? source sp/tukui-source-list)
+                              (error (str "addon host 'tukui' was disabled " constants/tukui-cutoff-label "."))
+
                               :else
                               ;; look in the current catalogue. emit an error if we fail
                               (or (:catalogue-match (-find-first-in-db (or (get-state :db) []) addon-summary-stub match-on-list))
@@ -1615,9 +1616,7 @@
                                                  :invalid-data? nil-me
                                                  :transform-map {:game-track keyword}})
 
-        curse? (fn [addon]
-                 (some-> addon :source (= "curseforge")))
-        addon-list (remove curse? addon-list)
+        addon-list (remove catalogue/host-disabled? addon-list)
 
         full-data? (fn [addon]
                      (utils/all (mapv #(contains? addon %) [:source :source-id :name])))

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -270,6 +270,7 @@
 (s/def :addon/category string?)
 (s/def :addon/category-list (s/coll-of :addon/category))
 
+(def tukui-source-list #{"tukui" "tukui-classic" "tukui-classic-tbc" "tukui-classic-wotlk"})
 (s/def :addon/source (s/or :known #{"curseforge" "wowinterface" "github" "gitlab" "tukui" "tukui-classic" "tukui-classic-tbc" "tukui-classic-wotlk"}
                            :unknown string?))
 (s/def :addon/source-id (s/or ::integer-id? int? ;; tukui has negative ids

--- a/src/strongbox/wowinterface_api.clj
+++ b/src/strongbox/wowinterface_api.clj
@@ -28,17 +28,14 @@
     (error (utils/reportable-error "given addon-summary has no game track list."))
     (error addon-summary))
 
+  ;; when the selected game track is supported by the addon, check for updates.
   (when (some #{game-track} (:game-track-list addon-summary))
     (let [url (str wowinterface-api "/filedetails/" (:source-id addon-summary) ".json")
           result-list (some-> url http/download-with-backoff http/sink-error utils/from-json)]
       (when-not (empty? result-list)
 
-        ;; has this happened before? can we find an example?
-        (when (> (count result-list) 1)
-          (warn "wowinterface api returned more than one result for addon with id:" (:source-id addon-summary)))
-
         ;; 2023-06-09: we don't expect more than one result from wowi, ever, but for the sake of testing and
-        ;; consistency it's now supported.
+        ;; consistency with other hosts it is now supported.
         (mapv (fn [result]
                 (let [sid (:source-id addon-summary)
                       ;; rarely present. use it if found. actual value of `aid` not necessary, it seems to work when empty as well.

--- a/src/strongbox/wowinterface_api.clj
+++ b/src/strongbox/wowinterface_api.clj
@@ -28,25 +28,26 @@
     (error (utils/reportable-error "given addon-summary has no game track list."))
     (error addon-summary))
 
-  ;; todo: this shouldn't be an 'if' if there is no 'else'
   (when (some #{game-track} (:game-track-list addon-summary))
     (let [url (str wowinterface-api "/filedetails/" (:source-id addon-summary) ".json")
-          result-list (some-> url http/download-with-backoff http/sink-error utils/from-json)
-          result (first result-list)]
-      (when result
+          result-list (some-> url http/download-with-backoff http/sink-error utils/from-json)]
+      (when-not (empty? result-list)
 
         ;; has this happened before? can we find an example?
         (when (> (count result-list) 1)
           (warn "wowinterface api returned more than one result for addon with id:" (:source-id addon-summary)))
 
-        (let [sid (:source-id addon-summary)
-              ;; rarely present. use it if found. actual value of `aid` not necessary, it seems to work when empty as well.
-              aid (extract-aid (:UIDownload result))]
-          [{:download-url (if aid
-                            (format "https://cdn.wowinterface.com/downloads/getfile.php?id=%s&aid=%s" sid aid)
-                            (format "https://cdn.wowinterface.com/downloads/getfile.php?id=%s" sid))
-            :version (:UIVersion result)
-            :game-track game-track}])))))
+        ;; 2023-06-09: we don't expect more than one result from wowi, ever, but for the sake of testing and
+        ;; consistency it's now supported.
+        (mapv (fn [result]
+                (let [sid (:source-id addon-summary)
+                      ;; rarely present. use it if found. actual value of `aid` not necessary, it seems to work when empty as well.
+                      aid (extract-aid (:UIDownload result))]
+                  {:download-url (if aid
+                                   (format "https://cdn.wowinterface.com/downloads/getfile.php?id=%s&aid=%s" sid aid)
+                                   (format "https://cdn.wowinterface.com/downloads/getfile.php?id=%s" sid))
+                   :version (:UIVersion result)
+                   :game-track game-track})) result-list)))))
 
 (defn-spec parse-user-string (s/or :ok :addon/source-id :error nil?)
   "extracts the addon ID from the given `url`"

--- a/test/fixtures/user-config-7.0.json
+++ b/test/fixtures/user-config-7.0.json
@@ -1,0 +1,47 @@
+{
+  "gui-theme": "dark-green",
+  "addon-dir-list": [
+    {
+      "addon-dir": "/tmp/.strongbox-bar",
+      "game-track": "classic-tbc",
+      "strict?": true
+    },
+    {
+      "addon-dir": "/tmp/.strongbox-foo",
+      "game-track": "retail",
+      "strict?": false
+    }
+  ],
+  "selected-addon-dir": "/tmp/.strongbox-foo",
+  "catalogue-location-list": [
+    {
+      "name": "short",
+      "label": "Short (default)",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+    },
+    {
+      "name": "full",
+      "label": "Full",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
+    },
+    {
+      "name": "wowinterface",
+      "label": "WoWInterface",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"
+    },
+    {
+      "name": "github",
+      "label": "GitHub",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"
+    }
+  ],
+  "selected-catalogue": "full",
+  "preferences":
+  {
+      "addon-zips-to-keep": 3,
+      "ui-selected-columns": [
+        "source", "name", "description", "installed-version", "available-version", "game-version", "uber-button"
+      ],
+      "keep-user-catalogue-updated": true
+  }
+}

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer [deftest testing is use-fixtures]]
    ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
    [strongbox
+    [utils :as utils]
     [constants :as constants]
     [logging :as logging]
     [catalogue :as catalogue]
@@ -280,9 +281,7 @@
           strict? true
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/281321"
                        {:get (fn [req] {:status 502 :reason-phrase "Gateway Time-out (HTTP 502)"})}}
-          expected ["failed to fetch 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 502) (HTTP 502)"
-                    "Curseforge: the API is having problems right now. Try again later."
-                    "no 'Retail' release found on curseforge."]]
+          expected ["addon host 'curseforge' was disabled Feb 1st, 2022.\n • use 'Source' and 'Find similar' from the addon context menu for alternatives."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
@@ -293,211 +292,240 @@
           strict? true
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/281321"
                        {:get (fn [req] {:status 504 :reason-phrase "Gateway Time-out (HTTP 504)"})}}
-          expected ["failed to fetch 'https://addons-ecs.forgesvc.net/api/v2/addon/281321': Gateway Time-out (HTTP 504) (HTTP 504)"
-                    "Curseforge: the API is having problems right now. Try again later."
-                    "no 'Retail' release found on curseforge."]]
+          expected ["addon host 'curseforge' was disabled Feb 1st, 2022.\n • use 'Source' and 'Find similar' from the addon context menu for alternatives."]]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log :info (catalogue/expand-summary addon game-track strict?))))))))
 
 ;; retail
 
-(deftest expand-summary--retail-strict
+(deftest expand-summary--retail-strict--just-retail
   (testing "when just retail is available, use it"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail]}
           game-track :retail
           strict? true
-          response (slurp (fixture-path "curseforge-api-addon--retail.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
-                    :interface-version 90000,
+          response [{:game-track :retail
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
                     :version "2.4.5"
                     :game-track :retail
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
                                     :game-track :retail,
-                                    :interface-version 90000,
-                                    :release-label "[WoW 9.0.1] Pawn-2.4.5",
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
+(deftest expand-summary--retail-strict--just-classic
   (testing "when just classic is available, use nothing"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:classic]}
           game-track :retail
           strict? true
-          response (slurp (fixture-path "curseforge-api-addon--classic.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
+          response [{:game-track :classic
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
           expected nil]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
+(deftest expand-summary--retail-strict--retail-and-classic
   (testing "when both retail and classic are available, use retail"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail :classic]}
           game-track :retail
           strict? true
-          response (slurp (fixture-path "curseforge-api-addon--retail-AND-classic.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
-                    :interface-version 90000,
+          response [{:game-track :retail
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646",
                     :version "2.4.5"
                     :game-track :retail
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646",
                                     :game-track :retail,
-                                    :interface-version 90000,
-                                    :release-label "[WoW 9.0.1] Pawn-2.4.5",
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 (deftest expand-summary--retail-then-classic
-  (testing "when just classic is available, use it"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
+  (testing "when both retail and classic are available, game track is set to retail and and strict-mode is off, use retail."
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail :classic]}
           game-track :retail
           strict? false
-          response (slurp (fixture-path "curseforge-api-addon--classic.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                    :interface-version 11300,
-                    :version "2.4.5 (Classic)"
-                    :game-track :classic
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                                    :game-track :classic,
-                                    :interface-version 11300,
-                                    :release-label "[WoW 1.13.5] Pawn-2.4.5-Classic",
-                                    :version "2.4.5 (Classic)"}]}
+          response [{:game-track :retail
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                    :version "2.4.5"
+                    :game-track :retail
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :retail
+                                    :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 ;; classic
 
-(deftest expand-summary--classic-strict
+(deftest expand-summary--classic-strict--just-classic
   (testing "when just classic is available, use it"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:classic]}
           game-track :classic
           strict? true
-          response (slurp (fixture-path "curseforge-api-addon--classic.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                    :interface-version 11300,
-                    :version "2.4.5 (Classic)"
-                    :game-track :classic
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                                    :game-track :classic,
-                                    :interface-version 11300,
-                                    :release-label "[WoW 1.13.5] Pawn-2.4.5-Classic",
-                                    :version "2.4.5 (Classic)"}]}
-          expected (merge addon expected)]
-      (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
-
-  (testing "when just retail is available, use nothing"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
-          game-track :classic
-          strict? true
-          response (slurp (fixture-path "curseforge-api-addon--retail.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected nil]
-      (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track strict?))))))
-
-  (testing "when both retail and classic are available, use classic"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
-          game-track :classic
-          strict? true
-          response (slurp (fixture-path "curseforge-api-addon--retail-AND-classic.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                    :interface-version 11300,
-                    :version "2.4.5 (Classic)"
-                    :game-track :classic
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/60/Pawn-2.4.5-Classic.zip",
-                                    :game-track :classic,
-                                    :interface-version 11300,
-                                    :release-label "[WoW 1.13.5] Pawn-2.4.5-Classic",
-                                    :version "2.4.5 (Classic)"}]}
-          expected (merge addon expected)]
-      (with-fake-routes-in-isolation fake-routes
-        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
-
-(deftest expand-summary--classic-then-retail
-  (testing "when just retail is available, use it"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"}
-          game-track :classic
-          strict? false
-          response (slurp (fixture-path "curseforge-api-addon--retail.json"))
-          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/4646"
-                       {:get (fn [req] {:status 200 :body response})}}
-          expected {:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
-                    :interface-version 90000,
+          response [{:game-track :classic
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
                     :version "2.4.5"
-                    :game-track :retail
-                    :release-list [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
-                                    :game-track :retail,
-                                    :interface-version 90000,
-                                    :release-label "[WoW 9.0.1] Pawn-2.4.5",
+                    :game-track :classic
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :classic,
                                     :version "2.4.5"}]}
           expected (merge addon expected)]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
+(deftest expand-summary--classic-strict--just-retail
+  (testing "when just retail is available, use nothing"
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail]}
+          game-track :classic
+          strict? true
+          response [{:game-track :retail
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected nil]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
+
+(deftest expand-summary--classic-strict--retail-and-classic
+  (testing "when both retail and classic are available, use classic"
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail :classic]}
+          game-track :classic
+          strict? true
+          response [{:game-track :retail ;; 2023-06-09: this is interesting behaviour. retail response, classic returned
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                    :version "2.4.5"
+                    :game-track :classic
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :classic,
+                                    :version "2.4.5"}]}
+          expected (merge addon expected)]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
+
+(deftest expand-summary--classic-then-retail
+  (testing "when both retail and classic are available, game track is set to classic and and strict-mode is off, use classic."
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:retail :classic]}
+          game-track :classic
+          strict? false
+          response [{:game-track :retail
+                     :UIVersion "2.4.5"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}
+          expected {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                    :version "2.4.5"
+                    :game-track :classic
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :classic
+                                    :version "2.4.5"}]}
+          expected (merge addon expected)]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
+
+;; ---
+
 (deftest expand-summary--pinned--use-pinned
   (testing "when an addon is pinned, look for it's release in the list of releases returned from the host"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"
-                 :installed-version "1.2.3" :pinned-version "1.2.0"}
+    (let [addon {:name "foo"
+                 :label "Foo"
+                 :source "wowinterface"
+                 :source-id "4646"
+                 :installed-version "1.2.3"
+                 :pinned-version "1.2.0"
+                 :game-track-list [:retail]}
           game-track :retail
           strict? true
-          fixture [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
+          expected {:name "foo"
+                    :label "Foo"
+                    :source "wowinterface"
+                    :source-id "4646"
+                    :installed-version "1.2.3"
+                    :pinned-version "1.2.0"
+                    :game-track-list [:retail]
+
+                    ;; pinned release merged in
+                    :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
                     :game-track :retail,
-                    :interface-version 90000,
-                    :release-label "[WoW 9.0.1] Pawn-1.2.3.zip",
-                    :version "1.2.3"}
-                   ;; pinned release
-                   {:download-url "https://edge.forgecdn.net/files/3104/062/Addon-2.4.5.zip",
-                    :game-track :retail,
-                    :interface-version 90000,
-                    :release-label "[WoW 9.0.1] Addon-1.2.0",
-                    :version "1.2.0"}]
-          expected (-> addon
-                       (merge {:release-list fixture}
-                              (second fixture))
-                       (dissoc :release-label))]
-      (with-fake-routes-in-isolation {}
-        ;; omg, with-redefs is fantastic
-        (with-redefs [strongbox.curseforge-api/expand-summary (constantly fixture)]
-          (is (= expected (catalogue/expand-summary addon game-track strict?))))))))
+                    :version "1.2.0"
+
+                    ;; pinned + new versions available in release list
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :retail,
+                                    :version "1.2.3"}
+                                   {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :retail,
+                                    :version "1.2.0"}]}
+          response [{:game-track :retail
+                     :UIVersion "1.2.3"}
+                    ;; pinned release
+                    {:game-track :retail
+                     :UIVersion "1.2.0"}]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 (deftest expand-summary--pinned--use-latest
   (testing "when a pinned addon cannot find it's pinned release, use the latest release available"
-    (let [addon {:name "foo" :label "Foo" :source "curseforge" :source-id "4646"
-                 :installed-version "0.9.9" :pinned-version "0.9.9"}
+    (let [addon {:name "foo"
+                 :label "Foo"
+                 :source "wowinterface"
+                 :source-id "4646"
+                 :installed-version "0.9.9"
+                 :pinned-version "0.9.9"
+                 :game-track-list [:retail]}
           game-track :retail
           strict? true
-          fixture [{:download-url "https://edge.forgecdn.net/files/3104/62/Pawn-2.4.5.zip",
+          expected {:name "foo"
+                    :label "Foo"
+                    :source "wowinterface"
+                    :source-id "4646"
+                    :installed-version "0.9.9"
+                    :pinned-version "0.9.9"
+                    :game-track-list [:retail]
+
+                    ;; latest release merged in
+                    :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
                     :game-track :retail,
-                    :interface-version 90000,
-                    :release-label "[WoW 9.0.1] Pawn-1.2.3",
-                    :version "1.2.3"}
-                   {:download-url "https://edge.forgecdn.net/files/3104/062/Addon-2.4.5.zip",
-                    :game-track :retail,
-                    :interface-version 90000,
-                    :release-label "[WoW 9.0.1] Addon-1.2.0",
-                    :version "1.2.0"}]
-          expected (-> addon
-                       (merge {:release-list fixture}
-                              (first fixture))
-                       (dissoc :release-label))]
-      (with-fake-routes-in-isolation {}
-        (with-redefs [strongbox.curseforge-api/expand-summary (constantly fixture)]
-          (is (= expected (catalogue/expand-summary addon game-track strict?))))))))
+                    :version "1.2.3"
+
+                    ;; pinned + new versions available in release list
+                    :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :retail,
+                                    :version "1.2.3"}
+                                   {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=4646"
+                                    :game-track :retail,
+                                    :version "1.2.0"}]}
+          response [{:game-track :retail
+                     :UIVersion "1.2.3"}
+                    {:game-track :retail
+                     :UIVersion "1.2.0"}
+                    ;; pinned release missing from response
+                    ;;{:game-track :retail
+                    ;; :UIVersion "1.2.0"}
+                    ]
+          fake-routes {"https://api.mmoui.com/v3/game/WOW/filedetails/4646.json"
+                       {:get (fn [req] {:status 200 :body (utils/to-json response)})}}]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (catalogue/expand-summary addon game-track strict?)))))))
 
 ;;
 

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -319,7 +319,11 @@
 
 (deftest expand-summary--retail-strict--just-classic
   (testing "when just classic is available, use nothing"
-    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646" :game-track-list [:classic]}
+    (let [addon {:name "foo" :label "Foo" :source "wowinterface" :source-id "4646"
+                 ;; 2023-06-11: test switched from curseforge to wowinterface.
+                 ;; wowinterface doesn't expand to different game tracks, so what we're testing here is refusing to expand,
+                 ;; rather than filtering out a classic release.
+                 :game-track-list [:classic]}
           game-track :retail
           strict? true
           response [{:game-track :classic

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -588,9 +588,11 @@
                     :source "tukui",
                     :source-id 98
                     :source-map-list [{:source "tukui" :source-id 98}]}
+          _ expected
 
           expected-addon-dir (utils/join install-dir "EveryAddon")
           expected-user-catalogue [match]
+          _ expected-user-catalogue
 
           catalogue (utils/to-json (catalogue/new-catalogue [match]))
 
@@ -616,21 +618,25 @@
           ;; user gives us this url, we find it and install it
           (cli/import-addon user-url)
 
-          ;; addon was successfully download and installed
-          (is (fs/exists? expected-addon-dir))
+          ;; addon was (not) successfully download and installed
+          ;;(is (fs/exists? expected-addon-dir))
+          (is (not (fs/exists? expected-addon-dir)))
 
           ;; re-read install dir
           (core/load-all-installed-addons)
 
-          ;; we expect our mushy set of .nfo and .toc data
-          (is (= [expected] (core/get-state :installed-addon-list)))
+          ;; we expect ~our~ (no) mushy set of .nfo and .toc data
+          ;;(is (= [expected] (core/get-state :installed-addon-list)))
+          (is (= [] (core/get-state :installed-addon-list)))
 
           ;; and that the addon was added to the user catalogue
-          (is (= expected-user-catalogue (core/get-state :user-catalogue :addon-summary-list)))
+          ;;(is (= expected-user-catalogue (core/get-state :user-catalogue :addon-summary-list)))
+          (is (nil? (core/get-state :user-catalogue :addon-summary-list)))
 
           ;; and that the user catalogue was persisted to disk
-          (is (= expected-user-catalogue
-                 (:addon-summary-list (catalogue/read-catalogue (core/paths :user-catalogue-file))))))))))
+          ;;(is (= expected-user-catalogue
+          ;;       (:addon-summary-list (catalogue/read-catalogue (core/paths :user-catalogue-file)))))
+          (is (nil? (:addon-summary-list (catalogue/read-catalogue (core/paths :user-catalogue-file))))))))))
 
 ;; todo: no import-addon-gitlab ?
 

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -360,6 +360,7 @@
                                 ;; the set of available catalogues are added to configuration.
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -408,6 +409,7 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -458,6 +460,7 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -507,6 +510,7 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -553,6 +557,7 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -601,6 +606,7 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
@@ -654,12 +660,12 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           ;;{:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
                                                           {:name :wowinterface :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"}
                                                           ;; new in 4.9
-                                                          ;; the set of available catalogues now includes a github catalogue
                                                           {:name :github :label "GitHub" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"}]
 
                                 :preferences {:addon-zips-to-keep 3
@@ -709,12 +715,68 @@
                                 ;; new in 1.0
                                 :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
                                                           {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
                                                           {:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
                                                           ;; removed in 5.0.0
                                                           ;;{:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
                                                           {:name :wowinterface :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"}
                                                           ;; new in 4.9
-                                                          ;; the set of available catalogues now includes a github catalogue
+                                                          {:name :github :label "GitHub" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"}]
+
+                                :preferences {:addon-zips-to-keep 3
+                                              :ui-selected-columns [:source :name :description
+                                                                    :installed-version :available-version ;; replaced in 5.0.0
+                                                                    :game-version :uber-button]
+                                              :keep-user-catalogue-updated true}}
+
+                    :etag-db {}}]
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
+
+(deftest load-settings-7.0
+  (testing "a standard config file circa 7.0 is loaded and parsed as expected"
+    (let [cli-opts {}
+          cfg-file (fixture-path "user-config-7.0.json")
+          etag-db-file (fixture-path "empty-map.json")
+
+          expected {:cfg {:gui-theme :dark-green ;; new in 0.11, `:dark-green` new in 3.2.0
+                          :selected-catalogue :full ;; new in 0.10
+                          ;;:debug? true ;; removed in 0.12
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc :strict? true} ;; `:classic-tbc` and `:strict?` added in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :retail :strict? false}]
+
+                          ;; new in 1.0
+                          ;; new in 4.9, the set of available catalogues now includes a github catalogue
+                          :catalogue-location-list (:catalogue-location-list config/default-cfg)
+
+                          ;; new in 0.12
+                          ;; moved to :cfg in 1.0
+                          :selected-addon-dir "/tmp/.strongbox-foo"
+
+                          ;; new in 3.1.0
+                          :preferences {:addon-zips-to-keep 3
+
+                                        :ui-selected-columns [:source :name :description
+                                                              :combined-version ;; new default in 5.0.0
+                                                              :game-version :uber-button]
+                                        ;; new in 6.2.0
+                                        :keep-user-catalogue-updated true}}
+
+                    :cli-opts {}
+                    :file-opts {:gui-theme :dark-green
+                                :selected-catalogue :full
+                                :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc, :strict? true}
+                                                 {:addon-dir "/tmp/.strongbox-foo", :game-track :retail, :strict? false}]
+                                :selected-addon-dir "/tmp/.strongbox-foo"
+
+                                ;; new in 1.0
+                                :catalogue-location-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"}
+                                                          {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"}
+                                                          ;; removed in 7.0.0
+                                                          ;;{:name :tukui :label "Tukui" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"}
+                                                          ;; removed in 5.0.0
+                                                          ;;{:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"}
+                                                          {:name :wowinterface :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"}
+                                                          ;; new in 4.9
                                                           {:name :github :label "GitHub" :source "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/github-catalogue.json"}]
 
                                 :preferences {:addon-zips-to-keep 3

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -6,9 +6,9 @@
    [envvar.core :refer [with-env]]
    [me.raynes.fs :as fs]
    [taoensso.timbre :as log :refer [debug info warn error spy]]
+   [java-time :as jt]
    [strongbox.cli :as cli]
    [strongbox
-    [constants :as constants]
     [addon :as addon :refer [downloaded-addon-fname]]
     [logging :as logging]
     [zip :as zip]
@@ -292,34 +292,6 @@
                      :version "1.2.3"}
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
-                     :dirname "Addon4",
-                     :dirsize 0
-                     :download-count 4,
-                     :download-url "https://www.tukui.org/addons.php?download=4",
-                     :game-track :retail,
-                     :group-id "https://www.tukui.org/addons.php?id=4",
-                     :installed-game-track :retail,
-                     :installed-version "1.2.3",
-                     :interface-version 80200,
-                     :label "Addon4",
-                     :matched? true,
-                     :name "addon4",
-                     :primary? true,
-                     :release-list [{:download-url "https://www.tukui.org/addons.php?download=4",
-                                     :game-track :retail,
-                                     :interface-version 80200,
-                                     :version "1.2.3"}],
-                     :source "tukui",
-                     :source-id 4,
-                     :source-map-list [{:source "tukui", :source-id 4}],
-                     :supported-game-tracks [:retail],
-                     :tag-list [],
-                     :update? false,
-                     :updated-date "2019-07-03T07:11:47Z",
-                     :url "https://www.tukui.org/addons.php?id=4",
-                     :version "1.2.3"}
-                    {:created-date "2011-01-04T05:42:23Z",
-                     :description "desc",
                      :dirname "Addon5",
                      :dirsize 0
                      :download-count 5,
@@ -439,34 +411,6 @@
                      :version "1.2.3"}
                     {:created-date "2011-01-04T05:42:23Z",
                      :description "desc",
-                     :dirname "Addon4",
-                     :dirsize 0
-                     :download-count 4,
-                     :download-url "https://www.tukui.org/addons.php?download=4",
-                     :game-track :retail,
-                     :group-id "https://www.tukui.org/addons.php?id=4",
-                     :installed-game-track :retail,
-                     :installed-version "1.2.3",
-                     :interface-version 80200,
-                     :label "Addon4",
-                     :matched? true,
-                     :name "addon4",
-                     :primary? true,
-                     :release-list [{:download-url "https://www.tukui.org/addons.php?download=4",
-                                     :game-track :retail,
-                                     :interface-version 80200,
-                                     :version "1.2.3"}],
-                     :source "tukui",
-                     :source-id 4,
-                     :source-map-list [{:source "tukui", :source-id 4}],
-                     :supported-game-tracks [:retail],
-                     :tag-list [],
-                     :update? false,
-                     :updated-date "2019-07-03T07:11:47Z",
-                     :url "https://www.tukui.org/addons.php?id=4",
-                     :version "1.2.3"}
-                    {:created-date "2011-01-04T05:42:23Z",
-                     :description "desc",
                      :dirname "Addon5",
                      :dirsize 0
                      :download-count 5,
@@ -503,38 +447,38 @@
 
 (deftest check-for-addon-update
   (testing "the key `:update?` is set to `true` when the installed version doesn't match the catalogue version"
-    (let [;; we start off with a list of these called a catalogue. it's downloaded from github
-          catalogue {:tag-list [:auction-house]
-                     :download-count 1
-                     :label "Every Addon"
-                     :name "every-addon",
-                     :source "curseforge",
-                     :source-id 0
-                     :updated-date "2012-09-20T05:32:00Z",
-                     :url "https://www.curseforge.com/wow/addons/every-addon"}
+    (let [;; we start off with a list of these called a catalogue
+          catalogue [{:label "Every Addon"
+                      :name "every-addon",
+                      :description "Does foo, only better."
+                      :source "wowinterface",
+                      :source-id 0
+                      :game-track-list [:retail]
+                      :url "https://github.com/addons/every-addon"
+                      :download-count 1
+                      :tag-list [:auction-house]
+                      :updated-date "2012-09-20T05:32:00Z",
+                      :created-date "2023-08-01T00:00:00Z"}]
 
-          ;; this is subset of the data the remote addon host (like curseforge) serves us
-          api-result {:latestFiles [{:downloadUrl "https://example.org/foo"
-                                     :displayName "v8.10.00"
-                                     :gameVersionFlavor "wow_retail",
-                                     :gameVersion ["7.0.0"]
-                                     :fileDate "2001-01-03T00:00:00.000Z",
-                                     :fileName "EveryAddon.zip"
-                                     :releaseType 1,
-                                     :exposeAsAlternative nil}]}
-          alt-api-result (assoc-in api-result [:latestFiles 0 :displayName] "v8.20.00")
+          dummy-catalogue (catalogue/new-catalogue catalogue)
 
-          dummy-catalogue (catalogue/new-catalogue [catalogue])
+          ;; this is a subset of the data the remote addon host (like curseforge) serves us
+          api-result [{:game-track :retail,
+                       :UIVersion "v8.10.00"}]
+
+          ;;alt-api-result (assoc-in api-result [:latestFiles 0 :displayName] "v8.20.00")
+          alt-api-result (assoc-in api-result [0 :UIVersion] "v8.20.00")
 
           fake-routes {;; catalogue
                        "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json dummy-catalogue)})}
 
-                       ;; every-addon
-                       "https://addons-ecs.forgesvc.net/api/v2/addon/0"
+                       ;; every-addon 0
+                       "https://api.mmoui.com/v3/game/WOW/filedetails/0.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json api-result)})}
 
-                       "https://addons-ecs.forgesvc.net/api/v2/addon/1"
+                       ;; every-addon 1
+                       "https://api.mmoui.com/v3/game/WOW/filedetails/1.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json alt-api-result)})}}]
 
       (with-global-fake-routes-in-isolation fake-routes
@@ -556,7 +500,7 @@
                      :name "every-addon",
                      :group-id "doesntmatter"
                      :primary? true,
-                     :source "curseforge"
+                     :source "wowinterface"
                      :source-id 0}
 
                 ;; the nfo data is simply merged over the top of the scraped toc data
@@ -566,20 +510,16 @@
                 ;; in this case we have a catalogue of 1 and only interested in the first result
                 result (first (core/db-match-installed-addon-list-with-catalogue (core/get-state :db) [toc]))
 
-                ;; previously done in above step, mooshing the installed addon and catalogue item together is
-                ;; now a separate step
+                ;; the installed addon result and catalogue item result are mooshed together
                 toc-addon (core/moosh-addons toc (:catalogue-match result))
-
                 alt-toc-addon (assoc toc-addon :source-id 1)
 
                 ;; and what we 'expand' that data into
-                source-updates {:download-url "https://example.org/foo",
+                source-updates {:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=0"
                                 :version "v8.10.00"
                                 :game-track :retail
-                                :release-list [{:download-url "https://example.org/foo",
+                                :release-list [{:download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=0"
                                                 :game-track :retail,
-                                                :interface-version 70000,
-                                                :release-label "[WoW 7.0.0] EveryAddon",
                                                 :version "v8.10.00"}]}
 
                 alt-source-updates (assoc source-updates :version "v8.20.00")
@@ -587,7 +527,8 @@
 
                 ;; after calling `check-for-update` we expect the result to be the merged sum of the below parts
                 expected (merge toc-addon source-updates {:update? false})
-                alt-expected (merge alt-toc-addon alt-source-updates {:update? true})]
+                alt-expected (merge alt-toc-addon alt-source-updates {:update? true :download-url "https://cdn.wowinterface.com/downloads/getfile.php?id=1"})
+                alt-expected (assoc-in alt-expected [:release-list 0 :download-url] "https://cdn.wowinterface.com/downloads/getfile.php?id=1")]
 
             (is (= expected (core/check-for-update toc-addon)))
             (is (= alt-expected (core/check-for-update alt-toc-addon)))))))))
@@ -1966,11 +1907,14 @@
 
 (deftest scheduled-user-catalogue-refresh
   (with-running-app
-    (with-redefs [constants/max-user-catalogue-age 0]
+    (java-time/with-clock (java-time/fixed-clock "2100-01-01T00:00:00Z")
       (cli/set-preference :keep-user-catalogue-updated true)
       (is (true? (core/get-state :cfg :preferences :keep-user-catalogue-updated)))
       (swap! core/state assoc :user-catalogue (catalogue/new-catalogue []))
-      (let [expected ["user-catalogue not updated in the last 0 days, automatic refresh triggered."
+      (is (true? (core/refresh-user-catalogue?
+                  (core/get-state :cfg :preferences :keep-user-catalogue-updated)
+                  (core/get-state :user-catalogue :datestamp))))
+      (let [expected ["user-catalogue not updated in the last 9999 days, automatic refresh triggered."
                       "downloading 'full' catalogue"
                       "refreshing \"user-catalogue.json\", this may take a minute ..."
                       "\"user-catalogue.json\" has been refreshed"]]

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -462,11 +462,10 @@
 
           dummy-catalogue (catalogue/new-catalogue catalogue)
 
-          ;; this is a subset of the data the remote addon host (like curseforge) serves us
+          ;; this is a subset of the data the remote addon host (like wowinterface) serves us
           api-result [{:game-track :retail,
                        :UIVersion "v8.10.00"}]
 
-          ;;alt-api-result (assoc-in api-result [:latestFiles 0 :displayName] "v8.20.00")
           alt-api-result (assoc-in api-result [0 :UIVersion] "v8.20.00")
 
           fake-routes {;; catalogue

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -84,19 +84,28 @@
         (is (= (utils/days-between-then-and-now "2001-01-01") 1)))))
 
 (deftest older-than?
-  (let [cases [[["2001-01-01" 0 :days] true]
-               [["2001-01-01" 0 :hours] true]
+  (java-time/with-clock (java-time/fixed-clock "2023-01-01T00:00:00Z")
+    (let [cases [[["2001-01-01" 0 :days] true]
+                 [["2001-01-01" 0 :hours] true]
 
-               [["2001-01-01" 1 :days] true]
-               [["2001-01-01" 1 :hours] true]
+                 [["2001-01-01" 1 :days] true]
+                 [["2001-01-01" 1 :hours] true]
 
-               [["2079-12-31" 1 :days] false]
-               [["2079-12-31" 1 :hours] false]
+                 [["2079-12-31" 1 :days] false]
+                 [["2079-12-31" 1 :hours] false]
 
-               [["2079-12-31" 0 :days] false]
-               [["2079-12-31" 0 :hours] false]]]
-    (doseq [[[then threshold period] expected] cases]
-      (is (= expected (utils/older-than? then threshold period))))))
+                 [["2079-12-31" 0 :days] false]
+                 [["2079-12-31" 0 :hours] false]
+
+                 ;; right now is 2023-01-01T00:00:00Z
+
+                 [["2023-01-01T00:00:00Z" 0 :minutes] false]
+
+                 [["2022-12-31T23:58:59Z" 1 :minutes] true]
+                 [["2023-01-01T00:00:00Z" 1 :minutes] false]]]
+
+      (doseq [[[then threshold period] expected] cases]
+        (is (= expected (utils/older-than? then threshold period)), (format "case %s %s %s" then threshold period))))))
 
 (deftest older-than?--bad-period
   (is (thrown? java.lang.IllegalArgumentException (utils/older-than? "2001-01-01" 12 :parsecs))))


### PR DESCRIPTION
- [x] addons from tukui can not be updated
    - `catalogue/host-disabled?` and `catalogue/expand-summary`
- [x] gui, update warning when tukui addons found
- [x] config, remove tukui catalogue from user config
- [x] tukui catalogue should not be generated
    - see `strongbox-catalogue-builder`
- [x] tukui addons should not be present in full and short catalogues
    - see `strongbox-catalogue-builder`
- [x] addons from tukui can not be imported
    - this will occur naturally when tukui addons are not present in any catalogue
      - non-github, non-gitlab addons consult the catalogue to find the addon before importing it to fill in the missing gaps in data.
    - disable anyway
    - see `core/find-addon` 
- [x] tukui should not be present in emergency catalogue
    - this will occur naturally when tukui addons are not present in any catalogue
    - see `core/emergency-catalogue`
- [x] user catalogue, filter out any tukui addons on reading catalogue
    - otherwise they will appear in search results, will be importable.
    - see `core/get-user-catalogue`
- [x] disable source switching *to* tukui.
    - see `addon/merge-toc-nfo` to remove curse and tukui from the available 'source-maps'
- [x] disable bulk imports of tukui addons
    - see `core/import-exported-file`
- [x] update README
- [x] review
- [x] update CHANGELOG