### PR TITLE
install addon from file, preserve 'ignore' and 'pin' flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* error handling for a few cases where uncaught exceptions were being swallowed.
+
 ### Changed
+
+* installing an addon by file now overwrites/updates ignored addons and unpins pinned addons.
+    - this accommodates a use case where Strongbox is used to install a select few addons manually from unsupported sources (like Curseforge) but then the new addons match against older versions in the catalogue from wowi.
+    - please open a feature request if you want this behaviour adjustable.
 
 ### Fixed
 
 * fixed bug in emergency 'short' catalogue generation.
     - it would include addons from BFA instead of stopping at Shadowlands.
+* fixed bug where installing a file manually would bypass ignored and pinned addon checks.
+    - it would tell you it was refusing to install, then install it anyway.
+* fixed bug where ignore check bypassed on ungrouped/single directory addons.
+    - logic assumed all addons were grouped, but grouping only happens when an addon unzip to multiple directories.
+    - pretty big bug!
 
 ### Removed
 

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,9 @@ bug:
     - it looks like it installed it anyway
     
 
+* Desktop Entry Name should not include "(Flatpak)" 
+    - https://github.com/flathub/la.ogri.strongbox/issues/7
+
 ## todo bucket (no particular order)
 
 bug: clear button isn't clearing search

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,11 @@ bug:
 
 ## todo bucket (no particular order)
 
+* gui, when installing an addon from file, allow the following options
+    - test-only?
+    - unpin-pinned?
+    - overwrite-ignored?
+
 bug: clear button isn't clearing search
 
 bug: 

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,36 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo
 
+* issue 433: preserve ignore and pin flags when addon updated manually via strongbox
+    - usecase: 
+        - old addon exists on wowi
+        - new addon exists on curse
+        - user installs new addon from curse and then 'ignores' it so nothing affects it
+        - user installs updated addon from curse and ignore flag is lost
+    - problems:
+        - if the addon was ignored, it shouldn't have been possible to overwrite it to begin with
+        - it seems reasonable to update addons in this way
+
+bug:
+    - attempting to overwrite ignored addon results in "refusing to delete ignored addon: /path/to/addon/dir" with no addon name
+    - it looks like it installed it anyway
+    
+
 ## todo bucket (no particular order)
