### PR TITLE
search, sampling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* added checkbox to bottom of search tab that will toggle search results sampling when search results are unfiltered.
+    - this lets you browse a catalogue page by page.
+* patch tooltip for Dragonflight 10.1 "Embers of Neltharion"
+
 ### Changed
 
+* bumped JavaFX dependencies from 17.x to 19.x.
+* removed the fixed widths on the 'updated' and 'downloads' columns in the search pane.
+    - attempting to control column widths in a JavaFX table is futile.
+
 ### Fixed
+
+* tag buttons in search pane are now centred vertically.
+* selecting hosts in search pane no longer samples results.
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -10,14 +10,19 @@ see CHANGELOG.md for a more formal list of changes by release
     - selecting by host still gives me samples
     - done
 
-## todo
-
-* search, vertically centre tag buttons. 
-    - they're currently top-aligned
-
 * search, add ability to browse catalogue page by page
     - returned to bucket 2022-03-02
     - the 'search' tab kinda sorta is this ... perhaps a preference to disable sampling?
+    - done
+
+* search, vertically centre tag buttons. 
+    - they're currently top-aligned
+    - done
+
+* cljfx, javafx
+    - bump deps
+
+## todo
 
 * catalogue/search results, if there are addons from the same host (github) with the same name (tukui), disambiguate them
     - 'tukui' in the search results shouldn't mean 'ogri-la/tukui' if 'tukui.org/tukui' is also available

--- a/TODO.md
+++ b/TODO.md
@@ -6,10 +6,11 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## done
 
-## todo
-
 * search, possible bug, thought I fixed it so catalogues are navigable now?
     - selecting by host still gives me samples
+    - done
+
+## todo
 
 * search, add ability to browse catalogue page by page
     - returned to bucket 2022-03-02

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,9 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* search, vertically centre tag buttons. 
+    - they're currently top-aligned
+
 * search, add ability to browse catalogue page by page
     - returned to bucket 2022-03-02
     - the 'search' tab kinda sorta is this ... perhaps a preference to disable sampling?
@@ -32,6 +35,14 @@ see CHANGELOG.md for a more formal list of changes by release
         - "ignored addons in the addon detail pane now display mutual dependencies (if any)."
 
 ## todo bucket (no particular order)
+
+* github-addons.md, update or get rid of
+
+* *.sh, consolidate these root-level bash scripts into a manage.sh 
+
+* move Dockerfile* files into a CircleCI folder
+
+* release.md, move to strongbox-release-script
 
 * metrics, add a 'catalogue is N days old'
     - add an 'oldest' addon (days since created date)?

