### PR TITLE
gui, 'raw data' widget now has 'keyvals', 'json' and 'plain text' modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `state.paths.config-dir`, path to where Strongbox is storing the application *config*.
     - `state.paths.data-dir`, path to where Strongbox is storing the application *data*.
     - `flatpak-id`, looks like `la.ogri.strongbox` when running within a Flatpak.
+* added plain-text and JSON views of the raw addon data to the 'raw data' widget on the addon detail tab.
+    - it's pretty basic but JavaFX really resists being able to select text within it's widgets.
 
 ### Changed
 
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * tag buttons in search pane are now centred vertically.
 * selecting hosts in search pane no longer samples results.
+* 'interface version' was being treated as an integer and being localised in the raw data widget.
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,11 +27,15 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* rawdata, interface-version is being localised
+
 * catalogue/search results, if there are addons from the same host (github) with the same name (tukui), disambiguate them
     - 'tukui' in the search results shouldn't mean 'ogri-la/tukui' if 'tukui.org/tukui' is also available
         - which it isn't, but that's not the point.
 
 * gui, better copying from the interface, especially the log box
+    - too much faff and bs for selectable text/labels, wontdo.
+    - added selectable plain text and json boxes to the raw text widgets
 
 * no errors displayed when installing from addon detail page
 

--- a/TODO.md
+++ b/TODO.md
@@ -29,13 +29,11 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * rawdata, interface-version is being localised
 
-* catalogue/search results, if there are addons from the same host (github) with the same name (tukui), disambiguate them
-    - 'tukui' in the search results shouldn't mean 'ogri-la/tukui' if 'tukui.org/tukui' is also available
-        - which it isn't, but that's not the point.
-
 * gui, better copying from the interface, especially the log box
     - too much faff and bs for selectable text/labels, wontdo.
     - added selectable plain text and json boxes to the raw text widgets
+
+## todo bucket (no particular order)
 
 * no errors displayed when installing from addon detail page
 
@@ -44,7 +42,9 @@ see CHANGELOG.md for a more formal list of changes by release
     - I think this was fixed in 6.1.0 but check anyway
         - "ignored addons in the addon detail pane now display mutual dependencies (if any)."
 
-## todo bucket (no particular order)
+* catalogue/search results, if there are addons from the same host (github) with the same name (tukui), disambiguate them
+    - 'tukui' in the search results shouldn't mean 'ogri-la/tukui' if 'tukui.org/tukui' is also available
+        - which it isn't, but that's not the point.
 
 * github-addons.md, update or get rid of
 

--- a/TODO.md
+++ b/TODO.md
@@ -25,13 +25,15 @@ see CHANGELOG.md for a more formal list of changes by release
 * support NO_COLOR envvar, http://no-color.org
     - done
 
-## todo
-
 * rawdata, interface-version is being localised
+    - done
 
 * gui, better copying from the interface, especially the log box
     - too much faff and bs for selectable text/labels, wontdo.
     - added selectable plain text and json boxes to the raw text widgets
+    - done
+
+## todo
 
 ## todo bucket (no particular order)
 

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -615,14 +615,21 @@
                ".table-view#key-vals .val-column.column-header .label"
                {:-fx-alignment "center-left"}
 
+               ".plain-text-area .content "
+               {:-fx-padding ".75em"}
+
+               ".code-text-area "
+               {:-fx-font-family "monospace"
+                :-fx-font-size ".9em"
+                :-fx-text-fill "-fx-text-base-color"
+
+                ".content"
+                {:-fx-padding ".75em"}}
+
                ;;
                ;; addon-detail
                ;;
 