+
+bug: clear button isn't clearing search
+
+bug: 
+    select github + wowi
+    search for 'alto'
+        - 3 results, 2 github, 1 wowi
+    deselect 'github'
+        - no results
+    select gitlab (so wowi and gitlab are selected)
+        - wowi result
+
+bug: search, next and previous buttons should take me to top of search results
+
 
 * patch tooltip, support multiple game versions
 

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -422,7 +422,7 @@
 (defn-spec ignored-dir-list (s/coll-of ::sp/dirname)
   "returns a list of unique addon directory names (including grouped addons) that are not being ignored"
   [addon-list (s/nilable :addon/installed-list)]
-  (->> addon-list (filter :ignore?) (map :group-addons) flatten (map :dirname) (remove nil?) set))
+  (->> addon-list (filter :ignore?) (map flatten-addon) flatten (map :dirname) (remove nil?) set))
 
 (defn-spec overwrites-ignored? boolean?
   "returns `true` if given archive file would unpack over *any* ignored addon.

--- a/src/strongbox/addon.clj
+++ b/src/strongbox/addon.clj
@@ -282,7 +282,7 @@
   but the new addon will be unzipped over the top of them.
 
   returns a list of nfo files that were written to disk, if any."
-  [addon :addon/nfo-input-minimum, install-dir ::sp/writeable-dir, downloaded-file ::sp/archive-file]
+  [addon :addon/nfo-input-minimum, install-dir ::sp/writeable-dir, downloaded-file ::sp/archive-file, opts map?]
   (let [nom (or (:label addon) (:name addon) (fs/base-name downloaded-file))
         version (:version addon)
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -372,7 +372,7 @@
   "installs/updates a list of addon zip files in parallel.
   does a clever refresh check afterwards to try and prevent a full refresh from happening.
   very similar code to `install-update-these-in-parallel`."
-  [download-file-list (s/coll-of ::sp/extant-archive-file)]
+  [download-file-list (s/coll-of ::sp/extant-archive-file), opts map?]
   (let [queue-atm (core/get-state :job-queue)
         install-dir (core/selected-addon-dir)
         current-locks (atom #{})
@@ -389,8 +389,7 @@
                      (let [error-messages
                            (logging/buffered-log
                             :warn
-                            (let [opts {}
-                                  results (core/install-addon addon install-dir downloaded-file opts)]
+                            (let [results (core/install-addon addon install-dir downloaded-file opts)]
                               (when-let [installed-addon-dir (some-> results first fs/parent str)]
                                 (core/refresh-addon* installed-addon-dir))))]
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -363,7 +363,7 @@
           error-messages
           (logging/buffered-log
            :warn
-           (addon/install-addon addon (core/selected-addon-dir) downloaded-file))]
+           (core/install-addon addon (core/selected-addon-dir) downloaded-file))]
       (core/refresh)
       {:label (fs/base-name downloaded-file)
        :error-messages error-messages}))
@@ -389,7 +389,8 @@
                      (let [error-messages
                            (logging/buffered-log
                             :warn
-                            (let [results (core/install-addon addon install-dir downloaded-file)]
+                            (let [opts {}
+                                  results (core/install-addon addon install-dir downloaded-file opts)]
                               (when-let [installed-addon-dir (some-> results first fs/parent str)]
                                 (core/refresh-addon* installed-addon-dir))))]
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -389,7 +389,7 @@
                      (let [error-messages
                            (logging/buffered-log
                             :warn
-                            (let [results (addon/install-addon addon install-dir downloaded-file)]
+                            (let [results (core/install-addon addon install-dir downloaded-file)]
                               (when-let [installed-addon-dir (some-> results first fs/parent str)]
                                 (core/refresh-addon* installed-addon-dir))))]
 

--- a/src/strongbox/cli.clj
+++ b/src/strongbox/cli.clj
@@ -312,10 +312,11 @@
                  (let [downloaded-file (core/download-addon-guard-affective addon install-dir)
                        existing-dirs (addon/dirname-set addon)
                        updated-dirs (zipfile-locks downloaded-file)
-                       locks-needed (clojure.set/union existing-dirs updated-dirs)]
+                       locks-needed (clojure.set/union existing-dirs updated-dirs)
+                       opts {}]
                    (swap! new-dirs into updated-dirs)
                    (utils/with-lock current-locks locks-needed
-                     (core/install-addon-affective addon install-dir downloaded-file)
+                     (core/install-addon-guard-affective addon install-dir opts downloaded-file)
                      (core/refresh-addon addon))))]
     (run! #(joblib/create-addon-job! queue-atm % job-fn) updateable-addon-list)
     (joblib/run-jobs! queue-atm core/num-concurrent-downloads)
@@ -372,7 +373,7 @@
   "installs/updates a list of addon zip files in parallel.
   does a clever refresh check afterwards to try and prevent a full refresh from happening.
   very similar code to `install-update-these-in-parallel`."
-  [download-file-list (s/coll-of ::sp/extant-archive-file), opts map?]
+  [download-file-list (s/coll-of ::sp/extant-archive-file), opts ::sp/install-opts]
   (let [queue-atm (core/get-state :job-queue)
         install-dir (core/selected-addon-dir)
         current-locks (atom #{})

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -543,7 +543,7 @@
 
 (defn-spec install-addon (s/or :ok (s/coll-of ::sp/extant-file), :passed-tests true?, :error nil?)
   "downloads an addon and installs it, bypassing checks. see `install-addon-guard`."
-  [addon :addon/installable, install-dir ::sp/extant-dir, downloaded-file (s/nilable ::sp/extant-archive-file)]
+  [addon (s/or :ok :addon/installable, :also-ok :addon/nfo-input-minimum), install-dir ::sp/extant-dir, downloaded-file (s/nilable ::sp/extant-archive-file)]
   (when downloaded-file
     (try
 
@@ -570,7 +570,11 @@
         :else (addon/install-addon addon install-dir downloaded-file))
 
       (finally
-        (addon/post-install addon install-dir (get-state :cfg :preferences :addon-zips-to-keep))))))
+        ;; todo: we need a handle on the newly installed addon here to pass it to post-install,
+        ;; or we need to munge a prefix
+        ;; or something. we can't skip post-install
+        (when (:name addon) 
+          (addon/post-install addon install-dir (get-state :cfg :preferences :addon-zips-to-keep)))))))
 
 (def install-addon-affective
   (affects-addon-wrapper install-addon))

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -573,7 +573,7 @@
         ;; todo: we need a handle on the newly installed addon here to pass it to post-install,
         ;; or we need to munge a prefix
         ;; or something. we can't skip post-install
-        (when (:name addon) 
+        (when (:name addon)
           (addon/post-install addon install-dir (get-state :cfg :preferences :addon-zips-to-keep)))))))
 
 (def install-addon-affective

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1007,10 +1007,13 @@
   (when-let [abs-path-list (file-chooser {:filters [{:description "ZIP files" :extensions ["*.zip"]}]
                                           :type :open-multi
                                           :initial-dir (core/selected-addon-dir)})]
-    (doseq [{:keys [error-messages label]} (cli/install-addons-from-file-in-parallel abs-path-list)]
-      (when-not (empty? error-messages)
-        (let [msg (message-list (format "warnings/errors while installing \"%s\"" label) error-messages)]
-          (alert :warning msg {:wait? false})))))
+    (let [;; future: allow user to set these
+          opts {:overwrite-ignored? true
+                :unpin-pinned? true}]
+      (doseq [{:keys [error-messages label]} (cli/install-addons-from-file-in-parallel abs-path-list opts)]
+        (when-not (empty? error-messages)
+          (let [msg (message-list (format "warnings/errors while installing \"%s\"" label) error-messages)]
+            (alert :warning msg {:wait? false}))))))
   nil)
 
 (defn exit-handler

--- a/src/strongbox/jfx.clj
+++ b/src/strongbox/jfx.clj
@@ -1007,8 +1007,7 @@
   (when-let [abs-path-list (file-chooser {:filters [{:description "ZIP files" :extensions ["*.zip"]}]
                                           :type :open-multi
                                           :initial-dir (core/selected-addon-dir)})]
-    (let [;; future: allow user to set these
-          opts {:overwrite-ignored? true
+    (let [opts {:overwrite-ignored? true
                 :unpin-pinned? true}]
       (doseq [{:keys [error-messages label]} (cli/install-addons-from-file-in-parallel abs-path-list opts)]
         (when-not (empty? error-messages)

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -261,6 +261,10 @@
 
 ;; ignoring
 
+(defn-spec ignore :addon/nfo
+  [nfo :addon/nfo]
+  (assoc nfo :ignore? true))
+
 (defn-spec ignore! nil?
   "prevent any changes made by strongbox to this addon. 
   explicitly ignores this addon by setting the `ignore?` flag to `true`."
@@ -285,6 +289,10 @@
   "'pins' the given `version` of a specific addon"
   [install-dir ::sp/extant-dir, addon-dirname ::sp/dirname, version :addon/pinned-version]
   (update-nfo! install-dir addon-dirname {:pinned-version version}))
+
+(defn-spec unpin :addon/nfo
+  [nfo :addon/nfo]
+  (dissoc nfo :pinned-version))
 
 (defn-spec unpin! nil?
   "removes `:pinned-version` from a specific addon's nfo file, if it exists"

--- a/src/strongbox/nfo.clj
+++ b/src/strongbox/nfo.clj
@@ -262,6 +262,7 @@
 ;; ignoring
 
 (defn-spec ignore :addon/nfo
+  "add a `ignore?` flag to given `nfo` data."
   [nfo :addon/nfo]
   (assoc nfo :ignore? true))
 
@@ -291,6 +292,7 @@
   (update-nfo! install-dir addon-dirname {:pinned-version version}))
 
 (defn-spec unpin :addon/nfo
+  "remove pin flag from given `nfo` data"
   [nfo :addon/nfo]
   (dissoc nfo :pinned-version))
 

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -503,3 +503,12 @@
                                             :github/requests-limit-reset-minutes
                                             :github/requests-remaining
                                             :github/requests-used]))
+
+;; addon/install-addon
+
+(s/def ::test-only? boolean?)
+(s/def ::overwrite-ignored? boolean?)
+(s/def ::unpin-pinned? boolean?)
+(s/def ::install-opts (s/keys :opt-un [::test-only?
+                                       ::overwrite-ignored?
+                                       ::unpin-pinned?]))

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -490,6 +490,24 @@
       (is (addon/overwrites-pinned? downloaded-file [pinned-addon]))
       (is (not (addon/overwrites-pinned? downloaded-file [addon]))))))
 
+(deftest test-overwrites-ignored?
+  (testing "addon zip files that would extract over an ignored addon are correctly detected"
+    (let [downloaded-file (fixture-path "everyaddon--1-2-3.zip") ;; ./EveryAddon
+          addon {:name "EveryAddon",
+                 :dirname "EveryAddon",
+                 :label "Every Addon",
+                 :description ""
+                 :interface-version-list [80300]
+                 :installed-version "1.2.3"
+                 :supported-game-tracks [:retail]
+                 :group-id "foo"
+                 :primary? true}
+          ignored-addon (assoc addon :ignore? true)
+          ]
+      (is (addon/overwrites-ignored? downloaded-file [ignored-addon]))
+      (is (not (addon/overwrites-pinned? downloaded-file [addon]))))))
+
+
 (deftest test-updateable?
   (testing "an addon's 'updateable' states"
     (let [cases [;; no update available

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -784,9 +784,11 @@
                        :source-map-list [{:source "curseforge", :source-id 2}]}]
 
         updates {:group-id "foobar"}
-        expected-nfo (mapv #(merge % updates) original-nfo)]
+        expected-nfo (mapv #(merge % updates) original-nfo)
 
-    (addon/install-addon addon (helper/install-dir) zipfile)
+        opts {}]
+
+    (addon/install-addon addon (helper/install-dir) zipfile opts)
 
     ;; sanity checks
     (is (= ["EveryAddon-BundledAddon" "EveryOtherAddon"] (helper/install-dir-contents)))

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -405,6 +405,22 @@
           (is (= expected (helper/install-dir-contents)))
           (is (clojure.string/starts-with? error-message error-prefix)))))))
 
+(deftest remove-addon--ignored-addon
+  (testing "removing an ignored addon with addon/remove-addon! emits a warning but otherwise removes addon"
+    (let [install-dir (helper/install-dir)
+          addon {:name "nom" :label "Nom" :description ""
+                 :interface-version-list [90100]
+                 :installed-version "0.1"
+                 :supported-game-tracks [:retail]
+                 :dirname "./EveryAddon"
+                 :ignore? true}
+          _ (fs/mkdir (utils/join install-dir "EveryAddon"))
+          messages (logging/buffered-log
+                    :warn
+                    (addon/remove-addon! install-dir addon))
+          expected-messages ["deleting ignored addon: Nom"]]
+      (is (= expected-messages messages)))))
+
 ;;
 
 (deftest test-pinned-dir-list

--- a/test/strongbox/addon_test.clj
+++ b/test/strongbox/addon_test.clj
@@ -502,11 +502,9 @@
                  :supported-game-tracks [:retail]
                  :group-id "foo"
                  :primary? true}
-          ignored-addon (assoc addon :ignore? true)
-          ]
+          ignored-addon (assoc addon :ignore? true)]
       (is (addon/overwrites-ignored? downloaded-file [ignored-addon]))
       (is (not (addon/overwrites-pinned? downloaded-file [addon]))))))