--- a/cloverage.clj
+++ b/cloverage.clj
@@ -1,5 +1,7 @@
 (ns strongbox.cloverage
   (:require
+   [clojure.test :as test :refer [report with-test-out inc-report-counter testing-vars-str testing-contexts-str *testing-contexts* *stack-trace-depth*]]
+   [clojure.stacktrace :as stack]
    [strongbox
     [main :as main]
     [constants :as constants]
@@ -8,24 +10,68 @@
     [joblib :as joblib]
     [logging :as logging]
     [core :as core]]
-   [clojure.test :as test]
    [cloverage.coverage :as c]))
 
 (comment
   "Cloverage hook. runs all of the application tests with spec checks enabled.
   These checks are disabled by default and only available if passed in from the REPL on app start.")
 
+(def ^:dynamic *testing-problems* nil)
+
+(defn report-testing-problems
+  []
+  (when-not (empty? (:fail @*testing-problems*))
+    (println)
+    (println "--- FAILURES ---")
+    (doseq [f (:fail @*testing-problems*)]
+      (println f)))
+  (when-not (empty? (:error @*testing-problems*))
+    (println)
+    (println "--- ERRORS ---")
+    (doseq [e (:error @*testing-problems*)]
+      (println e))))
+
+;; --- copied from clojure.test
+
+(defmethod report :fail [m]
+  (swap! *testing-problems* update-in [:fail] conj m)
+  (with-test-out
+    (inc-report-counter :fail)
+    (println "\nFAIL in" (testing-vars-str m))
+    (when (seq *testing-contexts*) (println (testing-contexts-str)))
+    (when-let [message (:message m)] (println message))
+    (println "expected:" (pr-str (:expected m)))
+    (println "  actual:" (pr-str (:actual m)))))
+
+(defmethod report :error [m]
+  (swap! *testing-problems* update-in [:error] conj m)
+  (with-test-out
+   (inc-report-counter :error)
+   (println "\nERROR in" (testing-vars-str m))
+   (when (seq *testing-contexts*) (println (testing-contexts-str)))
+   (when-let [message (:message m)] (println message))
+   (println "expected:" (pr-str (:expected m)))
+   (print "  actual: ")
+   (let [actual (:actual m)]
+     (if (instance? Throwable actual)
+       (stack/print-cause-trace actual *stack-trace-depth*)
+       (prn actual)))))
+
 (defmethod c/runner-fn :strongbox
   [_]
   (fn [ns-list]
-    (with-redefs [core/*testing?* true
-                  main/*spec?* true
-                  http/*default-pause* 1 ;; ms
-                  http/*default-attempts* 1
-                  ;;joblib/tick-delay joblib/*tick*
-                  utils/folder-size-bytes (constantly 0)
-                  constants/max-user-catalogue-age 9999]
-      (core/reset-logging!)
-      (apply require (map symbol ns-list))
-      {:errors (reduce + ((juxt :error :fail)
-                          (apply test/run-tests ns-list)))})))
+    (let [testing-problems (atom {:fail [] :error []})]
+      (with-redefs [core/*testing?* true
+                    main/*spec?* true
+                    http/*default-pause* 1 ;; ms
+                    http/*default-attempts* 1
+                    ;;joblib/tick-delay joblib/*tick*
+                    utils/folder-size-bytes (constantly 0)
+                    constants/max-user-catalogue-age 9999
+                    *testing-problems* testing-problems]
+        (core/reset-logging!)
+        (apply require (map symbol ns-list))
+        (let [retval {:errors (reduce + ((juxt :error :fail)
+                                         (apply test/run-tests ns-list)))}]
+          (report-testing-problems)
+          retval)))))

--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
-                 [org.clojure/core.cache "1.0.207"] ;; jfx context caching
+                 ;;[org.clojure/core.cache "1.0.207"] ;; jfx context caching
                  
                  ]
 

--- a/project.clj
+++ b/project.clj
@@ -27,21 +27,21 @@
                  [envvar "1.1.2"] ;; environment variable wrangling
                  [tolitius/lasync "0.1.24"] ;; better parallel processing
 
-                 [cljfx "1.7.22" :exclusions [org.openjfx/javafx-web
+                 [cljfx "1.7.23" :exclusions [org.openjfx/javafx-web
                                               org.openjfx/javafx-media]]
                  [cljfx/css "1.1.0"]
 
-                 [org.openjfx/javafx-base "17.0.2"]
-                 [org.openjfx/javafx-base "17.0.2" :classifier "linux"]
-                 [org.openjfx/javafx-base "17.0.2" :classifier "mac"]
+                 [org.openjfx/javafx-base "19.0.2.1"]
+                 [org.openjfx/javafx-base "19.0.2.1" :classifier "linux"]
+                 [org.openjfx/javafx-base "19.0.2.1" :classifier "mac"]
 
-                 [org.openjfx/javafx-controls "17.0.2"]
-                 [org.openjfx/javafx-controls "17.0.2" :classifier "linux"]
-                 [org.openjfx/javafx-controls "17.0.2" :classifier "mac"]
+                 [org.openjfx/javafx-controls "19.0.2.1"]
+                 [org.openjfx/javafx-controls "19.0.2.1" :classifier "linux"]
+                 [org.openjfx/javafx-controls "19.0.2.1" :classifier "mac"]
 
-                 [org.openjfx/javafx-graphics "17.0.2"]
-                 [org.openjfx/javafx-graphics "17.0.2" :classifier "linux"]
-                 [org.openjfx/javafx-graphics "17.0.2" :classifier "mac"]
+                 [org.openjfx/javafx-graphics "19.0.2.1"]
+                 [org.openjfx/javafx-graphics "19.0.2.1" :classifier "linux"]
+                 [org.openjfx/javafx-graphics "19.0.2.1" :classifier "mac"]
 
                  ;; GPLv3 compatible dependencies.
                  ;; these don't need an exception in LICENCE.txt
@@ -51,7 +51,7 @@
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
-                 ;;[org.clojure/core.cache "1.0.207"] ;; jfx context caching
+                 [org.clojure/core.cache "1.0.207"] ;; jfx context caching
                  
                  ]
 

--- a/repl/strongbox/user.clj
+++ b/repl/strongbox/user.clj
@@ -1,61 +1,106 @@
 (ns strongbox.user
   (:refer-clojure :rename {test clj-test})
   (:require
-   [taoensso.timbre :as timbre :refer [spy info warn error report]]
-   [clojure.test]
+   [clojure.test :refer [report with-test-out inc-report-counter testing-vars-str testing-contexts-str *testing-contexts* *stack-trace-depth*]]
+   [clojure.stacktrace :as stack]
+   [taoensso.timbre :as timbre :refer [spy info warn error]]
    [clojure.tools.namespace.repl :as tn :refer [refresh]]
    [strongbox
+    [logging :as logging]
     [addon :as addon]
     [constants :as constants]
     [main :as main :refer [restart stop]]
     [catalogue :as catalogue]
     [http :as http]
     [core :as core]
-    [utils :as utils :refer [in?]]
-    ;;[cli :as cli]
-    ]
-   [gui.diff :refer [with-gui-diff]]
-   ))
+    [utils :as utils :refer [in?]]]
+   [gui.diff :refer [with-gui-diff]]))
+
+(def ^:dynamic *testing-problems* nil)
+
+(defn report-testing-problems
+  []
+  (when-not (empty? (:fail @*testing-problems*))
+    (println)
+    (println "--- FAILURES ---")
+    (doseq [f (:fail @*testing-problems*)]
+      (println f)))
+  (when-not (empty? (:error @*testing-problems*))
+    (println)
+    (println "--- ERRORS ---")
+    (doseq [e (:error @*testing-problems*)]
+      (println e))))
+
+;; --- copied from clojure.test
+
+(defmethod report :fail [m]
+  (swap! *testing-problems* update-in [:fail] conj m)
+  (with-test-out
+    (inc-report-counter :fail)
+    (println "\nFAIL in" (testing-vars-str m))
+    (when (seq *testing-contexts*) (println (testing-contexts-str)))
+    (when-let [message (:message m)] (println message))
+    (println "expected:" (pr-str (:expected m)))
+    (println "  actual:" (pr-str (:actual m)))))
+
+(defmethod report :error [m]
+  (swap! *testing-problems* update-in [:error] conj m)
+  (with-test-out
+   (inc-report-counter :error)
+   (println "\nERROR in" (testing-vars-str m))
+   (when (seq *testing-contexts*) (println (testing-contexts-str)))
+   (when-let [message (:message m)] (println message))
+   (println "expected:" (pr-str (:expected m)))
+   (print "  actual: ")
+   (let [actual (:actual m)]
+     (if (instance? Throwable actual)
+       (stack/print-cause-trace actual *stack-trace-depth*)
+       (prn actual)))))
+
+;; ---
 
 (defn test
   [& [ns-kw fn-kw]]
   (main/stop)
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including strongbox.whatever-test ones
   (utils/instrument true) ;; always test with spec checking ON
-
+  
   (try
-    ;; note! remember to update `cloverage.clj` with any new bindings
-    (with-redefs [core/*testing?* true
-                  http/*default-pause* 1 ;; ms
-                  http/*default-attempts* 1
-                  ;; don't pause while testing. nothing should depend on that pause happening.
-                  ;; note! this is different to `joblib/tick-delay` not delaying when `joblib/*tick*` is unbound.
-                  ;; tests still bind `joblib/*tick*` and run things in parallel.
-                  ;;joblib/tick-delay joblib/*tick*
-                  ;;main/*spec?* true
-                  ;;cli/install-update-these-in-parallel cli/install-update-these-serially
-                  ;;core/check-for-updates core/check-for-updates-serially
-                  ;; for testing purposes, no addon host is disabled
-                  utils/folder-size-bytes (constantly 0)
-                  constants/max-user-catalogue-age 9999
-                  ]
-      (core/reset-logging!)
+    (let [testing-problems (atom {:fail [] :error []})]
+      ;; note! remember to update `cloverage.clj` with any new bindings
+      (with-redefs [core/*testing?* true
+                    http/*default-pause* 1 ;; ms
+                    http/*default-attempts* 1
+                    ;; don't pause while testing. nothing should depend on that pause happening.
+                    ;; note! this is different to `joblib/tick-delay` not delaying when `joblib/*tick*` is unbound.
+                    ;; tests still bind `joblib/*tick*` and run things in parallel.
+                    ;;joblib/tick-delay joblib/*tick*
+                    ;;main/*spec?* true
+                    ;;cli/install-update-these-in-parallel cli/install-update-these-serially
+                    ;;core/check-for-updates core/check-for-updates-serially
+                    ;; for testing purposes, no addon host is disabled
+                    utils/folder-size-bytes (constantly 0)
+                    constants/max-user-catalogue-age 9999
+                    *testing-problems* testing-problems
+                    
+                    ]
+        (core/reset-logging!)
 
-      (if ns-kw
-        (if (some #{ns-kw} [:main :utils :http
-                            :core :toc :nfo :zip :config :catalogue :addon :logging :joblib
-                            :cli :gui :jfx
-                            :curseforge-api :wowinterface-api :gitlab-api :github-api :tukui-api
-                            :release-json])
-          (with-gui-diff
-            (if fn-kw
-              ;; `test-vars` will run the test but not give feedback if test passes OR test not found
-              ;; slightly better than nothing
-              (clojure.test/test-vars [(resolve (symbol (str "strongbox." (name ns-kw) "-test") (name fn-kw)))])
-              (clojure.test/run-all-tests (re-pattern (str "strongbox." (name ns-kw) "-test"))))
-            )
-          (error "unknown test file:" ns-kw))
-        (clojure.test/run-all-tests #"strongbox\..*-test")))
+        (if ns-kw
+          (if (some #{ns-kw} [:main :utils :http
+                              :core :toc :nfo :zip :config :catalogue :addon :logging :joblib
+                              :cli :gui :jfx
+                              :curseforge-api :wowinterface-api :gitlab-api :github-api :tukui-api
+                              :release-json])
+            (do (with-gui-diff
+                  (if fn-kw
+                    ;; `test-vars` will run the test but not give feedback if test passes OR test not found
+                    ;; slightly better than nothing
+                    (clojure.test/test-vars [(resolve (symbol (str "strongbox." (name ns-kw) "-test") (name fn-kw)))])
+                    (clojure.test/run-all-tests (re-pattern (str "strongbox." (name ns-kw) "-test")))))
+                (report-testing-problems))
+            (error "unknown test file:" ns-kw))
+          (clojure.test/run-all-tests #"strongbox\..*-test"))))
     (finally
       ;; use case: we run the tests from the repl and afterwards we call `restart` to start the app.
       ;; `stop` inside `restart` will be outside of `with-redefs` and still have logging `:min-level` set to `:debug`

--- a/repl/strongbox/user.clj
+++ b/repl/strongbox/user.clj
@@ -64,7 +64,7 @@
   (main/stop)
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including strongbox.whatever-test ones
   (utils/instrument true) ;; always test with spec checking ON
-  
+
   (try
     (let [testing-problems (atom {:fail [] :error []})]
       ;; note! remember to update `cloverage.clj` with any new bindings
@@ -92,15 +92,15 @@
                               :cli :gui :jfx
                               :curseforge-api :wowinterface-api :gitlab-api :github-api :tukui-api
                               :release-json])
-            (do (with-gui-diff
-                  (if fn-kw
-                    ;; `test-vars` will run the test but not give feedback if test passes OR test not found
-                    ;; slightly better than nothing
-                    (clojure.test/test-vars [(resolve (symbol (str "strongbox." (name ns-kw) "-test") (name fn-kw)))])
-                    (clojure.test/run-all-tests (re-pattern (str "strongbox." (name ns-kw) "-test")))))
-                (report-testing-problems))
+            (with-gui-diff
+              (if fn-kw
+                ;; `test-vars` will run the test but not give feedback if test passes OR test not found
+                ;; slightly better than nothing
+                (clojure.test/test-vars [(resolve (symbol (str "strongbox." (name ns-kw) "-test") (name fn-kw)))])
+                (clojure.test/run-all-tests (re-pattern (str "strongbox." (name ns-kw) "-test")))))
             (error "unknown test file:" ns-kw))
-          (clojure.test/run-all-tests #"strongbox\..*-test"))))
+          (clojure.test/run-all-tests #"strongbox\..*-test"))
+        (report-testing-problems)))
     (finally
       ;; use case: we run the tests from the repl and afterwards we call `restart` to start the app.
       ;; `stop` inside `restart` will be outside of `with-redefs` and still have logging `:min-level` set to `:debug`

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -138,6 +138,11 @@
   []
   (search (some-> @core/state :search :term (str " "))))
 
+(defn-spec toggle-search-sampling! nil?
+  []
+  (swap! core/state update-in [:search :sample?] not)
+  (bump-search))
+
 (defn-spec search-results ::sp/list-of-maps
   "returns the current page of search results"
   ([]

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -136,7 +136,9 @@
   "search for the set `[:search :term]`, if one exists, and adds some whitespace to jog the GUI into forcing an empty.
   the db search function trims whitespace so there won't be any change to results"
   []
-  (search (some-> @core/state :search :term (str " "))))
+  (let [term (some-> @core/state :search :term)
+        term (if (nil? term) "" nil)]
+    (search term)))
 
 (defn-spec toggle-search-sampling! nil?
   []

--- a/src/strongbox/constants.clj
+++ b/src/strongbox/constants.clj
@@ -69,7 +69,8 @@
 (def releases
   "https://wowpedia.fandom.com/wiki/Patch"
 
-  {"10.0" "Dragonflight"
+  {"10.1" "Dragonflight: Embers of Neltharion"
+   "10.0" "Dragonflight"
 
    "9.2" "Shadowlands: Eternity's End"
    "9.1" "Shadowlands: Chains of Domination"

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -89,7 +89,8 @@
    :page 0
    :results []
    :selected-result-list []
-   :results-per-page 60})
+   :results-per-page 60
+   :sample? true})
 
 (def -state-template
   {:cleanup []
@@ -862,6 +863,19 @@
   (let [xf (filter #(= name (:name %)))]
     (into [] xf db)))
 
+(defn-spec db-search-sampling? boolean?
+  "returns `true` if a database search should return a random sample.
+  essentially, if nothing has been searched for and no filters have been set, we should take a random
+  sample of the selected catalogue UNLESS something has explicitly flipped the `:sample?` boolean."
+  [search-state map?]
+  (let [filter-by (-> search-state :filter-by)]
+    ;; todo: could we just compare this to the default empty search state ...?
+    (and (:sample? search-state) ;; true by default, set to false to short circuit this logic.
+         (empty? (-> search-state :term (or "") clojure.string/trim))
+         (empty? (:tag filter-by))
+         (not (:user-catalogue filter-by))
+         (not (:source filter-by)))))
+
 (defn db-search
   "returns a lazily fetched and paginated list of addon summaries.
   results are constructed using a `seque` that (somehow) bypasses chunking behaviour so 
@@ -870,9 +884,10 @@
   if no user input, returns a list of randomly ordered ('sampled') results.
   `filter-by` filters are applied before searching for `uin`."
   ([search-term cap filter-by]
-   (db-search (get-state :db) (utils/nilable search-term) cap filter-by (get-state :user-catalogue-idx)))
+   (let [{:keys [db user-catalogue-idx search]} (get-state)]
+     (db-search db (utils/nilable search-term) cap filter-by user-catalogue-idx (db-search-sampling? search))))
 
-  ([db uin cap filter-by user-catalogue-idx]
+  ([db uin cap filter-by user-catalogue-idx random-sample?]
    (let [constantly-true (constantly true)
 
          user-catalogue-filter (if (:user-catalogue filter-by)
@@ -903,12 +918,7 @@
          db (->> db
                  (filter user-catalogue-filter)
                  (filter host-filter)
-                 (filter tag-filter))
-
-         random-sample? (and (nil? uin)
-                             (empty? selected-tag-set)
-                             (not (:user-catalogue filter-by))
-                             (not (:source filter-by)))]
+                 (filter tag-filter))]
 
      ;; no/empty input, do a random sample
      (if random-sample?

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -869,7 +869,6 @@
   sample of the selected catalogue UNLESS something has explicitly flipped the `:sample?` boolean."
   [search-state map?]
   (let [filter-by (-> search-state :filter-by)]
-    ;; todo: could we just compare this to the default empty search state ...?
     (and (:sample? search-state) ;; true by default, set to false to short circuit this logic.
          (empty? (-> search-state :term (or "") clojure.string/trim))
          (empty? (:tag filter-by))
@@ -923,7 +922,6 @@
      ;; no/empty input, do a random sample
      (if random-sample?
        (let [pct (->> db count (max 1) (/ 100) (* 0.6))]
-         (println "sampling!!!!!!!!!!!!!!!!!" pct "with cap" cap)
          ;; decrement cap here so navigation for random search results is disabled
          [(take (dec cap) (random-sample pct db))])
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -864,7 +864,7 @@
     (into [] xf db)))
 
 (defn-spec db-search-sampling? boolean?
-  "returns `true` if a database search should return a random sample.
+  "returns `true` if a database search should return a random sample of results.
   essentially, if nothing has been searched for and no filters have been set, we should take a random
   sample of the selected catalogue UNLESS something has explicitly flipped the `:sample?` boolean."
   [search-state map?]
@@ -923,6 +923,7 @@
      ;; no/empty input, do a random sample
      (if random-sample?
        (let [pct (->> db count (max 1) (/ 100) (* 0.6))]
+         (println "sampling!!!!!!!!!!!!!!!!!" pct "with cap" cap)
          ;; decrement cap here so navigation for random search results is disabled
          [(take (dec cap) (random-sample pct db))])
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -864,9 +864,10 @@
 
 (defn db-search
   "returns a lazily fetched and paginated list of addon summaries.
-  results are constructed using a `seque` that (somehow) bypasses chunking behaviour so our
-  search never takes more than `cap` results.
-  matches on `uin` are case insensitive. if no user input, returns a list of randomly ordered results.
+  results are constructed using a `seque` that (somehow) bypasses chunking behaviour so 
+  searching never takes more than `cap` results.
+  matches on `uin` are case insensitive.
+  if no user input, returns a list of randomly ordered ('sampled') results.
   `filter-by` filters are applied before searching for `uin`."
   ([search-term cap filter-by]
    (db-search (get-state :db) (utils/nilable search-term) cap filter-by (get-state :user-catalogue-idx)))
@@ -906,7 +907,8 @@
 
          random-sample? (and (nil? uin)
                              (empty? selected-tag-set)
-                             (not (:user-catalogue filter-by)))]
+                             (not (:user-catalogue filter-by))
+                             (not (:source filter-by)))]
 
      ;; no/empty input, do a random sample
      (if random-sample?

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -547,8 +547,7 @@
                  ".updated-column" {:-fx-alignment "center"}}
 
                 "#search-addons-footer "
-                {;;:-fx-background-color "#ddd"
-                 :-fx-alignment "center-left"
+                {:-fx-alignment "center-left"
 
                  ".left-hbox"
                  {:-fx-alignment "center-left"
@@ -2184,13 +2183,17 @@
 (defn search-addons-table-extra
   [{:keys [fx/context]}]
   (let [search (fx/sub-val context get-in [:app-state, :search])]
-    {:fx/type :check-box
-     :text "sample results"
-     :selected (:sample? search)
-   ;; prevent sample toggle if search in a state where sampling not possible
-     :disable (not (db-search-sampling? search))
-     :node-orientation :right-to-left
-     :on-selected-changed (async-handler cli/toggle-search-sampling!)}))
+    {:fx/type fx.ext.node/with-tooltip-props
+     :props {:tooltip {:fx/type :tooltip
+                       :text (format "show a single page of %s random addons" (:results-per-page search))
+                       :show-delay 200}}
+     :desc {:fx/type :check-box
+            :text "sample results"
+            :selected (:sample? search)
+            ;; prevent sample toggle if search in a state where sampling not possible
+            :disable (not (db-search-sampling? search))
+            :node-orientation :right-to-left
+            :on-selected-changed (async-handler cli/toggle-search-sampling!)}}))
 
 (defn search-addons-pane
   [_]

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2174,13 +2174,13 @@
   sample of the selected catalogue UNLESS something has explicitly flipped the `:sample?` boolean."
   [search-state map?]
   (let [filter-by (-> search-state :filter-by)]
-    ;; todo: could we just compare this to the default empty search state ...?
-    (and (empty? (-> search-state :term (or "") clojure.string/trim))
-         (empty? (:tag filter-by))
-         (not (:user-catalogue filter-by))
-         (not (:source filter-by)))))
+    (and ;;(:sample? search-state) ;; differs to `core/db-search-sampling`. this fn determines if box should be ticked, not *is* the box ticked.
+     (empty? (-> search-state :term (or "") clojure.string/trim))
+     (empty? (:tag filter-by))
+     (not (:user-catalogue filter-by))
+     (not (:source filter-by)))))
 
-(defn search-addons-table-extra
+(defn search-addons-table-footer-right
   [{:keys [fx/context]}]
   (let [search (fx/sub-val context get-in [:app-state, :search])]
     {:fx/type fx.ext.node/with-tooltip-props
@@ -2208,7 +2208,7 @@
                         :children []}
                        {:fx/type :h-box
                         :style-class ["right-hbox"]
-                        :children [{:fx/type search-addons-table-extra}]}]}})
+                        :children [{:fx/type search-addons-table-footer-right}]}]}})
 
 (defn addon-detail-button-menu
   "a row of buttons attached to available actions for the given addon"

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -538,6 +538,7 @@
                 "#search-selected-tag-bar"
                 {:-fx-padding "0 0 10 10"
                  :-fx-spacing "10"
+                 :-fx-alignment "center-left"
                  " > .button" {:-fx-padding "2.5 8"
                                :-fx-background-radius "4"}}
 
@@ -550,25 +551,14 @@
                  :-fx-alignment "center-left"
 
                  ".left-hbox"
-                 {
-                  ;;:-fx-background-color :blue
-                  :-fx-alignment "center-left"
-                  :-fx-pref-width 9999.0
-                  }
+                 {:-fx-alignment "center-left"
+                  :-fx-pref-width 9999.0}
 
                  ".right-hbox"
-                 {;;:-fx-background-color :orange
-                  :-fx-min-width "150px"
+                 {:-fx-min-width "150px"
                   :-fx-pref-width "200px"
                   :-fx-alignment "center-right"
-                  :-fx-padding "5 10 5 5"
-
-
-                   
-
-                  }
-                 }
-                }
+                  :-fx-padding "5 10 5 5"}}}
 
                ;;
                ;; status bar (bottom of app)
@@ -2179,7 +2169,6 @@
       {:fx/type :v-box
        :children [row-1 row-2]})))
 
-
 (defn-spec db-search-sampling? boolean?
   "returns `true` if a database search should return a random sample.
   essentially, if nothing has been searched for and no filters have been set, we should take a random
@@ -2194,16 +2183,14 @@
 
 (defn search-addons-table-extra
   [{:keys [fx/context]}]
-  (let [search (fx/sub-val context get-in [:app-state, :search])
-        ]
-  {:fx/type :check-box
-   :text "sample results"
-   :selected (:sample? search)
+  (let [search (fx/sub-val context get-in [:app-state, :search])]
+    {:fx/type :check-box
+     :text "sample results"
+     :selected (:sample? search)
    ;; prevent sample toggle if search in a state where sampling not possible
-   :disable (not (db-search-sampling? search))
-   :node-orientation :right-to-left
-   :on-selected-changed (async-handler cli/toggle-search-sampling!)
-   }))
+     :disable (not (db-search-sampling? search))
+     :node-orientation :right-to-left
+     :on-selected-changed (async-handler cli/toggle-search-sampling!)}))
 
 (defn search-addons-pane
   [_]

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -246,7 +246,7 @@
           ;; if we set 3 results per page cap we'll always get one page of results with the first two sampled addons back.
           (swap! core/state assoc-in [:search :results-per-page] (inc cap))
           (cli/bump-search)
-          (Thread/sleep 100)
+          (Thread/sleep 50)
 
           ;; one page, two results
           (is (-> (core/get-state) :search :results count (= 1)))
@@ -254,12 +254,13 @@
 
           ;; disable sampling
           (cli/toggle-search-sampling!)
+          (Thread/sleep 50)
           (is (not (core/db-search-sampling? (core/get-state :search))))
 
           ;; and disable the random result pagination navigation button hack
           (swap! core/state assoc-in [:search :results-per-page] cap)
           (cli/bump-search)
-          (Thread/sleep 100)
+          (Thread/sleep 50)
 
           ;; two pages, each with two results
           (is (-> (core/get-state) :search :results count (= 2)))

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -1407,7 +1407,11 @@
       (with-global-fake-routes-in-isolation fake-routes
         (with-running-app
 
-          ;; we have 4 search results to start with
+          ;; we have 4 search results to start with:
+          ;; 1. "$old!it"
+          ;; 2. "A New Simple Percent"
+          ;; 3. "Skins for AddOns"
+          ;; 4. "Chinchilla"
           (cli/bump-search)
           (Thread/sleep 50) ;; searching happens in the background
           (is (= 4 (-> (core/get-state :search) :results first count)))
@@ -1427,10 +1431,14 @@
           (is (= expected-empty-search-state (core/get-state :search)))
 
           ;; do the search again without specifying a search term
-          ;; we should have three search results again
+          ;; we should have 4 search results again:
+          ;; 1. "$old!it"
+          ;; 2. "A New Simple Percent"
+          ;; 3. "Skins for AddOns"
+          ;; 4. "Chinchilla"
           (cli/bump-search)
           (Thread/sleep 50)
-          (is (= 3 (-> (core/get-state :search) :results first count))))))))
+          (is (= 4 (-> (core/get-state :search) :results first count))))))))
 
 (deftest reset-search-state
   (testing "search state can be cleared entirely"


### PR DESCRIPTION
- [x] do not sample results when filtering by addon host alone
- [x] entire catalogue can be browsed unsampled 
- [x] add tooltip to 'sample results' button, explaining it's purpose
- [x] ... what if this was a global toggle? right now it only affects unfiltered results and allows the entire catalogue to be browsed page by page, but if it were a global toggle, then *any* set of results > $results-per-page would be sampled down to a single page. You could type 'chat' or 'adi', get > 1 page of results but not show all of them.
     - I don't think this would be good default behaviour. You search, you expect a full set of navigable results. It could be an opt-in preference to always sample search results, but this feels like a rabbit hole I'm going down, making shit up to solve imaginary problems.
- [x] review
- [x] update CHANGELOG