-               ".code-text-area"
-               {:-fx-font-family "monospace"
-                :-fx-font-size ".9em"
-                :-fx-text-fill "-fx-text-base-color"}
 
                "#addon-detail-pane "
                {".table-row-cell.installed"
@@ -2270,15 +2277,25 @@
         row-list (apply utils/csv-map [:key :val] (vec sanitised))
         row-list (sort-by :key row-list)
 
-        addon-string (format "%s\n\nVersion %s\n\n\"%s\"\n\nInstalled from %s\n\nSupports %s\n\nLast updated %s (%s)"
-                             (:label addon)
-                             (:version addon)
-                             (:description addon)
-                             (:source addon)
-                             (clojure.string/join ", " (mapv sp/game-track-labels-map (:supported-game-tracks addon)))
-                             (-> addon :updated-date utils/format-dt)
-                             (-> addon :updated-date utils/datestamp-ymd))
+        addon-string (if (:version addon)
+                       (format "%s\n\nVersion %s\n\n\"%s\"\n\nInstalled from %s\n\nSupports %s\n\nLast updated %s (%s)"
+                               (:label addon)
+                               (:version addon)
+                               (:description addon)
+                               (:source addon)
+                               (clojure.string/join ", " (mapv sp/game-track-labels-map (:supported-game-tracks addon)))
+                               (-> addon :updated-date utils/format-dt)
+                               (-> addon :updated-date utils/datestamp-ymd))
 
+                       ;; catalogue item
+                       (format "%s\n\n\"%s\"\n\nAvailable from %s\n\nSupports %s\n\nLast updated %s (%s)"
+                               (:label addon)
+                               (:description addon)
+                               (:source addon)
+                               (clojure.string/join ", " (mapv sp/game-track-labels-map (:game-track-list addon)))
+                               (-> addon :updated-date utils/format-dt)
+                               (-> addon :updated-date utils/datestamp-ymd)))
+        
         key-vals
         {:fx/type :tab
          :text "keyvals"
@@ -2300,7 +2317,7 @@
          :id "raw-data-json-tab"
          :closable false
          :content {:fx/type :text-area
-                   :style-class ["text-area", "code-text-area"]
+                   :style-class ["text-area" "code-text-area"]
                    :editable false
                    :text (utils/to-json addon)}}
 
@@ -2310,6 +2327,7 @@
          :id "raw-data-text-tab"
          :closable false
          :content {:fx/type :text-area
+                   :style-class ["text-area" "plain-text-area"]
                    :editable false
                    :wrap-text true
                    :text addon-string}}]

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -619,6 +619,11 @@
                ;; addon-detail
                ;;
 
+               ".code-text-area"
+               {:-fx-font-family "monospace"
+                :-fx-font-size ".9em"
+                :-fx-text-fill "-fx-text-base-color"}
+
                "#addon-detail-pane "
                {".table-row-cell.installed"
                 {:-fx-background-color (colour :row-updateable)}
@@ -2263,20 +2268,55 @@
         sanitised (apply dissoc addon blacklist)
 
         row-list (apply utils/csv-map [:key :val] (vec sanitised))
-        row-list (sort-by :key row-list)]
-    {:fx/type :border-pane
-     :top {:fx/type :label
-           :style-class ["section-title"]
-           :text "raw data"}
-     :center {:fx/type :table-view
-              :id "key-vals"
-              :style-class ["table-view"]
-              :placeholder {:fx/type :text
-                            :style-class ["table-placeholder-text"]
-                            :text "(not installed)"}
-              :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
-              :columns (mapv make-table-column column-list)
-              :items (or row-list [])}}))
+        row-list (sort-by :key row-list)
+
+        addon-string (format "%s\n\nVersion %s\n\n\"%s\"\n\nInstalled from %s\n\nSupports %s\n\nLast updated %s (%s)"
+                             (:label addon)
+                             (:version addon)
+                             (:description addon)
+                             (:source addon)
+                             (clojure.string/join ", " (mapv sp/game-track-labels-map (:supported-game-tracks addon)))
+                             (-> addon :updated-date utils/format-dt)
+                             (-> addon :updated-date utils/datestamp-ymd))
+
+        key-vals
+        {:fx/type :tab
+         :text "keyvals"
+         :id "raw-data-keyvals-tab"
+         :closable false
+         :content {:fx/type :table-view
+                   :id "key-vals"
+                   :style-class ["table-view"]
+                   :placeholder {:fx/type :text
+                                 :style-class ["table-placeholder-text"]
+                                 :text "(not installed)"}
+                   :column-resize-policy javafx.scene.control.TableView/CONSTRAINED_RESIZE_POLICY
+                   :columns (mapv make-table-column column-list)
+                   :items (or row-list [])}}
+
+        as-json
+        {:fx/type :tab
+         :text "json"
+         :id "raw-data-json-tab"
+         :closable false
+         :content {:fx/type :text-area
+                   :style-class ["text-area", "code-text-area"]
+                   :editable false
+                   :text (utils/to-json addon)}}
+
+        plain
+        {:fx/type :tab
+         :text "text"
+         :id "raw-data-text-tab"
+         :closable false
+         :content {:fx/type :text-area
+                   :editable false
+                   :wrap-text true
+                   :text addon-string}}]
+    {:fx/type :tab-pane
+     :tabs [key-vals
+            as-json
+            plain]}))
 
 (defn addon-detail-group-addons
   "displays a list of other addons that came grouped with this addon"

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -2274,6 +2274,10 @@
         blacklist [:group-addons :release-list :source-map-list]
         sanitised (apply dissoc addon blacklist)
 
+        transformations {:interface-version str}
+        sanitised (apply (fn [[key valfn]]
+                           (update addon key valfn)) transformations)
+
         row-list (apply utils/csv-map [:key :val] (vec sanitised))
         row-list (sort-by :key row-list)
 

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -119,12 +119,15 @@
   (let [dt (if (-> dt count (= 10)) (str dt "T00:00:00Z") dt)]
     (java-time/zoned-date-time (get java-time.format/predefined-formatters "iso-zoned-date-time") dt)))
 