-
 
 (deftest test-updateable?
   (testing "an addon's 'updateable' states"

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -4,7 +4,8 @@
    [strongbox.cli :as cli]
    [clj-http.fake :refer [with-global-fake-routes-in-isolation]]
    [strongbox
-    ;;[nfo :as nfo]
+    [nfo :as nfo]
+    [addon :as addon]
     [specs :as specs]
     [utils :as utils]
     [logging :as logging]
@@ -905,87 +906,105 @@
         expected #{"EveryAddon" "EveryAddon-BundledAddon"}]
     (is (= expected (cli/zipfile-locks zipfile-fixture)))))
 
-#_(deftest install-addon-from-file
-    (testing "an addon can be installed from a zip file."
-      (with-redefs [utils/unique-id (constantly "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")]
+(deftest install-addon-from-file-in-parallel
+  (testing "an addon can be installed from a zip file."
+    (with-redefs [utils/unique-id (constantly "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")]
+      (with-running-app
+        (let [install-dir (helper/install-dir)
+              fixture (helper/fixture-path "everyaddon--0-1-2.zip")
+              expected [{:description "Does what no other addon does, slightly differently",
+                         :dirname "EveryAddon",
+                         :dirsize 0
+                         :group-addons [{:description "Does what no other addon does, slightly differently",
+                                         :dirname "EveryAddon",
+                                         :dirsize 0
+                                         :group-id "everyaddon-aaaaaaaa",
+                                         :installed-version "1.2.3",
+                                         :interface-version-list [70000],
+                                         :label "EveryAddon 1.2.3",
+                                         :name "everyaddon",
+                                         :primary? true,
+                                         :supported-game-tracks [:retail]}
+                                        {:description "A useful addon that everyone bundles with their own.",
+                                         :dirname "EveryAddon-BundledAddon",
+                                         :dirsize 0
+                                         :group-id "everyaddon-aaaaaaaa",
+                                         :installed-version "a.b.c",
+                                         :interface-version-list [80000],
+                                         :label "BundledAddon a.b.c",
+                                         :name "bundledaddon-a-b-c",
+                                         :primary? false,
+                                         :supported-game-tracks [:retail]}],
+                         :group-id "everyaddon-aaaaaaaa",
+                         :installed-version "1.2.3",
+                         :interface-version-list [70000],
+                         :label "EveryAddon 1.2.3",
+                         :name "everyaddon",
+                         :primary? true,
+                         :supported-game-tracks [:retail]}]
+
+              expected-nfo {:group-id "everyaddon-aaaaaaaa", :primary? true}]
+          (cli/install-addons-from-file-in-parallel [fixture])
+          (is (= expected (core/get-state :installed-addon-list)))
+          (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon"))))))))
+
+(deftest install-addon-from-file--then-update
+  (testing "an addon can be installed from a zip file."
+    (let [fixture (helper/fixture-path "everyaddon--0-1-2.zip")
+          dummy-catalogue (slurp (fixture-path "catalogue--v2--everyaddon.json"))
+          dummy-host-response (slurp (fixture-path "everyaddon--wowinterface--detail.json"))
+          update-fixture (fixture-path "everyaddon--7-8-9.zip")
+
+          fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+                       {:get (fn [req] {:status 200 :body dummy-catalogue})}
+
+                       "https://api.mmoui.com/v3/game/WOW/filedetails/1.json"
+                       {:get (fn [req] {:status 200 :body dummy-host-response})}
+
+                       "https://cdn.wowinterface.com/downloads/getfile.php?id=1"
+                       {:get (fn [req] {:status 200 :body (helper/file-to-lazy-byte-array update-fixture)})}}
+
+          expected-nfo {:source "wowinterface",
+                        :source-id 1,
+                        :group-id "https://www.wowinterface.com/downloads/info1",
+
+                        :installed-game-track :retail,
+                        :installed-version "7.8.9",
+                        :name "everyaddon",
+                        :primary? true,
+                        :source-map-list [{:source "wowinterface", :source-id 1}]}]
+
+      (with-global-fake-routes-in-isolation fake-routes
         (with-running-app
           (let [install-dir (helper/install-dir)
-                fixture (helper/fixture-path "everyaddon--0-1-2.zip")
-                expected [{:description "Does what no other addon does, slightly differently",
-                           :dirname "EveryAddon",
-                           :group-addons [{:description "Does what no other addon does, slightly differently",
-                                           :dirname "EveryAddon",
-                                           :group-id "everyaddon-aaaaaaaa",
-                                           :installed-version "1.2.3",
-                                           :interface-version-list [70000],
-                                           :label "EveryAddon 1.2.3",
-                                           :name "everyaddon",
-                                           :primary? true,
-                                           :supported-game-tracks [:retail]}
-                                          {:description "A useful addon that everyone bundles with their own.",
-                                           :dirname "EveryAddon-BundledAddon",
-                                           :group-id "everyaddon-aaaaaaaa",
-                                           :installed-version "a.b.c",
-                                           :interface-version-list [80000],
-                                           :label "BundledAddon a.b.c",
-                                           :name "bundledaddon-a-b-c",
-                                           :primary? false,
-                                           :supported-game-tracks [:retail]}],
-                           :group-id "everyaddon-aaaaaaaa",
-                           :installed-version "1.2.3",
-                           :interface-version-list [70000],
-                           :label "EveryAddon 1.2.3",
-                           :name "everyaddon",
-                           :primary? true,
-                           :supported-game-tracks [:retail],
-                           :update? false}]
+                _ (cli/install-addons-from-file-in-parallel [fixture])
+                _ (core/refresh)
+                addon (first (core/get-state :installed-addon-list))]
 
-                expected-nfo {:group-id "everyaddon-aaaaaaaa", :primary? true}]
-            (cli/install-addon-from-file fixture)
-            (is (= expected (core/get-state :installed-addon-list)))
-            (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon"))))))))
+            (is (:matched? addon))
+            (is (:update? addon))
 
-#_(deftest install-addon-from-file--then-update
-    (testing "an addon can be installed from a zip file."
-      (let [fixture (helper/fixture-path "everyaddon--0-1-2.zip")
-            dummy-catalogue (slurp (fixture-path "catalogue--v2--everyaddon.json"))
-            dummy-host-response (slurp (fixture-path "everyaddon--wowinterface--detail.json"))
-            update-fixture (fixture-path "everyaddon--7-8-9.zip")
+            (cli/install-update-these-serially [addon])
+            (core/refresh)
 
-            fake-routes {"https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
-                         {:get (fn [req] {:status 200 :body dummy-catalogue})}
+            (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon")))))))))
 
-                         "https://api.mmoui.com/v3/game/WOW/filedetails/1.json"
-                         {:get (fn [req] {:status 200 :body dummy-host-response})}
+(deftest install-addon--ignore-then-update-from-file
+  (testing "an addon installed+updated from a zip file respects ignore and pin flags."
+    (with-running-app
+      (helper/install-every-addon!)
+      (core/refresh)
+      (let [addon (first (core/get-state :installed-addon-list))]
+        (addon/ignore! (helper/install-dir) addon)
+        (core/refresh)
+        (let [addon (first (core/get-state :installed-addon-list))
+              update (helper/fixture-path "everyaddon--7-8-9.zip")]
 
-                         "https://cdn.wowinterface.com/downloads/getfile.php?id=1"
-                         {:get (fn [req] {:status 200 :body (helper/file-to-lazy-byte-array update-fixture)})}}
+          (is (:ignore? addon))
 
-          ;;expected []
-            expected-nfo {:source "wowinterface",
-                          :source-id 1,
-                          :group-id "https://www.wowinterface.com/downloads/info1",
-
-                          :installed-game-track :retail,
-                          :installed-version "7.8.9",
-                          :name "everyaddon",
-                          :primary? true,
-                          :source-map-list [{:source "wowinterface", :source-id 1}]}]
-
-        (with-global-fake-routes-in-isolation fake-routes
-          (with-running-app
-            (let [install-dir (helper/install-dir)
-                  _ (cli/install-addon-from-file fixture)
-                  _ (core/refresh)
-                  addon (first (core/get-state :installed-addon-list))]
-
-              (is (:matched? addon))
-              (is (:update? addon))
-
-              (cli/install-update-these-serially [addon])
-              (core/refresh)
-
-              (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon")))))))))
+          (cli/install-addons-from-file-in-parallel [update])
+          (let [addon (first (core/get-state :installed-addon-list))]
+            (is (:ignore? addon))))))))
 
 (deftest unique-group-id-from-zip-file
   (let [cases [["/foo/bar/baz.zip" "baz-aaaaaaaa"]

--- a/test/strongbox/cli_test.clj
+++ b/test/strongbox/cli_test.clj
@@ -912,6 +912,7 @@
       (with-running-app
         (let [install-dir (helper/install-dir)
               fixture (helper/fixture-path "everyaddon--0-1-2.zip")
+              opts {}
               expected [{:description "Does what no other addon does, slightly differently",
                          :dirname "EveryAddon",
                          :dirsize 0
@@ -944,7 +945,7 @@
                          :supported-game-tracks [:retail]}]
 
               expected-nfo {:group-id "everyaddon-aaaaaaaa", :primary? true}]
-          (cli/install-addons-from-file-in-parallel [fixture])
+          (cli/install-addons-from-file-in-parallel [fixture] opts)
           (is (= expected (core/get-state :installed-addon-list)))
           (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon"))))))))
 
@@ -977,7 +978,8 @@
       (with-global-fake-routes-in-isolation fake-routes
         (with-running-app
           (let [install-dir (helper/install-dir)
-                _ (cli/install-addons-from-file-in-parallel [fixture])
+                opts {}
+                _ (cli/install-addons-from-file-in-parallel [fixture] opts)
                 _ (core/refresh)
                 addon (first (core/get-state :installed-addon-list))]
 
@@ -998,11 +1000,12 @@
         (addon/ignore! (helper/install-dir) addon)
         (core/refresh)
         (let [addon (first (core/get-state :installed-addon-list))
-              update (helper/fixture-path "everyaddon--7-8-9.zip")]
+              update (helper/fixture-path "everyaddon--7-8-9.zip")
+              opts {}]
 
           (is (:ignore? addon))
 
-          (cli/install-addons-from-file-in-parallel [update])
+          (cli/install-addons-from-file-in-parallel [update] opts)
           (let [addon (first (core/get-state :installed-addon-list))]
             (is (:ignore? addon))))))))
 

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -600,8 +600,8 @@
         ;; ensure nothing was actually unzipped
         (is (not (fs/exists? (utils/join install-dir "EveryAddon"))))))))
 
-(deftest install-bad-addon
-  (testing "installing a bad addon"
+(deftest install-addon-guard--invalid-zip-file
+  (testing "installing a corrupted zip file"
     (with-global-fake-routes-in-isolation {}
       (let [install-dir (str fs/*cwd*)
             fname (downloaded-addon-fname (:name helper/addon) (:version helper/addon))
@@ -613,7 +613,7 @@
         ;; bad zip file deleted
         (is (= 0 (count (fs/list-dir install-dir))))))))
 
-(deftest install-bundled-addon
+(deftest install-addon-guard--bundled-addon
   (testing "installing a bundled addon"
     (with-running-app
       (let [install-dir (helper/install-dir)
@@ -641,7 +641,7 @@
         (is (= ["EveryAddon" "EveryAddon-BundledAddon" "everyaddon--0-1-2.zip"] directory-list))
         (is (= expected-nfo (nfo/read-nfo-file install-dir "EveryAddon-BundledAddon")))))))
 
-(deftest install-bundled-addon-overwriting-ignored-addon
+(deftest install-addon-guard--bundled-addon-overwriting-ignored-addon
   (testing "installing/unzipping an addon with a shared mutual dependency of an addon that is ignored isn't possible"
     (with-running-app
       (let [install-dir (helper/install-dir)
@@ -664,7 +664,7 @@
           (core/install-addon-guard addon2)
           (is (= ["EveryAddon" "EveryAddon-BundledAddon"] (helper/install-dir-contents))))))))
 
-(deftest install-bundled-addon-overwriting-pinned-addon
+(deftest install-addon-guard--bundled-addon-overwriting-pinned-addon
   (testing "installing/unzipping an addon with a shared mutual dependency of an addon that is pinned isn't possible"
     (with-running-app
       (let [install-dir (helper/install-dir)
@@ -695,7 +695,7 @@
         (core/install-addon-guard addon2)
         (is (= ["EveryAddon" "EveryAddon-BundledAddon"] (helper/install-dir-contents)))))))
 
-(deftest install-addon--lenient-game-track
+(deftest install-addon-guard--lenient-game-track
   (testing "a classic addon can be installed into an addon directory by setting the non-strict (lenient) flag"
     (with-running-app
       (let [install-dir (helper/install-dir)
@@ -710,7 +710,7 @@
 
         (core/install-addon-guard addon install-dir)))))
 
-(deftest install-addon--remove-zip
+(deftest install-addon-guard--remove-zip
   (testing "installing an addon with the `:addon-zips-to-keep` preference set to `0` will delete the zip afterwards"
     (with-running-app
       (let [install-dir (helper/install-dir)
@@ -721,7 +721,7 @@
         (core/install-addon-guard helper/addon install-dir)
         (is (= ["EveryAddon"] (helper/install-dir-contents)))))))
 
-(deftest install-addon--remove-multiple-zips
+(deftest install-addon-guard--remove-multiple-zips
   (testing "installing an addon with the `:addon-zips-to-keep` preference set to `0` will delete the zip afterwards"
     (with-running-app
       (let [install-dir (helper/install-dir)

--- a/test/strongbox/nfo_test.clj
+++ b/test/strongbox/nfo_test.clj
@@ -299,7 +299,20 @@
       (is (= expected-raw (nfo/read-nfo-file (install-dir) ignorable-addon-dir)))
       (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir))))))
 
-(deftest pin-addon
+(deftest ignore
+  (let [nfo-data {:installed-version "1.2.1"
+                  :installed-game-track :classic
+                  :name "EveryAddon"
+                  :group-id "https://foo.bar"
+                  :primary? true
+                  :source "curseforge"
+                  :source-id 321
+                  :source-map-list [{:source "curseforge" :source-id 321}]
+                  :ignore? false} ;; explicit ignore flag
+        expected (merge nfo-data {:ignore? true})]
+    (is (= expected (nfo/ignore nfo-data)))))
+
+(deftest pin!
   (testing "a pinned addon can be pinned to a specific version"
     (let [nfo-data {:installed-version "1.2.1"
                     :installed-game-track :classic
@@ -314,7 +327,21 @@
       (nfo/pin! (install-dir) addon-dir "a.b.c")
       (is (= expected (nfo/read-nfo (install-dir) addon-dir))))))
 
-(deftest unpin-addon
+(deftest unpin
+  (let [nfo-data {:installed-version "1.2.1"
+                  :installed-game-track :classic
+                  :name "EveryAddon"
+                  :group-id "https://foo.bar"
+                  :primary? true
+                  :source "curseforge"
+                  :source-id 321
+                  :source-map-list [{:source "curseforge", :source-id 123}]
+                  :pinned-version "a.b.c"}
+        expected (dissoc nfo-data :pinned-version)]
+
+    (is (= expected (nfo/unpin nfo-data)))))
+
+(deftest unpin!
   (testing "a pinned addon can be 'unpinned'"
     (let [nfo-data {:installed-version "1.2.1"
                     :installed-game-track :classic


### PR DESCRIPTION
Issue #433 

- [x] if an installed addon is being ignored then installing an addon that modifies it should be expressly prohibited.
  - huh - turns out the `overwrites-ignored?` and `overwrites-pinned?` checks happen *during download*. weird.
- [x] if an installed, ignored, addon is (somehow) affected by the installation of another addon, new addon is also ignored
- [x] if an installed, pinned, addon is (somehow) affected by the installation of another addon, new addon is no longer pinned
- [x] add a means to allow overwrite ignored and unpin addon via `core/install-addon`
- [ ] ~if an installed, ignored, addon would be modified by installing from a file, prompt the user to continue.~
  - good idea but: I don't have the time right now and I'm focusing on strongbox v8
- [ ] ~if an installed, pinned, addon would be modified by installing from a file, warn and prompt the user to continue~
  - good idea but: I don't have the time right now and I'm focusing on strongbox v8
- [x] review
- [x] update CHANGELOG