-(defn datestamp-ymd
-  [val]
-  (println "got" val "type" (type val))
-  (jt/format "yyyy-MM-dd" (todt val)))
+(defn-spec datestamp-ymd string?
+  "returns a y-m-d formatted date for the given `val`"
+  [val (s/or :ok ::sp/inst :tolerated nil?)]
+  (if (nil? val)
+    ""
+    (jt/format "yyyy-MM-dd" (todt val))))
 
-(defn datestamp-now-ymd
+(defn-spec datestamp-now-ymd string?
+  "returns a y-m-d formatted date for 'today'"
   []
   (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.)))
 

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -112,16 +112,21 @@
           now (java-time/local-date)]
       (.getDays (java-time/period then now))))
 
-(defn datestamp-now-ymd
-  []
-  (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.)))
-
 (defn-spec todt ::sp/zoned-dt-obj
   "takes an ISO8601 string and returns a java.time.ZonedDateTime object.
   if the date is missing it's time portion, it's assumed to be `T00:00:00Z`."
   [dt ::sp/inst]
   (let [dt (if (-> dt count (= 10)) (str dt "T00:00:00Z") dt)]
     (java-time/zoned-date-time (get java-time.format/predefined-formatters "iso-zoned-date-time") dt)))
+
+(defn datestamp-ymd
+  [val]
+  (println "got" val "type" (type val))
+  (jt/format "yyyy-MM-dd" (todt val)))
+
+(defn datestamp-now-ymd
+  []
+  (.format (java.text.SimpleDateFormat. "yyyy-MM-dd") (java.util.Date.)))
 
 (defn-spec dt-before? boolean?
   "returns `true` if `date-1` happened before `date-2`"

--- a/test/strongbox/jfx_test.clj
+++ b/test/strongbox/jfx_test.clj
@@ -112,3 +112,75 @@
                   :g {:h {:j :k}
                       :i {:j :k}}}]
     (is (= expected (jfx/expand given)))))
+
+(deftest addon-as-text-for-installed
+  (testing "empty"
+    (let [given {}
+          expected ""]
+      (is (= expected (jfx/addon-as-text-for-installed given)))))
+
+  (testing "default"
+    (let [given helper/addon
+          expected "EveryAddon
+
+Version 1.2.3
+
+\"Does what no other addon does, slightly differently\"
+
+Installed from curseforge
+
+Supports Retail
+
+Last updated 7 years ago (2016-09-08)"]
+      (is (= expected (jfx/addon-as-text-for-installed given)))))
+
+  (testing "with overrides"
+    (let [overrides {:supported-game-tracks nil
+                     :updated-date nil}
+          given (merge helper/addon overrides)
+          expected "EveryAddon
+
+Version 1.2.3
+
+\"Does what no other addon does, slightly differently\"
+
+Installed from curseforge
+
+Supports 
+
+Last updated  ()"]
+      (is (= expected (jfx/addon-as-text-for-installed given))))))
+
+(deftest addon-as-text-for-catalogue
+  (testing "empty"
+    (let [given {}
+          expected ""]
+      (is (= expected (jfx/addon-as-text-for-catalogue given)))))
+
+  (testing "default"
+    (let [given helper/addon-summary
+          expected "EveryAddon
+
+\"Does what no other addon does, slightly differently\"
+
+Available from curseforge
+
+Supports 
+
+Last updated 7 years ago (2016-09-08)"]
+      (is (= expected (jfx/addon-as-text-for-catalogue given)))))
+
+  (testing "with overrides"
+    (let [overrides {:supported-game-tracks nil
+                     :updated-date nil}
+          given (merge helper/addon-summary overrides)
+          expected "EveryAddon
+
+\"Does what no other addon does, slightly differently\"
+
+Available from curseforge
+
+Supports 
+
+Last updated  ()"]
+      (is (= expected (jfx/addon-as-text-for-catalogue given))))))


### PR DESCRIPTION
I tried to make certain fields selectable for simple copying but it was an uphill battle against javafx. 

Instead I've opted for the (less than ideal) textual outputs 'json' and 'plain text' alongside the 'keyvals' mode.

- [x] fix padding in json and plain text boxes, I seem to have lost it 
- [x] rawdata, interface-version is being localised
- [ ] ~right align tabs? or lose the background or something?~ can't
- [ ] ~widget butts up against the rhs. add a little space?~ it's consistent as-is
- [ ] ~selectable values in tables?~ fucking *can't* grrr
- [x] review
- [x] update CHANGELOG